### PR TITLE
Allow the plugin to be used in pure JVM modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Next Version
 
 * Add the annotation artifact as an `implementation` dependency instead of `api` #40.
+* Remove the strong dependency on the Android Gradle Plugin and allow Anvil to be used in pure JVM modules #39.
 
 ## 1.0.5-1.4-M3 (2020-07-24)
 

--- a/gradle-plugin/src/main/java/com/squareup/anvil/plugin/AnvilPlugin.kt
+++ b/gradle-plugin/src/main/java/com/squareup/anvil/plugin/AnvilPlugin.kt
@@ -116,9 +116,7 @@ open class AnvilPlugin : Plugin<Project> {
     // compile task. If the plugin classpath changed, then DisableIncrementalCompilationTask sets
     // the signal to false.
     @Suppress("UnstableApiUsage")
-    val incrementalSignal = project.gradle.sharedServices
-        .registerIfAbsent("incrementalSignal", IncrementalSignal::class.java) { }
-
+    val incrementalSignal = IncrementalSignal.registerIfAbsent(project)
     if (isAndroidProject) {
       project.androidVariantsConfigure { variant ->
         val compileTaskName = "compile${variant.name.capitalize(US)}Kotlin"
@@ -165,7 +163,7 @@ open class AnvilPlugin : Plugin<Project> {
       compileTask.doFirst {
         // If the signal is set, then the plugin classpath changed. Apply the setting that
         // DisableIncrementalCompilationTask requested.
-        val incremental = incrementalSignal.get().incremental[projectPath]
+        val incremental = incrementalSignal.get().isIncremental(projectPath)
         if (incremental != null) {
           compileTask.incremental = incremental
         }

--- a/gradle-plugin/src/main/java/com/squareup/anvil/plugin/AnvilPlugin.kt
+++ b/gradle-plugin/src/main/java/com/squareup/anvil/plugin/AnvilPlugin.kt
@@ -12,6 +12,7 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.plugins.AppliedPlugin
 import org.gradle.api.plugins.PluginManager
+import org.gradle.api.provider.Provider
 import org.jetbrains.kotlin.gradle.internal.KaptGenerateStubsTask
 import org.jetbrains.kotlin.gradle.plugin.KaptExtension
 import org.jetbrains.kotlin.gradle.plugin.KotlinPluginWrapper
@@ -115,26 +116,26 @@ open class AnvilPlugin : Plugin<Project> {
     // compile task. If the plugin classpath changed, then DisableIncrementalCompilationTask sets
     // the signal to false.
     @Suppress("UnstableApiUsage")
-    val incrementalSignalServiceKey = registerIncrementalSignalBuildService(project)
+    val incrementalSignal = project.gradle.sharedServices
+        .registerIfAbsent("incrementalSignal", IncrementalSignal::class.java) { }
 
     if (isAndroidProject) {
       project.androidVariantsConfigure { variant ->
         val compileTaskName = "compile${variant.name.capitalize(US)}Kotlin"
-        disableIncrementalCompilationAction(project, incrementalSignalServiceKey, compileTaskName)
+        disableIncrementalCompilationAction(project, incrementalSignal, compileTaskName)
       }
     } else {
       // The Java plugin has two Kotlin tasks we care about: compileKotlin and compileTestKotlin.
-      disableIncrementalCompilationAction(project, incrementalSignalServiceKey, "compileKotlin")
-      disableIncrementalCompilationAction(project, incrementalSignalServiceKey, "compileTestKotlin")
+      disableIncrementalCompilationAction(project, incrementalSignal, "compileKotlin")
+      disableIncrementalCompilationAction(project, incrementalSignal, "compileTestKotlin")
     }
   }
 
   fun disableIncrementalCompilationAction(
     project: Project,
-    incrementalSignalServiceKey: IncrementalSignalServiceKey,
+    incrementalSignal: Provider<IncrementalSignal>,
     compileTaskName: String
   ) {
-
     // Disable incremental compilation, if the compiler plugin dependency isn't up-to-date.
     // This will trigger a full compilation of a module using Anvil even though its
     // source files might not have changed. This workaround is necessary, otherwise
@@ -146,11 +147,15 @@ open class AnvilPlugin : Plugin<Project> {
       task.pluginClasspath.from(
           project.configurations.getByName(PLUGIN_CLASSPATH_CONFIGURATION_NAME)
       )
+      task.incrementalSignal.set(incrementalSignal)
     }
 
     project.tasks.named(compileTaskName, KotlinCompile::class.java) { compileTask ->
       compileTask.dependsOn(disableIncrementalCompilationTaskProvider)
     }
+
+    // We avoid a reference to the project in the doFirst.
+    val projectPath = project.path
 
     // If we merge the block below and the block above, it looks like
     // the kotlin compiler is generating byte code for
@@ -160,7 +165,7 @@ open class AnvilPlugin : Plugin<Project> {
       compileTask.doFirst {
         // If the signal is set, then the plugin classpath changed. Apply the setting that
         // DisableIncrementalCompilationTask requested.
-        val incremental = getIncrementalSignalService(incrementalSignalServiceKey).incremental
+        val incremental = incrementalSignal.get().incremental[projectPath]
         if (incremental != null) {
           compileTask.incremental = incremental
         }

--- a/gradle-plugin/src/main/java/com/squareup/anvil/plugin/DisableIncrementalCompilationTask.kt
+++ b/gradle-plugin/src/main/java/com/squareup/anvil/plugin/DisableIncrementalCompilationTask.kt
@@ -4,8 +4,10 @@ package com.squareup.anvil.plugin
 
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
@@ -23,13 +25,14 @@ abstract class DisableIncrementalCompilationTask : DefaultTask() {
   @get:OutputFile @get:Optional
   val someFile = File(project.buildDir, "not-existing-file-because-gradle-needs-an-output")
 
-  private val serviceKey: IncrementalSignalServiceKey = IncrementalSignalServiceKey(project.path)
+  @get:Internal
+  abstract val incrementalSignal: Property<IncrementalSignal>
+
+  private val projectPath = project.path
 
   @TaskAction fun toggleFlag() {
     // Disable incremental compilation if something in the classpath changed. If nothing has changed
     // in the classpath, then this task wouldn't run at all and be skipped.
-    useIncrementalSignalService(serviceKey) {
-      it.incremental = false
-    }
+    incrementalSignal.get().incremental[projectPath] = false
   }
 }

--- a/gradle-plugin/src/main/java/com/squareup/anvil/plugin/DisableIncrementalCompilationTask.kt
+++ b/gradle-plugin/src/main/java/com/squareup/anvil/plugin/DisableIncrementalCompilationTask.kt
@@ -33,6 +33,6 @@ abstract class DisableIncrementalCompilationTask : DefaultTask() {
   @TaskAction fun toggleFlag() {
     // Disable incremental compilation if something in the classpath changed. If nothing has changed
     // in the classpath, then this task wouldn't run at all and be skipped.
-    incrementalSignal.get().incremental[projectPath] = false
+    incrementalSignal.get().setIncremental(projectPath, false)
   }
 }

--- a/gradle-plugin/src/main/java/com/squareup/anvil/plugin/IncrementalSignal.kt
+++ b/gradle-plugin/src/main/java/com/squareup/anvil/plugin/IncrementalSignal.kt
@@ -1,9 +1,42 @@
 package com.squareup.anvil.plugin
 
+import org.gradle.api.Project
+import org.gradle.api.provider.Provider
 import org.gradle.api.services.BuildService
 import org.gradle.api.services.BuildServiceParameters.None
+import kotlin.random.Random
+
+/*
+ * The key is important. Gradle uses different class loaders for different modules when the plugin
+ * is applied through the new plugins { } syntax. If we'd use the same key, then the
+ * IncrementalSignal class would be different for the same entry and Gradle would throw an error.
+ *
+ * By using a random key per class loader we avoid this issue. Since this service isn't shared
+ * across modules and only within a module it's not causing any problems tasks only use the service
+ * for their project.
+ *
+ * We could also create one service per module, but that seems wasteful. When the Gradle plugin is
+ * added to classpath of the root project, then the key is always the same and all modules share
+ * a single build service and a single cache.
+ */
+private val KEY = "incrementalSignal-" + Random.nextLong()
 
 /** This signal is used to share state between the task above and Kotlin compile tasks. */
+@Suppress("UnstableApiUsage")
 abstract class IncrementalSignal : BuildService<None> {
-  val incremental = mutableMapOf<String, Boolean?>()
+  private val incremental = mutableMapOf<String, Boolean?>()
+
+  @Synchronized fun setIncremental(
+    projectPath: String,
+    incremental: Boolean
+  ) {
+    this.incremental[projectPath] = incremental
+  }
+
+  @Synchronized fun isIncremental(projectPath: String): Boolean? = incremental[projectPath]
+
+  companion object {
+    fun registerIfAbsent(project: Project): Provider<IncrementalSignal> =
+      project.gradle.sharedServices.registerIfAbsent(KEY, IncrementalSignal::class.java) { }
+  }
 }

--- a/gradle-plugin/src/main/java/com/squareup/anvil/plugin/IncrementalSignal.kt
+++ b/gradle-plugin/src/main/java/com/squareup/anvil/plugin/IncrementalSignal.kt
@@ -1,80 +1,9 @@
-@file:Suppress("UnstableApiUsage")
-
 package com.squareup.anvil.plugin
 
-import com.android.build.gradle.internal.workeractions.WorkerActionServiceRegistry
-import com.android.ide.common.process.ProcessException
-import com.google.common.io.Closer
-import org.gradle.api.Project
 import org.gradle.api.services.BuildService
 import org.gradle.api.services.BuildServiceParameters.None
-import java.io.IOException
-import java.util.UUID
-
-/** Used to get unique build service name. Each class loader will initialize it's onw version. */
-private val ANVIL_INCREMENTAL_SIGNAL_BUILD_SERVICE_NAME =
-  "anvil-incremental-signal-build-service" + UUID.randomUUID()
-
-/**
- * Registers incremental signal build service and returns a service key that can be used to access
- * the service later.
- */
-fun registerIncrementalSignalBuildService(project: Project): IncrementalSignalServiceKey {
-  val buildServiceProvider = project.gradle.sharedServices.registerIfAbsent(
-      ANVIL_INCREMENTAL_SIGNAL_BUILD_SERVICE_NAME,
-      IncrementalSignalBuildService::class.java
-  ) {}
-  return buildServiceProvider.get()
-      .registerIncrementalSignalService(project.path)
-}
-
-/**
- * Service registry used to store IncrementalSignal services so they are accessible from the worker
- * actions.
- */
-var incrementalSignalServiceRegistry: WorkerActionServiceRegistry = WorkerActionServiceRegistry()
-
-/** Intended for use from worker actions. */
-@Throws(ProcessException::class, IOException::class)
-fun useIncrementalSignalService(
-  incrementalSignalServiceKey: IncrementalSignalServiceKey,
-  serviceRegistry: WorkerActionServiceRegistry = incrementalSignalServiceRegistry,
-  block: (IncrementalSignalService) -> Unit
-) = serviceRegistry.getService(incrementalSignalServiceKey).service.let(block)
-
-fun getIncrementalSignalService(
-  incrementalSignalServiceKey: IncrementalSignalServiceKey,
-  serviceRegistry: WorkerActionServiceRegistry = incrementalSignalServiceRegistry
-): IncrementalSignalService = serviceRegistry.getService(incrementalSignalServiceKey).service
-
-data class IncrementalSignalServiceKey(
-  val projectPath: String
-) : WorkerActionServiceRegistry.ServiceKey<IncrementalSignalService> {
-  override val type: Class<IncrementalSignalService> get() = IncrementalSignalService::class.java
-}
-
-data class IncrementalSignalService(var incremental: Boolean? = null)
 
 /** This signal is used to share state between the task above and Kotlin compile tasks. */
-abstract class IncrementalSignalBuildService : BuildService<None>, AutoCloseable {
-  private val registeredServices = mutableSetOf<IncrementalSignalServiceKey>()
-  private val closer = Closer.create()
-
-  @Synchronized
-  fun registerIncrementalSignalService(
-    projectPath: String,
-    serviceRegistry: WorkerActionServiceRegistry = incrementalSignalServiceRegistry
-  ): IncrementalSignalServiceKey {
-    val key = IncrementalSignalServiceKey(projectPath)
-
-    if (registeredServices.add(key)) {
-      closer.register(serviceRegistry.registerServiceAsCloseable(key, IncrementalSignalService()))
-    }
-
-    return key
-  }
-
-  override fun close() {
-    closer.close()
-  }
+abstract class IncrementalSignal : BuildService<None> {
+  val incremental = mutableMapOf<String, Boolean?>()
 }


### PR DESCRIPTION
This PR reverts #35, which accidentally added a hard dependency on the Android Gradle Plugin. It fixes #31 in a different way and resolves #39 due to the revert.