### PR TITLE
Change the `replaces` attribute from a single class to an array. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ different bindings for instrumentation tests, e.g.
 @Module
 @ContributesTo(
     scope = AppScope::class,
-    replaces = DevelopmentApplicationModule::class
+    replaces = [DevelopmentApplicationModule::class]
 )
 object DevelopmentApplicationTestModule {
   @Provides

--- a/annotations/src/main/java/com/squareup/anvil/annotations/ContributesBinding.kt
+++ b/annotations/src/main/java/com/squareup/anvil/annotations/ContributesBinding.kt
@@ -45,7 +45,7 @@ import kotlin.reflect.KClass
  * ```
  * @ContributesBinding(
  *     scope = AppScope::class,
- *     replaces = RealAuthenticator::class
+ *     replaces = [RealAuthenticator::class]
  * )
  * class FakeAuthenticator @Inject constructor() : Authenticator
  * ```
@@ -55,5 +55,5 @@ import kotlin.reflect.KClass
 annotation class ContributesBinding(
   val scope: KClass<*>,
   val boundType: KClass<*> = Unit::class,
-  val replaces: KClass<*> = Unit::class
+  val replaces: Array<KClass<*>> = []
 )

--- a/annotations/src/main/java/com/squareup/anvil/annotations/ContributesTo.kt
+++ b/annotations/src/main/java/com/squareup/anvil/annotations/ContributesTo.kt
@@ -28,7 +28,7 @@ import kotlin.reflect.KClass
  * @Module
  * @ContributesTo(
  *     AppScope::class,
- *     replaces = DevelopmentApplicationModule::class
+ *     replaces = [DevelopmentApplicationModule::class]
  * )
  * object DevelopmentApplicationTestModule {
  *   @Provides
@@ -40,5 +40,5 @@ import kotlin.reflect.KClass
 @Retention(RUNTIME)
 annotation class ContributesTo(
   val scope: KClass<*>,
-  val replaces: KClass<*> = Unit::class
+  val replaces: Array<KClass<*>> = []
 )

--- a/compiler/src/main/java/com/squareup/anvil/compiler/Utils.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/Utils.kt
@@ -20,6 +20,7 @@ import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.platform.has
 import org.jetbrains.kotlin.platform.jvm.JvmPlatform
 import org.jetbrains.kotlin.resolve.DescriptorUtils
+import org.jetbrains.kotlin.resolve.constants.ArrayValue
 import org.jetbrains.kotlin.resolve.constants.ConstantValue
 import org.jetbrains.kotlin.resolve.constants.KClassValue
 import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
@@ -109,11 +110,15 @@ internal fun AnnotationDescriptor.scope(module: ModuleDescriptor): ClassDescript
       .classDescriptorForType()
 }
 
-internal fun AnnotationDescriptor.replaces(module: ModuleDescriptor): ClassDescriptor? {
-  return (getAnnotationValue("replaces") as? KClassValue)
-      ?.getType(module)
-      ?.argumentType()
-      ?.classDescriptorForType()
+internal fun AnnotationDescriptor.replaces(module: ModuleDescriptor): List<ClassDescriptor> {
+  return (getAnnotationValue("replaces") as? ArrayValue)
+      ?.value
+      ?.map {
+        it.getType(module)
+            .argumentType()
+            .classDescriptorForType()
+      }
+      ?: emptyList()
 }
 
 internal fun AnnotationDescriptor.boundType(

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/BindingModuleGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/BindingModuleGenerator.kt
@@ -153,9 +153,11 @@ internal class BindingModuleGenerator(
       ).asSequence()
 
       val replacedBindings = (contributedBindingsThisModule + contributedBindingsDependencies)
-          .mapNotNull {
+          .flatMap {
             it.annotationOrNull(contributesBindingFqName, scope = scope)
                 ?.replaces(module)
+                ?.asSequence()
+                ?: emptySequence()
           }
 
       // Contributed Dagger modules can replace other Dagger modules but also contributed bindings.
@@ -168,9 +170,11 @@ internal class BindingModuleGenerator(
               annotation = contributesToFqName
           ))
           .filter { it.annotationOrNull(daggerModuleFqName) != null }
-          .mapNotNull {
+          .flatMap {
             it.annotationOrNull(contributesToFqName, scope)
                 ?.replaces(module)
+                ?.asSequence()
+                ?: emptySequence()
           }
 
       val bindingMethods = (contributedBindingsThisModule + contributedBindingsDependencies)

--- a/compiler/src/test/java/com/squareup/anvil/compiler/InterfaceMergerTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/InterfaceMergerTest.kt
@@ -159,7 +159,7 @@ class InterfaceMergerTest(
         
         @ContributesTo(
             Any::class,
-            replaces = ContributingInterface::class
+            replaces = [ContributingInterface::class]
         )
         interface SecondContributingInterface        
 
@@ -185,7 +185,7 @@ class InterfaceMergerTest(
         
         @ContributesTo(
             Any::class,
-            replaces = ContributingInterface::class
+            replaces = [ContributingInterface::class]
         )
         interface SecondContributingInterface        
 
@@ -213,7 +213,7 @@ class InterfaceMergerTest(
         
         @ContributesTo(
             Any::class,
-            replaces = ContributingInterface::class
+            replaces = [ContributingInterface::class]
         )
         interface SecondContributingInterface
 

--- a/compiler/src/test/java/com/squareup/anvil/compiler/MergeModulesTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/MergeModulesTest.kt
@@ -172,7 +172,7 @@ class MergeModulesTest {
 
         @ContributesTo(
             Any::class,
-            replaces = DaggerModule2::class
+            replaces = [DaggerModule2::class]
         )
         @dagger.Module
         abstract class DaggerModule3
@@ -202,7 +202,7 @@ class MergeModulesTest {
 
         @ContributesTo(
             Any::class,
-            replaces = ContributingInterface::class
+            replaces = [ContributingInterface::class]
         )
         @dagger.Module
         abstract class DaggerModule2
@@ -235,7 +235,7 @@ class MergeModulesTest {
 
         @ContributesBinding(
             Any::class,
-            replaces = DaggerModule2::class
+            replaces = [DaggerModule2::class]
         )
         interface ContributingInterface : ParentInterface
 
@@ -260,7 +260,7 @@ class MergeModulesTest {
 
         @ContributesTo(
             Any::class,
-            replaces = DaggerModule3::class
+            replaces = [DaggerModule3::class]
         )
         @dagger.Module
         abstract class DaggerModule2
@@ -288,7 +288,7 @@ class MergeModulesTest {
 
         @ContributesTo(
             Any::class,
-            replaces = DaggerModule2::class
+            replaces = [DaggerModule2::class]
         )
         @dagger.Module
         abstract class DaggerModule3

--- a/compiler/src/test/java/com/squareup/anvil/compiler/ModuleMergerTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/ModuleMergerTest.kt
@@ -228,7 +228,7 @@ class ModuleMergerTest(
 
         @ContributesTo(
             Any::class,
-            replaces = DaggerModule1::class
+            replaces = [DaggerModule1::class]
         )
         @dagger.Module
         abstract class DaggerModule2 
@@ -258,7 +258,7 @@ class ModuleMergerTest(
 
         @ContributesTo(
             Any::class,
-            replaces = ContributingInterface::class
+            replaces = [ContributingInterface::class]
         )
         @dagger.Module
         abstract class DaggerModule1
@@ -291,7 +291,7 @@ class ModuleMergerTest(
 
         @ContributesBinding(
             Any::class,
-            replaces = DaggerModule1::class
+            replaces = [DaggerModule1::class]
         )
         interface ContributingInterface : ParentInterface
 
@@ -316,7 +316,7 @@ class ModuleMergerTest(
 
         @ContributesTo(
             Any::class,
-            replaces = DaggerModule1::class
+            replaces = [DaggerModule1::class]
         )
         @dagger.Module
         abstract class DaggerModule2 
@@ -344,7 +344,7 @@ class ModuleMergerTest(
 
         @ContributesTo(
             Any::class,
-            replaces = DaggerModule1::class
+            replaces = [DaggerModule1::class]
         )
         @dagger.Module
         abstract class DaggerModule2 

--- a/compiler/src/test/java/com/squareup/anvil/compiler/codegen/BindingModuleGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/codegen/BindingModuleGeneratorTest.kt
@@ -312,7 +312,7 @@ class BindingModuleGeneratorTest(
         
         @ContributesBinding(
             Any::class,
-            replaces = ContributingInterface::class
+            replaces = [ContributingInterface::class]
         )
         interface SecondContributingInterface : ParentInterface
         

--- a/sample/app/src/androidTest/java/com/squareup/anvil/sample/FakeFatherProviderModule.kt
+++ b/sample/app/src/androidTest/java/com/squareup/anvil/sample/FakeFatherProviderModule.kt
@@ -10,7 +10,7 @@ import dagger.Module
 @Module
 @ContributesTo(
     scope = AppScope::class,
-    replaces = FatherProviderModule::class
+    replaces = [FatherProviderModule::class]
 )
 abstract class FakeFatherProviderModule {
   @Binds abstract fun bindFatherProvider(provider: FakeFatherProvider): FatherProvider


### PR DESCRIPTION
This gives the API more flexibility and avoids redundant classes. E.g. one Dagger module with several binding and provider methods may wish to replace multiple other Dagger modules.