### PR TITLE
Generate a hint for the scope of each contributed type.

### DIFF
--- a/compiler/src/main/java/com/squareup/anvil/compiler/ClassScanner.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/ClassScanner.kt
@@ -5,19 +5,22 @@ import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 import org.jetbrains.kotlin.descriptors.PackageViewDescriptor
 import org.jetbrains.kotlin.descriptors.PropertyDescriptor
 import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
 import org.jetbrains.kotlin.resolve.scopes.DescriptorKindFilter
+import kotlin.LazyThreadSafetyMode.NONE
 
 internal class ClassScanner {
 
   /**
-   * Returns a list of classes from the dependency graph annotated with `@ContributesTo`. Note that
-   * the list includes inner classes already.
+   * Returns a sequence of contributed classes from the dependency graph. Note that the result
+   * includes inner classes already.
    */
   fun findContributedClasses(
     module: ModuleDescriptor,
     packageName: String,
-    annotation: FqName
-  ): List<ClassDescriptor> {
+    annotation: FqName,
+    scope: FqName
+  ): Sequence<ClassDescriptor> {
     val packageDescriptor = module.getPackage(FqName(packageName))
     return generateSequence(packageDescriptor.subPackages()) { subPackages ->
       subPackages
@@ -30,15 +33,57 @@ internal class ClassScanner {
               .asSequence()
         }
         .filterIsInstance<PropertyDescriptor>()
-        .map {
-          it.type.argumentType()
-              .classDescriptorForType()
+        .groupBy { property ->
+          // For each contributed hint there are several properties, e.g. the reference itself
+          // and the scope. Group them by their common name without the suffix.
+          val name = property.name.asString()
+          val suffix = propertySuffixes.firstOrNull { name.endsWith(it) } ?: return@groupBy name
+          name.substringBeforeLast(suffix)
         }
-        .filter { it.annotationOrNull(annotation) != null }
-        .toList()
+        .values
+        .asSequence()
+        .filter { properties ->
+          // Double check that the number of properties matches how many suffixes we have and how
+          // many properties we expect.
+          properties.size == propertySuffixes.size
+        }
+        .map { ContributedHint(it) }
+        .filter { hint ->
+          // The scope must match what we're looking for.
+          hint.scope.fqNameSafe == scope
+        }
+        .map { hint -> hint.reference }
+        .filter {
+          // Check that the annotation really is present. It should always be the case, but it's
+          // a safetynet in case the generated properties are out of sync.
+          it.annotationOrNull(annotation, scope) != null
+        }
   }
 }
 
 private fun PackageViewDescriptor.subPackages(): List<PackageViewDescriptor> = memberScope
     .getContributedDescriptors(DescriptorKindFilter.PACKAGES)
     .filterIsInstance<PackageViewDescriptor>()
+
+private class ContributedHint(properties: List<PropertyDescriptor>) {
+  val reference by lazy(NONE) {
+    properties
+        .bySuffix(REFERENCE_SUFFIX)
+        .toClassDescriptor()
+  }
+
+  val scope by lazy(NONE) {
+    properties
+        .bySuffix(SCOPE_SUFFIX)
+        .toClassDescriptor()
+  }
+
+  private fun List<PropertyDescriptor>.bySuffix(suffix: String): PropertyDescriptor = first {
+    it.name.asString()
+        .endsWith(suffix)
+  }
+
+  private fun PropertyDescriptor.toClassDescriptor(): ClassDescriptor =
+    type.argumentType()
+        .classDescriptorForType()
+}

--- a/compiler/src/main/java/com/squareup/anvil/compiler/InterfaceMerger.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/InterfaceMerger.kt
@@ -43,9 +43,9 @@ internal class InterfaceMerger(
         .findContributedClasses(
             module = thisDescriptor.module,
             packageName = HINT_CONTRIBUTES_PACKAGE_PREFIX,
-            annotation = contributesToFqName
+            annotation = contributesToFqName,
+            scope = scope.fqNameSafe
         )
-        .asSequence()
         .filter {
           DescriptorUtils.isInterface(it) && it.annotationOrNull(daggerModuleFqName) == null
         }

--- a/compiler/src/main/java/com/squareup/anvil/compiler/ModuleMerger.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/ModuleMerger.kt
@@ -62,9 +62,9 @@ internal class ModuleMerger(
         .findContributedClasses(
             module = module,
             packageName = HINT_CONTRIBUTES_PACKAGE_PREFIX,
-            annotation = contributesToFqName
+            annotation = contributesToFqName,
+            scope = scopeFqName
         )
-        .asSequence()
         .filter {
           // We generate a Dagger module for each merged component. We use Anvil itself to
           // contribute this generated module. It's possible that there are multiple components
@@ -131,9 +131,9 @@ internal class ModuleMerger(
         .findContributedClasses(
             module = module,
             packageName = HINT_BINDING_PACKAGE_PREFIX,
-            annotation = contributesBindingFqName
+            annotation = contributesBindingFqName,
+            scope = scopeFqName
         )
-        .asSequence()
         .flatMap { contributedClass ->
           val annotation = contributedClass.annotation(contributesBindingFqName)
           if (scopeFqName == annotation.scope(module).fqNameSafe) {

--- a/compiler/src/main/java/com/squareup/anvil/compiler/Utils.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/Utils.kt
@@ -47,6 +47,10 @@ internal const val MODULE_PACKAGE_PREFIX = "anvil.module"
 
 internal const val ANVIL_MODULE_SUFFIX = "AnvilModule"
 
+internal const val REFERENCE_SUFFIX = "_reference"
+internal const val SCOPE_SUFFIX = "_scope"
+internal val propertySuffixes = arrayOf(REFERENCE_SUFFIX, SCOPE_SUFFIX)
+
 internal fun ClassDescriptor.annotationOrNull(
   annotationFqName: FqName,
   scope: FqName? = null

--- a/compiler/src/main/java/com/squareup/anvil/compiler/Utils.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/Utils.kt
@@ -54,17 +54,34 @@ internal fun ClassDescriptor.annotationOrNull(
   // Must be JVM, we don't support anything else.
   if (!module.platform.has<JvmPlatform>()) return null
   val annotationDescriptor = try {
+    println("This: $this | annotation: $annotationFqName")
     annotations.findAnnotation(annotationFqName)
-  } catch (e: IllegalStateException) {
-    // In some scenarios this exception is thrown. Throw a new exception with a better explanation.
-    // Caused by: java.lang.IllegalStateException: Should not be called!
-    // at org.jetbrains.kotlin.types.ErrorUtils$1.getPackage(ErrorUtils.java:95)
-    throw AnvilCompilationException(
-        this,
-        message = "It seems like you tried to contribute an inner class to its outer class. This " +
-            "is not supported and results in a compiler error.",
-        cause = e
-    )
+  } catch (t: Throwable) {
+    // In some scenarios these exceptions are thrown. Throw a new exception with a better
+    // explanation.
+    when {
+      // Caused by: java.lang.IllegalStateException: Should not be called!
+      // at org.jetbrains.kotlin.types.ErrorUtils$1.getPackage(ErrorUtils.java:95)
+      t is IllegalStateException -> throw AnvilCompilationException(
+          this,
+          message = "It seems like you tried to contribute an inner class to its outer class. This " +
+              "is not supported and results in a compiler error.",
+          cause = t
+      )
+
+      // e: java.lang.AssertionError: Recursion detected on input: ANNOTATION_ENTRY
+      // under LockBasedStorageManager@199db68d (TopDownAnalyzer for JVM)
+      t is AssertionError &&
+          t.message?.startsWith("Recursion detected on input: ANNOTATION_ENTRY") == true ->
+        throw AnvilCompilationException(
+            this,
+            message = "It seems like you tried to contribute an inner class of a merged " +
+                "component to another component. This is not supported and results in a " +
+                "compiler error.",
+            cause = t
+        )
+      else -> throw t
+    }
   }
   return if (scope == null || annotationDescriptor == null) {
     annotationDescriptor

--- a/compiler/src/main/java/com/squareup/anvil/compiler/Utils.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/Utils.kt
@@ -41,7 +41,7 @@ internal val daggerSubcomponentFqName = FqName(Subcomponent::class.java.canonica
 internal val daggerModuleFqName = FqName(Module::class.java.canonicalName)
 internal val daggerBindsFqName = FqName(Binds::class.java.canonicalName)
 
-internal const val HINT_CONTRIBUTES_PACKAGE_PREFIX = "hint.anvil"
+internal const val HINT_CONTRIBUTES_PACKAGE_PREFIX = "anvil.hint.merge"
 internal const val HINT_BINDING_PACKAGE_PREFIX = "anvil.hint.binding"
 internal const val MODULE_PACKAGE_PREFIX = "anvil.module"
 

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/BindingModuleGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/BindingModuleGenerator.kt
@@ -149,8 +149,9 @@ internal class BindingModuleGenerator(
       val contributedBindingsDependencies = classScanner.findContributedClasses(
           module,
           packageName = HINT_BINDING_PACKAGE_PREFIX,
-          annotation = contributesBindingFqName
-      ).asSequence()
+          annotation = contributesBindingFqName,
+          scope = scope
+      )
 
       val replacedBindings = (contributedBindingsThisModule + contributedBindingsDependencies)
           .flatMap {
@@ -167,7 +168,8 @@ internal class BindingModuleGenerator(
           .plus(classScanner.findContributedClasses(
               module,
               packageName = HINT_CONTRIBUTES_PACKAGE_PREFIX,
-              annotation = contributesToFqName
+              annotation = contributesToFqName,
+              scope = scope
           ))
           .filter { it.annotationOrNull(daggerModuleFqName) != null }
           .flatMap {

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesBindingGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesBindingGenerator.kt
@@ -2,6 +2,8 @@ package com.squareup.anvil.compiler.codegen
 
 import com.squareup.anvil.compiler.AnvilCompilationException
 import com.squareup.anvil.compiler.HINT_BINDING_PACKAGE_PREFIX
+import com.squareup.anvil.compiler.REFERENCE_SUFFIX
+import com.squareup.anvil.compiler.SCOPE_SUFFIX
 import com.squareup.anvil.compiler.codegen.CodeGenerator.GeneratedFile
 import com.squareup.anvil.compiler.contributesBindingFqName
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
@@ -45,10 +47,13 @@ internal class ContributesBindingGenerator : CodeGenerator {
             "Could not generate package directory: ${file.parentFile}"
           }
 
+          val scope = clazz.scope(contributesBindingFqName, module)
+
           val content = """
             package $generatedPackage
             
-            val ${className.replace('.', '_')} = $className::class
+            val ${className.replace('.', '_')}$REFERENCE_SUFFIX = $className::class
+            val ${className.replace('.', '_')}$SCOPE_SUFFIX = $scope::class
           """.trimIndent()
           file.writeText(content)
 

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesToGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesToGenerator.kt
@@ -3,6 +3,8 @@ package com.squareup.anvil.compiler.codegen
 import com.squareup.anvil.annotations.ContributesTo
 import com.squareup.anvil.compiler.AnvilCompilationException
 import com.squareup.anvil.compiler.HINT_CONTRIBUTES_PACKAGE_PREFIX
+import com.squareup.anvil.compiler.REFERENCE_SUFFIX
+import com.squareup.anvil.compiler.SCOPE_SUFFIX
 import com.squareup.anvil.compiler.codegen.CodeGenerator.GeneratedFile
 import com.squareup.anvil.compiler.contributesToFqName
 import com.squareup.anvil.compiler.daggerModuleFqName
@@ -57,10 +59,13 @@ internal class ContributesToGenerator : CodeGenerator {
             "Could not generate package directory: ${file.parentFile}"
           }
 
+          val scope = clazz.scope(contributesToFqName, module)
+
           val content = """
               package $generatedPackage
               
-              val ${className.replace('.', '_')} = $className::class
+              val ${className.replace('.', '_')}$REFERENCE_SUFFIX = $className::class
+              val ${className.replace('.', '_')}$SCOPE_SUFFIX = $scope::class
           """.trimIndent()
           file.writeText(content)
 

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/PsiUtils.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/PsiUtils.kt
@@ -1,9 +1,20 @@
 package com.squareup.anvil.compiler.codegen
 
+import com.squareup.anvil.compiler.AnvilCompilationException
+import org.jetbrains.kotlin.descriptors.ModuleDescriptor
+import org.jetbrains.kotlin.descriptors.resolveClassByFqName
+import org.jetbrains.kotlin.incremental.components.NoLookupLocation.FROM_BACKEND
 import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.psi.KtAnnotationEntry
 import org.jetbrains.kotlin.psi.KtClass
+import org.jetbrains.kotlin.psi.KtClassLiteralExpression
 import org.jetbrains.kotlin.psi.KtClassOrObject
+import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
 import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtNameReferenceExpression
+import org.jetbrains.kotlin.psi.KtValueArgument
+import org.jetbrains.kotlin.psi.KtValueArgumentName
+import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
 
 internal fun KtFile.classesAndInnerClasses(): Sequence<KtClassOrObject> {
   val children = findChildrenByClass(KtClassOrObject::class.java)
@@ -24,25 +35,127 @@ internal fun KtClassOrObject.requireFqName(): FqName = requireNotNull(fqName) {
 internal fun KtClassOrObject.isInterface(): Boolean = this is KtClass && this.isInterface()
 
 internal fun KtClassOrObject.hasAnnotation(fqName: FqName): Boolean {
+  return findAnnotation(fqName) != null
+}
+
+internal fun KtClassOrObject.findAnnotation(fqName: FqName): KtAnnotationEntry? {
   val annotationEntries = annotationEntries
-  if (annotationEntries.isEmpty()) return false
+  if (annotationEntries.isEmpty()) return null
 
   // Check first if the fully qualified name is used, e.g. `@dagger.Module`.
-  val containsFullyQualifiedName = annotationEntries.any {
+  val annotationEntry = annotationEntries.firstOrNull {
     it.text.startsWith("@${fqName.asString()}")
   }
-  if (containsFullyQualifiedName) return true
+  if (annotationEntry != null) return annotationEntry
 
   // Check if the simple name is used, e.g. `@Module`.
-  val containsShortName = annotationEntries.any {
-    it.shortName == fqName.shortName()
-  }
-  if (!containsShortName) return false
+  val annotationEntryShort = annotationEntries
+      .firstOrNull {
+        it.shortName == fqName.shortName()
+      }
+      ?: return null
 
   // If the simple name is used, check that the annotation is imported.
-  return containingKtFile.importDirectives
+  val hasImport = containingKtFile.importDirectives
       .mapNotNull { it.importPath }
       .any {
         it.fqName == fqName
       }
+
+  return if (hasImport) annotationEntryShort else null
+}
+
+internal fun KtClassOrObject.scope(
+  annotationFqName: FqName,
+  module: ModuleDescriptor
+): FqName {
+  val scopeElement = findScopeClassLiteralExpression(annotationFqName)
+      .let {
+        val children = it.children
+        children.singleOrNull() ?: throw AnvilCompilationException(
+            "Expected a single child, but had ${children.size} instead: ${it.text}",
+            element = this
+        )
+      }
+
+  val scopeClassReference = when (scopeElement) {
+    // If a fully qualified name is used, then we're done and don't need to do anything further.
+    is KtDotQualifiedExpression -> return FqName(scopeElement.text)
+    is KtNameReferenceExpression -> scopeElement.getReferencedName()
+    else -> throw AnvilCompilationException(
+        "Don't know how to handle Psi element: ${scopeElement.text}",
+        element = this
+    )
+  }
+
+  // First look in the imports for the reference name. If the class is imported, then we know the
+  // fully qualified name.
+  containingKtFile.importDirectives
+      .mapNotNull { it.importPath }
+      .firstOrNull {
+        it.fqName.shortName()
+            .asString() == scopeClassReference
+      }
+      ?.let { return it.fqName }
+
+  // If there is no import, then try to resolve the class with the same package as this file.
+  module
+      .resolveClassByFqName(
+          FqName("${containingKtFile.packageFqName}.$scopeClassReference"),
+          FROM_BACKEND
+      )
+      ?.let { return it.fqNameSafe }
+
+  // If this doesn't work, then maybe a class from the Kotlin package is used.
+  module.resolveClassByFqName(FqName("kotlin.$scopeClassReference"), FROM_BACKEND)
+      ?.let { return it.fqNameSafe }
+
+  // Everything else isn't supported.
+  throw AnvilCompilationException(
+      "Couldn't resolve scope $scopeClassReference for Psi element: $text",
+      element = this
+  )
+}
+
+private fun KtClassOrObject.findScopeClassLiteralExpression(
+  annotationFqName: FqName
+): KtClassLiteralExpression {
+  val annotationEntry = findAnnotation(annotationFqName)
+      ?: throw AnvilCompilationException(
+          "Couldn't find $annotationFqName for Psi element: $text",
+          element = this
+      )
+
+  val annotationValues = annotationEntry.valueArguments
+      .asSequence()
+      .filterIsInstance<KtValueArgument>()
+
+  // First check if the is any named parameter. Named parameters allow a different order of
+  // arguments.
+  annotationValues
+      .mapNotNull { valueArgument ->
+        val children = valueArgument.children
+        if (children.size == 2 && children[0] is KtValueArgumentName &&
+            (children[0] as KtValueArgumentName).asName.asString() == "scope" &&
+            children[1] is KtClassLiteralExpression
+        ) {
+          children[1] as KtClassLiteralExpression
+        } else {
+          null
+        }
+      }
+      .firstOrNull()
+      ?.let { return it }
+
+  // If there is no named argument, then take the first argument, which must be a class literal
+  // expression, e.g. @ContributesTo(Unit::class)
+  return annotationValues
+      .firstOrNull()
+      ?.let { valueArgument ->
+        valueArgument.children.firstOrNull() as? KtClassLiteralExpression
+      }
+      ?: throw AnvilCompilationException(
+          "The first argument for $annotationFqName must be a class literal: $text",
+          element = this
+      )
 }

--- a/compiler/src/test/java/com/squareup/anvil/compiler/InterfaceMergerTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/InterfaceMergerTest.kt
@@ -425,7 +425,7 @@ class InterfaceMergerTest(
     }
   }
 
-  @Test fun `inner interface in a merged component with different scope fail`() {
+  @Test fun `inner interface in a merged component with different scope are merged`() {
     assumeMergeComponent(annotationClass)
 
     compile(
@@ -442,16 +442,15 @@ class InterfaceMergerTest(
         @MergeSubcomponent(Any::class)
         interface SubcomponentInterface {
           @ContributesTo(Unit::class)
-          interface InnerComponent
+          interface InnerInterface
         }
     """
     ) {
-      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
-      assertThat(messages).contains("File being compiled: (13,13)")
-      assertThat(messages).contains(
-          "It seems like you tried to contribute an inner class of a merged component to " +
-              "another component. This is not supported and results in a compiler error."
-      )
+      val innerInterface = classLoader
+          .loadClass("com.squareup.test.SubcomponentInterface\$InnerInterface")
+      assertThat(componentInterface extends innerInterface).isTrue()
+      assertThat(componentInterface.interfaces).hasLength(1)
+      assertThat(subcomponentInterface.interfaces).hasLength(0)
     }
   }
 

--- a/compiler/src/test/java/com/squareup/anvil/compiler/InterfaceMergerTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/InterfaceMergerTest.kt
@@ -425,6 +425,36 @@ class InterfaceMergerTest(
     }
   }
 
+  @Test fun `inner interface in a merged component with different scope fail`() {
+    assumeMergeComponent(annotationClass)
+
+    compile(
+        """
+        package com.squareup.test
+
+        import com.squareup.anvil.annotations.ContributesTo
+        import com.squareup.anvil.annotations.MergeComponent
+        import com.squareup.anvil.annotations.MergeSubcomponent
+        
+        @MergeComponent(Unit::class)
+        interface ComponentInterface
+        
+        @MergeSubcomponent(Any::class)
+        interface SubcomponentInterface {
+          @ContributesTo(Unit::class)
+          interface InnerComponent
+        }
+    """
+    ) {
+      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+      assertThat(messages).contains("File being compiled: (13,13)")
+      assertThat(messages).contains(
+          "It seems like you tried to contribute an inner class of a merged component to " +
+              "another component. This is not supported and results in a compiler error."
+      )
+    }
+  }
+
   @Test fun `module interfaces are not merged`() {
     // They could cause errors while compiling code when adding our contributed super classes.
     compile(

--- a/compiler/src/test/java/com/squareup/anvil/compiler/ModuleMergerTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/ModuleMergerTest.kt
@@ -555,6 +555,33 @@ class ModuleMergerTest(
     }
   }
 
+  @Test fun `inner modules in a merged component with different scope are merged`() {
+    compile(
+        """
+        package com.squareup.test
+
+        import com.squareup.anvil.annotations.ContributesTo
+        $import
+        
+        $annotation(Unit::class)
+        interface ComponentInterface
+        
+        $annotation(Any::class)
+        interface SubcomponentInterface {
+          @ContributesTo(Unit::class)
+          @dagger.Module
+          abstract class InnerModule
+        }
+    """
+    ) {
+      val innerModule = classLoader
+          .loadClass("com.squareup.test.SubcomponentInterface\$InnerModule")
+      assertThat(componentInterface.anyDaggerComponent.modules.withoutAnvilModule())
+          .containsExactly(innerModule.kotlin)
+      assertThat(subcomponentInterface.anyDaggerComponent.modules.withoutAnvilModule()).isEmpty()
+    }
+  }
+
   @Test fun `a module is not allowed to be included and excluded`() {
     compile(
         """

--- a/compiler/src/test/java/com/squareup/anvil/compiler/codegen/ContributesBindingGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/codegen/ContributesBindingGeneratorTest.kt
@@ -4,6 +4,7 @@ import com.google.common.truth.Truth.assertThat
 import com.squareup.anvil.compiler.compile
 import com.squareup.anvil.compiler.contributingInterface
 import com.squareup.anvil.compiler.hintBinding
+import com.squareup.anvil.compiler.hintBindingScope
 import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.COMPILATION_ERROR
 import org.junit.Test
 
@@ -23,6 +24,7 @@ class ContributesBindingGeneratorTest {
     """
     ) {
       assertThat(contributingInterface.hintBinding?.java).isEqualTo(contributingInterface)
+      assertThat(contributingInterface.hintBindingScope).isEqualTo(Any::class)
     }
   }
 
@@ -40,6 +42,24 @@ class ContributesBindingGeneratorTest {
     """
     ) {
       assertThat(contributingInterface.hintBinding?.java).isEqualTo(contributingInterface)
+      assertThat(contributingInterface.hintBindingScope).isEqualTo(Any::class)
+    }
+  }
+
+  @Test fun `the order of the scope can be changed with named parameters`() {
+    compile(
+        """
+        package com.squareup.test
+
+        import com.squareup.anvil.annotations.ContributesBinding
+
+        interface ParentInterface
+
+        @ContributesBinding(boundType = ParentInterface::class, scope = Int::class)
+        class ContributingInterface : ParentInterface
+    """
+    ) {
+      assertThat(contributingInterface.hintBindingScope).isEqualTo(Int::class)
     }
   }
 
@@ -61,6 +81,7 @@ class ContributesBindingGeneratorTest {
       val contributingInterface =
         classLoader.loadClass("com.squareup.test.Abc\$ContributingInterface")
       assertThat(contributingInterface.hintBinding?.java).isEqualTo(contributingInterface)
+      assertThat(contributingInterface.hintBindingScope).isEqualTo(Any::class)
     }
   }
 
@@ -82,6 +103,7 @@ class ContributesBindingGeneratorTest {
       val contributingClass =
         classLoader.loadClass("com.squareup.test.Abc\$ContributingClass")
       assertThat(contributingClass.hintBinding?.java).isEqualTo(contributingClass)
+      assertThat(contributingClass.hintBindingScope).isEqualTo(Any::class)
     }
   }
 

--- a/compiler/src/test/java/com/squareup/anvil/compiler/codegen/ContributesToGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/codegen/ContributesToGeneratorTest.kt
@@ -6,6 +6,7 @@ import com.squareup.anvil.compiler.componentInterface
 import com.squareup.anvil.compiler.contributingInterface
 import com.squareup.anvil.compiler.daggerModule1
 import com.squareup.anvil.compiler.hintContributes
+import com.squareup.anvil.compiler.hintContributesScope
 import com.squareup.anvil.compiler.innerInterface
 import com.squareup.anvil.compiler.innerModule
 import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.COMPILATION_ERROR
@@ -25,6 +26,7 @@ class ContributesToGeneratorTest {
     """
     ) {
       assertThat(componentInterface.hintContributes).isNull()
+      assertThat(componentInterface.hintContributesScope).isNull()
     }
 
     compile(
@@ -38,6 +40,7 @@ class ContributesToGeneratorTest {
     """
     ) {
       assertThat(componentInterface.hintContributes).isNull()
+      assertThat(componentInterface.hintContributesScope).isNull()
     }
   }
 
@@ -54,6 +57,7 @@ class ContributesToGeneratorTest {
     """
     ) {
       assertThat(daggerModule1.hintContributes?.java).isEqualTo(daggerModule1)
+      assertThat(daggerModule1.hintContributesScope).isEqualTo(Any::class)
     }
   }
 
@@ -69,6 +73,22 @@ class ContributesToGeneratorTest {
     """
     ) {
       assertThat(contributingInterface.hintContributes?.java).isEqualTo(contributingInterface)
+      assertThat(contributingInterface.hintContributesScope).isEqualTo(Any::class)
+    }
+  }
+
+  @Test fun `the order of the scope can be changed with named parameters`() {
+    compile(
+        """
+        package com.squareup.test
+
+        import com.squareup.anvil.annotations.ContributesTo
+
+        @ContributesTo(replaces = [Unit::class], scope = Int::class)
+        interface ContributingInterface
+    """
+    ) {
+      assertThat(contributingInterface.hintContributesScope).isEqualTo(Int::class)
     }
   }
 
@@ -87,6 +107,7 @@ class ContributesToGeneratorTest {
     """
     ) {
       assertThat(innerModule.hintContributes?.java).isEqualTo(innerModule)
+      assertThat(innerModule.hintContributesScope).isEqualTo(Any::class)
     }
   }
 
@@ -104,6 +125,7 @@ class ContributesToGeneratorTest {
     """
     ) {
       assertThat(innerInterface.hintContributes?.java).isEqualTo(innerInterface)
+      assertThat(innerInterface.hintContributesScope).isEqualTo(Any::class)
     }
   }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=com.squareup.anvil
-VERSION_NAME=1.0.7-SNAPSHOT
+VERSION_NAME=2.0.0-SNAPSHOT
 
 POM_DESCRIPTION=A Kotlin compiler plugin to make dependency injection with Dagger 2 easier by automatically merging Dagger modules and component interfaces.
 POM_INCEPTION_YEAR=2020


### PR DESCRIPTION
This PR fixes #45. It requires quite a lot of changes. 

The hint for the scope allows us to filter classes without resolving them. Resolving classes can be problematic, because super types need to be resolved and we modify the super types for certain classes. This would result in never ending recursive loop inside of the compiler.

This PR depends on #54, which requires a major version bump according to semantic versioning. This also allows to make non-backwards compatible changes here. Users don't need to fix any code, they only must recompile all libraries using Anvil at the same time. In a monorepo this isn't a concern.