### PR TITLE
Missing Factory class

### DIFF
--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/BindingModuleGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/BindingModuleGenerator.kt
@@ -151,8 +151,8 @@ internal class BindingModuleGenerator(
   override fun flush(
     codeGenDir: File,
     module: ModuleDescriptor
-  ) {
-    mergedScopes.forEach { (scope, daggerModuleFiles) ->
+  ): Collection<GeneratedFile> {
+    return mergedScopes.flatMap { (scope, daggerModuleFiles) ->
       val contributedBindingsThisModule = contributedBindingClasses
           .asSequence()
           .mapNotNull { clazz ->
@@ -248,14 +248,16 @@ internal class BindingModuleGenerator(
           }
           .toList()
 
-      daggerModuleFiles.forEach { (file, psiClass) ->
-        file.writeText(
-            daggerModuleContent(
-                scope = scope.asString(),
-                psiClass = psiClass,
-                generatedMethods = generatedMethods
-            )
+      daggerModuleFiles.map { (file, psiClass) ->
+        val content = daggerModuleContent(
+            scope = scope.asString(),
+            psiClass = psiClass,
+            generatedMethods = generatedMethods
         )
+
+        file.writeText(content)
+
+        GeneratedFile(file, content)
       }
     }
   }
@@ -378,9 +380,6 @@ internal class BindingModuleGenerator(
         }
         .build()
         .writeToString()
-        .also {
-          println(it)
-        }
   }
 }
 

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/CodeGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/CodeGenerator.kt
@@ -5,6 +5,7 @@ import org.jetbrains.kotlin.psi.KtFile
 import java.io.File
 
 internal interface CodeGenerator {
+
   /**
    * Called multiple times in order to create new code. Note that instances should not rely on
    * being able to resolve [projectFiles] to descriptors. They should rather use the Psi APIs to
@@ -22,12 +23,14 @@ internal interface CodeGenerator {
 
   /**
    * Called after the last round of [generateCode] when no new files were produced by any code
-   * generator anymore.
+   * generator anymore. The returned result should contain files that were added or changed one
+   * last time. Code generates that do not impact other code generators get a last chance to
+   * evaluate these results.
    */
   fun flush(
     codeGenDir: File,
     module: ModuleDescriptor
-  ) = Unit
+  ): Collection<GeneratedFile> = emptyList()
 
   data class GeneratedFile(
     val file: File,

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/PrivateCodeGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/PrivateCodeGenerator.kt
@@ -1,0 +1,28 @@
+package com.squareup.anvil.compiler.codegen
+
+import com.squareup.anvil.compiler.codegen.CodeGenerator.GeneratedFile
+import org.jetbrains.kotlin.descriptors.ModuleDescriptor
+import org.jetbrains.kotlin.psi.KtFile
+import java.io.File
+
+/**
+ * Generates code that doesn't impact any other [CodeGenerator], meaning no other code generator
+ * will process the generated code produced by this instance. A [PrivateCodeGenerator] in called
+ * one last time after [flush] has been called to get a chance to evaluate written results.
+ */
+internal abstract class PrivateCodeGenerator : CodeGenerator {
+  final override fun generateCode(
+    codeGenDir: File,
+    module: ModuleDescriptor,
+    projectFiles: Collection<KtFile>
+  ): Collection<GeneratedFile> {
+    generateCodePrivate(codeGenDir, module, projectFiles)
+    return emptyList()
+  }
+
+  protected abstract fun generateCodePrivate(
+    codeGenDir: File,
+    module: ModuleDescriptor,
+    projectFiles: Collection<KtFile>
+  )
+}

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/ComponentDetectorCheck.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/ComponentDetectorCheck.kt
@@ -1,8 +1,7 @@
 package com.squareup.anvil.compiler.codegen.dagger
 
 import com.squareup.anvil.compiler.AnvilCompilationException
-import com.squareup.anvil.compiler.codegen.CodeGenerator
-import com.squareup.anvil.compiler.codegen.CodeGenerator.GeneratedFile
+import com.squareup.anvil.compiler.codegen.PrivateCodeGenerator
 import com.squareup.anvil.compiler.codegen.classesAndInnerClasses
 import com.squareup.anvil.compiler.codegen.hasAnnotation
 import com.squareup.anvil.compiler.daggerComponentFqName
@@ -10,12 +9,13 @@ import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 import org.jetbrains.kotlin.psi.KtFile
 import java.io.File
 
-internal class ComponentDetectorCheck : CodeGenerator {
-  override fun generateCode(
+internal class ComponentDetectorCheck : PrivateCodeGenerator() {
+
+  override fun generateCodePrivate(
     codeGenDir: File,
     module: ModuleDescriptor,
     projectFiles: Collection<KtFile>
-  ): Collection<GeneratedFile> {
+  ) {
     val component = projectFiles
         .asSequence()
         .flatMap { it.classesAndInnerClasses() }
@@ -30,7 +30,5 @@ internal class ComponentDetectorCheck : CodeGenerator {
           element = component
       )
     }
-
-    return emptyList()
   }
 }

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/InjectConstructorFactoryGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/InjectConstructorFactoryGenerator.kt
@@ -1,7 +1,7 @@
 package com.squareup.anvil.compiler.codegen.dagger
 
-import com.squareup.anvil.compiler.codegen.CodeGenerator
 import com.squareup.anvil.compiler.codegen.CodeGenerator.GeneratedFile
+import com.squareup.anvil.compiler.codegen.PrivateCodeGenerator
 import com.squareup.anvil.compiler.codegen.addGeneratedByComment
 import com.squareup.anvil.compiler.codegen.asArgumentList
 import com.squareup.anvil.compiler.codegen.asTypeName
@@ -30,23 +30,23 @@ import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.allConstructors
 import java.io.File
 
-internal class InjectConstructorFactoryGenerator : CodeGenerator {
-  override fun generateCode(
+internal class InjectConstructorFactoryGenerator : PrivateCodeGenerator() {
+
+  override fun generateCodePrivate(
     codeGenDir: File,
     module: ModuleDescriptor,
     projectFiles: Collection<KtFile>
-  ): Collection<GeneratedFile> {
-    return projectFiles
+  ) {
+    projectFiles
         .asSequence()
         .flatMap { it.classesAndInnerClasses() }
-        .mapNotNull { clazz ->
+        .forEach { clazz ->
           clazz.allConstructors
               .singleOrNull { it.hasAnnotation(injectFqName) }
               ?.let {
                 generateFactoryClass(codeGenDir, module, clazz, it)
               }
         }
-        .toList()
   }
 
   @OptIn(ExperimentalStdlibApi::class)

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/ProvidesMethodFactoryGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/ProvidesMethodFactoryGenerator.kt
@@ -1,7 +1,7 @@
 package com.squareup.anvil.compiler.codegen.dagger
 
-import com.squareup.anvil.compiler.codegen.CodeGenerator
 import com.squareup.anvil.compiler.codegen.CodeGenerator.GeneratedFile
+import com.squareup.anvil.compiler.codegen.PrivateCodeGenerator
 import com.squareup.anvil.compiler.codegen.addGeneratedByComment
 import com.squareup.anvil.compiler.codegen.asArgumentList
 import com.squareup.anvil.compiler.codegen.asTypeName
@@ -39,26 +39,26 @@ import org.jetbrains.kotlin.psi.psiUtil.parents
 import java.io.File
 import java.util.Locale.US
 
-internal class ProvidesMethodFactoryGenerator : CodeGenerator {
-  override fun generateCode(
+internal class ProvidesMethodFactoryGenerator : PrivateCodeGenerator() {
+
+  override fun generateCodePrivate(
     codeGenDir: File,
     module: ModuleDescriptor,
     projectFiles: Collection<KtFile>
-  ): Collection<GeneratedFile> {
-    return projectFiles
+  ) {
+    projectFiles
         .asSequence()
         .flatMap { it.classesAndInnerClasses() }
         .filter { it.hasAnnotation(daggerModuleFqName) }
-        .flatMap { clazz ->
+        .forEach { clazz ->
           clazz
               .functions(includeCompanionObjects = true)
               .asSequence()
               .filter { it.hasAnnotation(daggerProvidesFqName) }
-              .map { function ->
+              .forEach { function ->
                 generateFactoryClass(codeGenDir, module, clazz, function)
               }
         }
-        .toList()
   }
 
   @OptIn(ExperimentalStdlibApi::class)


### PR DESCRIPTION
Generate a Dagger factory for provider methods that Anvil generates in its Anvil specific modules when the experimental feature is enabled to generate Dagger factories.