### PR TITLE
Throw a compilation error when the contributed binding has a type argument.

### DIFF
--- a/compiler/src/test/java/com/squareup/anvil/compiler/codegen/BindingModuleGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/codegen/BindingModuleGeneratorTest.kt
@@ -339,6 +339,36 @@ class BindingModuleGeneratorTest(
     }
   }
 
+  @Test fun `the contributed binding class must not have a generic type parameter`() {
+    compile(
+        """
+        package com.squareup.test
+        
+        import com.squareup.anvil.annotations.ContributesBinding
+        $import
+
+        interface ParentInterface<T, S>
+        
+        class SomeOtherType
+        
+        @ContributesBinding(Any::class, ParentInterface::class)
+        interface ContributingInterface:
+                ParentInterface<Map<String, List<Pair<String, Int>>>, SomeOtherType>
+        
+        $annotation(Any::class)
+        interface ComponentInterface
+    """
+    ) {
+      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+
+      assertThat(messages).contains("Source.kt: (6, 11)")
+      assertThat(messages).contains(
+          "Binding com.squareup.test.ParentInterface contains type parameters(s)" +
+              " <Map<String, List<Pair<String, Int>>>, SomeOtherType>"
+      )
+    }
+  }
+
   private val Class<*>.anyDaggerComponent: AnyDaggerComponent
     get() = anyDaggerComponent(annotationClass)
 }

--- a/compiler/src/test/java/com/squareup/anvil/compiler/codegen/BindingModuleGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/codegen/BindingModuleGeneratorTest.kt
@@ -352,7 +352,7 @@ class BindingModuleGeneratorTest(
         class SomeOtherType
         
         @ContributesBinding(Any::class, ParentInterface::class)
-        interface ContributingInterface:
+        interface ContributingInterface :
                 ParentInterface<Map<String, List<Pair<String, Int>>>, SomeOtherType>
         
         $annotation(Any::class)


### PR DESCRIPTION
This is an example of a (more complicated) error for `ParentInterface<Map<String, List<Pair<String, Int>>>, SomeOtherType>`

>  com.squareup.anvil.compiler.AnvilCompilationException: Back-end (JVM) Internal error: Binding com.squareup.test.ParentInterface contains type parameters(s) <Map<String, List<Pair<String, Int>>>, SomeOtherType>. Type parameters in bindings are not supported. This binding needs to be contributed to a dagger module manually