### PR TITLE
Add the annotation artifact as an `implementation` dependency instead of `api`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next Version
 
+* Add the annotation artifact as an `implementation` dependency instead of `api` #40.
+
 ## 1.0.5-1.4-M3 (2020-07-24)
 
 * Renamed the project from Hephaestus to Anvil #12. **IMPORTANT:** Anvil is not compatible with Hephaestus and you must upgrade the plugin in all of your libraries. The artifact coordinates changed, too.

--- a/gradle-plugin/src/main/java/com/squareup/anvil/plugin/AnvilPlugin.kt
+++ b/gradle-plugin/src/main/java/com/squareup/anvil/plugin/AnvilPlugin.kt
@@ -69,7 +69,7 @@ open class AnvilPlugin : Plugin<Project> {
       project.extensions.findByType(KaptExtension::class.java)?.correctErrorTypes = false
     }
 
-    project.dependencies.add("api", "$GROUP:annotations:$VERSION")
+    project.dependencies.add("implementation", "$GROUP:annotations:$VERSION")
   }
 
   private fun disablePreciseJavaTracking(


### PR DESCRIPTION
This prevents misleading results where one could forget to apply the Gradle
plugin. Imagine module B depends on module A. A applies the Gradle plugin, which
adds an `api` dependency for the annotation. In module B you can reference
the annotations due the transitive dependency, but the compiler plugin won't
run, because the Gradle plugin wasn't applied in this module. By using an
`implementation` dependency you cannot reference the annotations in module B
without applying the Gradle plugin.

Fixes #40