### PR TITLE
Fix crash for inner classes starting with a lowercase character

### DIFF
--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/KotlinPoet.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/KotlinPoet.kt
@@ -62,7 +62,7 @@ internal fun KtCallableDeclaration.requireTypeName(
       ?: typeReference.fqNameOrNull(module)
       ?: return typeVariableName()
 
-  return ClassName.bestGuess(fqNameForGuess.asString())
+  return fqNameForGuess.asTypeName()
       .let { if (typeReference.isNullable()) it.copy(nullable = true) else it }
 }
 


### PR DESCRIPTION
Support inner classes starting with a lowercase character when generating factories for inject constructors.

Fixes #96