### PR TITLE
Add missing import

### DIFF
--- a/compiler/src/main/java/com/squareup/anvil/compiler/InterfaceMerger.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/InterfaceMerger.kt
@@ -3,15 +3,12 @@ package com.squareup.anvil.compiler
 import org.jetbrains.kotlin.descriptors.ClassDescriptor
 import org.jetbrains.kotlin.descriptors.EffectiveVisibility.Public
 import org.jetbrains.kotlin.descriptors.effectiveVisibility
-import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.resolve.DescriptorUtils
-import org.jetbrains.kotlin.resolve.DescriptorUtils.getFqNameSafe
 import org.jetbrains.kotlin.resolve.constants.ArrayValue
 import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
 import org.jetbrains.kotlin.resolve.descriptorUtil.module
 import org.jetbrains.kotlin.resolve.extensions.SyntheticResolveExtension
 import org.jetbrains.kotlin.types.KotlinType
-import org.jetbrains.kotlin.types.typeUtil.supertypes
 
 /**
  * Finds all contributed component interfaces and adds them as super types to Dagger components
@@ -98,6 +95,7 @@ internal class InterfaceMerger(
 
     if (excludedClasses.isNotEmpty()) {
       val intersect = supertypes.getAllSuperTypes()
+          .toList()
           .intersect(excludedClasses)
 
       if (intersect.isNotEmpty()) {
@@ -123,12 +121,4 @@ internal class InterfaceMerger(
     supertypes += contributedClasses
     super.addSyntheticSupertypes(thisDescriptor, supertypes)
   }
-
-  private fun List<KotlinType>.getAllSuperTypes(): List<FqName> =
-    generateSequence(this) { kotlinTypes ->
-      if (kotlinTypes.isEmpty()) null else kotlinTypes.flatMap { it.supertypes() }
-    }
-        .flatMap { it.asSequence() }
-        .map { getFqNameSafe(it.classDescriptorForType()) }
-        .toList()
 }

--- a/compiler/src/main/java/com/squareup/anvil/compiler/Utils.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/Utils.kt
@@ -34,6 +34,7 @@ import org.jetbrains.kotlin.resolve.descriptorUtil.getSuperClassNotAny
 import org.jetbrains.kotlin.resolve.descriptorUtil.getSuperInterfaces
 import org.jetbrains.kotlin.resolve.descriptorUtil.module
 import org.jetbrains.kotlin.types.KotlinType
+import org.jetbrains.kotlin.types.typeUtil.supertypes
 import org.jetbrains.org.objectweb.asm.Type
 import javax.inject.Inject
 import javax.inject.Provider
@@ -177,3 +178,10 @@ internal fun KtClassOrObject.generateClassName(
             .shortName()
             .asString()
       }
+
+internal fun List<KotlinType>.getAllSuperTypes(): Sequence<FqName> =
+  generateSequence(this) { kotlinTypes ->
+    kotlinTypes.ifEmpty { null }?.flatMap { it.supertypes() }
+  }
+      .flatMap { it.asSequence() }
+      .map { DescriptorUtils.getFqNameSafe(it.classDescriptorForType()) }


### PR DESCRIPTION
Add missing import for inject constructor factories when an injected type is an inner class of the class itself or are parent type.

Fixes #79.