### PR TITLE
Allow using Anvil to generate Dagger factories even though the module uses a Subcomponent.

### DIFF
--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/ComponentDetectorCheck.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/ComponentDetectorCheck.kt
@@ -6,7 +6,6 @@ import com.squareup.anvil.compiler.codegen.CodeGenerator.GeneratedFile
 import com.squareup.anvil.compiler.codegen.classesAndInnerClasses
 import com.squareup.anvil.compiler.codegen.hasAnnotation
 import com.squareup.anvil.compiler.daggerComponentFqName
-import com.squareup.anvil.compiler.daggerSubcomponentFqName
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 import org.jetbrains.kotlin.psi.KtFile
 import java.io.File
@@ -20,11 +19,7 @@ internal class ComponentDetectorCheck : CodeGenerator {
     val component = projectFiles
         .asSequence()
         .flatMap { it.classesAndInnerClasses() }
-        .firstOrNull() { clazz ->
-          clazz.hasAnnotation(daggerComponentFqName) || clazz.hasAnnotation(
-              daggerSubcomponentFqName
-          )
-        }
+        .firstOrNull { it.hasAnnotation(daggerComponentFqName) }
 
     if (component != null) {
       throw AnvilCompilationException(

--- a/compiler/src/test/java/com/squareup/anvil/compiler/dagger/ComponentDetectorCheckTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/dagger/ComponentDetectorCheckTest.kt
@@ -2,6 +2,7 @@ package com.squareup.anvil.compiler.dagger
 
 import com.google.common.truth.Truth.assertThat
 import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.COMPILATION_ERROR
+import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.OK
 import com.tschuchort.compiletesting.KotlinCompilation.Result
 import org.junit.Test
 
@@ -30,7 +31,7 @@ class ComponentDetectorCheckTest {
     }
   }
 
-  @Test fun `a Dagger subcomponent causes an error`() {
+  @Test fun `a Dagger subcomponent is allowed`() {
     compile(
         """
         package com.squareup.test
@@ -41,15 +42,7 @@ class ComponentDetectorCheckTest {
         interface ComponentInterface
         """
     ) {
-      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
-      // Position to the class.
-      assertThat(messages).contains("Source.kt: (5, 1")
-      assertThat(messages).contains(
-          "Anvil cannot generate the code for Dagger components or subcomponents. In these " +
-              "cases the Dagger annotation processor is required. Enabling the Dagger " +
-              "annotation processor and turning on Anvil to generate Dagger factories is " +
-              "redundant. Set 'generateDaggerFactories' to false."
-      )
+      assertThat(exitCode).isEqualTo(OK)
     }
   }
 
@@ -78,7 +71,7 @@ class ComponentDetectorCheckTest {
     }
   }
 
-  @Test fun `a Dagger subcomponent causes an error inner class`() {
+  @Test fun `a Dagger subcomponent in an inner class is allowed`() {
     compile(
         """
         package com.squareup.test
@@ -91,15 +84,7 @@ class ComponentDetectorCheckTest {
         }
         """
     ) {
-      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
-      // Position to the class.
-      assertThat(messages).contains("Source.kt: (6, 3")
-      assertThat(messages).contains(
-          "Anvil cannot generate the code for Dagger components or subcomponents. In these " +
-              "cases the Dagger annotation processor is required. Enabling the Dagger " +
-              "annotation processor and turning on Anvil to generate Dagger factories is " +
-              "redundant. Set 'generateDaggerFactories' to false."
-      )
+      assertThat(exitCode).isEqualTo(OK)
     }
   }
 


### PR DESCRIPTION
This is fine, because Dagger only generates the code for Subcomponents when generating the parent Component.

Fixes #74.