### PR TITLE
Fix wrong imports

### DIFF
--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/BindingModuleGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/BindingModuleGenerator.kt
@@ -222,8 +222,8 @@ internal class BindingModuleGenerator(
                               }
                       )
                       .addAnnotation(Provides::class)
-                      .returns(boundType.asTypeName())
-                      .addStatement("return %T", contributedClass.asTypeName())
+                      .returns(boundType.asClassName())
+                      .addStatement("return %T", contributedClass.asClassName())
                       .build()
               )
             } else {
@@ -239,9 +239,9 @@ internal class BindingModuleGenerator(
                       .addModifiers(ABSTRACT)
                       .addParameter(
                           name = concreteType.shortName().asString().decapitalize(US),
-                          type = contributedClass.asTypeName()
+                          type = contributedClass.asClassName()
                       )
-                      .returns(boundType.asTypeName())
+                      .returns(boundType.asClassName())
                       .build()
               )
             }

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/BindingModuleGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/BindingModuleGenerator.kt
@@ -223,7 +223,7 @@ internal class BindingModuleGenerator(
                       )
                       .addAnnotation(Provides::class)
                       .returns(boundType.asTypeName())
-                      .addStatement("return %T", concreteType.asTypeName())
+                      .addStatement("return %T", contributedClass.asTypeName())
                       .build()
               )
             } else {
@@ -239,7 +239,7 @@ internal class BindingModuleGenerator(
                       .addModifiers(ABSTRACT)
                       .addParameter(
                           name = concreteType.shortName().asString().decapitalize(US),
-                          type = concreteType.asTypeName()
+                          type = contributedClass.asTypeName()
                       )
                       .returns(boundType.asTypeName())
                       .build()

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/KotlinPoet.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/KotlinPoet.kt
@@ -13,6 +13,7 @@ import com.squareup.kotlinpoet.LambdaTypeName
 import com.squareup.kotlinpoet.ParameterSpec
 import com.squareup.kotlinpoet.ParameterizedTypeName
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import com.squareup.kotlinpoet.STAR
 import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.asClassName
 import com.squareup.kotlinpoet.jvm.jvmSuppressWildcards
@@ -26,6 +27,7 @@ import org.jetbrains.kotlin.psi.KtCallableDeclaration
 import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.psi.KtFunctionType
 import org.jetbrains.kotlin.psi.KtNullableType
+import org.jetbrains.kotlin.psi.KtProjectionKind
 import org.jetbrains.kotlin.psi.KtTypeArgumentList
 import org.jetbrains.kotlin.psi.KtTypeElement
 import org.jetbrains.kotlin.psi.KtTypeProjection
@@ -100,7 +102,11 @@ internal fun KtTypeReference.requireTypeName(
         if (typeArgumentList != null) {
           className.parameterizedBy(
               typeArgumentList.arguments.map {
-                (it.typeReference ?: it.fail()).requireTypeName(module)
+                if (it.projectionKind == KtProjectionKind.STAR) {
+                  STAR
+                } else {
+                  (it.typeReference ?: it.fail()).requireTypeName(module)
+                }
               }
           )
         } else {

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/PsiUtils.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/PsiUtils.kt
@@ -259,6 +259,10 @@ internal fun PsiElement.requireFqName(
   module.resolveClassByFqName(FqName("kotlin.collections.$classReference"), FROM_BACKEND)
       ?.let { return it.fqNameSafe }
 
+  // Or java.lang.
+  module.resolveClassByFqName(FqName("java.lang.$classReference"), FROM_BACKEND)
+      ?.let { return it.fqNameSafe }
+
   findFqNameInSuperTypes(module, classReference)
       ?.let { return it }
 

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/InjectConstructorFactoryGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/InjectConstructorFactoryGenerator.kt
@@ -8,7 +8,6 @@ import com.squareup.anvil.compiler.codegen.asTypeName
 import com.squareup.anvil.compiler.codegen.classesAndInnerClasses
 import com.squareup.anvil.compiler.codegen.hasAnnotation
 import com.squareup.anvil.compiler.codegen.mapToParameter
-import com.squareup.anvil.compiler.codegen.replaceImports
 import com.squareup.anvil.compiler.codegen.writeToString
 import com.squareup.anvil.compiler.generateClassName
 import com.squareup.anvil.compiler.injectFqName
@@ -168,7 +167,6 @@ internal class InjectConstructorFactoryGenerator : PrivateCodeGenerator() {
         }
         .build()
         .writeToString()
-        .replaceImports(clazz)
         .addGeneratedByComment()
 
     val directory = File(codeGenDir, packageName.replace('.', File.separatorChar))

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/InjectConstructorFactoryGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/InjectConstructorFactoryGenerator.kt
@@ -4,7 +4,7 @@ import com.squareup.anvil.compiler.codegen.CodeGenerator.GeneratedFile
 import com.squareup.anvil.compiler.codegen.PrivateCodeGenerator
 import com.squareup.anvil.compiler.codegen.addGeneratedByComment
 import com.squareup.anvil.compiler.codegen.asArgumentList
-import com.squareup.anvil.compiler.codegen.asTypeName
+import com.squareup.anvil.compiler.codegen.asClassName
 import com.squareup.anvil.compiler.codegen.classesAndInnerClasses
 import com.squareup.anvil.compiler.codegen.hasAnnotation
 import com.squareup.anvil.compiler.codegen.mapToParameter
@@ -57,7 +57,7 @@ internal class InjectConstructorFactoryGenerator : PrivateCodeGenerator() {
   ): GeneratedFile {
     val packageName = clazz.containingKtFile.packageFqName.asString()
     val className = "${clazz.generateClassName()}_Factory"
-    val classType = clazz.asTypeName()
+    val classType = clazz.asClassName()
 
     val parameters = constructor.getValueParameters().mapToParameter(module)
 

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/MembersInjectorGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/MembersInjectorGenerator.kt
@@ -3,7 +3,7 @@ package com.squareup.anvil.compiler.codegen.dagger
 import com.squareup.anvil.compiler.codegen.CodeGenerator.GeneratedFile
 import com.squareup.anvil.compiler.codegen.PrivateCodeGenerator
 import com.squareup.anvil.compiler.codegen.addGeneratedByComment
-import com.squareup.anvil.compiler.codegen.asTypeName
+import com.squareup.anvil.compiler.codegen.asClassName
 import com.squareup.anvil.compiler.codegen.classesAndInnerClasses
 import com.squareup.anvil.compiler.codegen.hasAnnotation
 import com.squareup.anvil.compiler.codegen.isGenericClass
@@ -70,12 +70,10 @@ internal class MembersInjectorGenerator : PrivateCodeGenerator() {
   ): GeneratedFile {
     val packageName = clazz.containingKtFile.packageFqName.asString()
     val className = "${clazz.generateClassName()}_MembersInjector"
-    val classType = clazz.asTypeName()
+    val classType = clazz.asClassName()
         .let {
-          if (it is ClassName && clazz.isGenericClass()) {
-            val numberOfStars = clazz.typeParameterList!!.parameters.size
-            val stars = Array(numberOfStars) { STAR }
-            it.parameterizedBy(*stars)
+          if (clazz.isGenericClass()) {
+            it.parameterizedBy(List(size = clazz.typeParameters.size) { STAR })
           } else {
             it
           }

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/MembersInjectorGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/MembersInjectorGenerator.kt
@@ -8,7 +8,6 @@ import com.squareup.anvil.compiler.codegen.classesAndInnerClasses
 import com.squareup.anvil.compiler.codegen.hasAnnotation
 import com.squareup.anvil.compiler.codegen.isGenericClass
 import com.squareup.anvil.compiler.codegen.mapToParameter
-import com.squareup.anvil.compiler.codegen.replaceImports
 import com.squareup.anvil.compiler.codegen.requireFqName
 import com.squareup.anvil.compiler.codegen.writeToString
 import com.squareup.anvil.compiler.daggerDoubleCheckFqNameString
@@ -188,7 +187,6 @@ internal class MembersInjectorGenerator : PrivateCodeGenerator() {
         )
         .build()
         .writeToString()
-        .replaceImports(clazz)
         .addGeneratedByComment()
 
     val directory = File(codeGenDir, packageName.replace('.', File.separatorChar))

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/ProvidesMethodFactoryGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/ProvidesMethodFactoryGenerator.kt
@@ -5,7 +5,7 @@ import com.squareup.anvil.compiler.codegen.CodeGenerator.GeneratedFile
 import com.squareup.anvil.compiler.codegen.PrivateCodeGenerator
 import com.squareup.anvil.compiler.codegen.addGeneratedByComment
 import com.squareup.anvil.compiler.codegen.asArgumentList
-import com.squareup.anvil.compiler.codegen.asTypeName
+import com.squareup.anvil.compiler.codegen.asClassName
 import com.squareup.anvil.compiler.codegen.classesAndInnerClasses
 import com.squareup.anvil.compiler.codegen.functions
 import com.squareup.anvil.compiler.codegen.hasAnnotation
@@ -103,7 +103,7 @@ internal class ProvidesMethodFactoryGenerator : PrivateCodeGenerator() {
     val returnTypeIsNullable = function.typeReference?.isNullable() ?: false
 
     val factoryClass = ClassName(packageName, className)
-    val moduleClass = clazz.asTypeName()
+    val moduleClass = clazz.asClassName()
 
     val content = FileSpec.builder(packageName, className)
         .apply {

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/ProvidesMethodFactoryGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/ProvidesMethodFactoryGenerator.kt
@@ -11,9 +11,9 @@ import com.squareup.anvil.compiler.codegen.functions
 import com.squareup.anvil.compiler.codegen.hasAnnotation
 import com.squareup.anvil.compiler.codegen.isNullable
 import com.squareup.anvil.compiler.codegen.mapToParameter
-import com.squareup.anvil.compiler.codegen.replaceImports
 import com.squareup.anvil.compiler.codegen.requireFqName
 import com.squareup.anvil.compiler.codegen.requireTypeName
+import com.squareup.anvil.compiler.codegen.requireTypeReference
 import com.squareup.anvil.compiler.codegen.withJvmSuppressWildcardsIfNeeded
 import com.squareup.anvil.compiler.codegen.writeToString
 import com.squareup.anvil.compiler.daggerModuleFqName
@@ -98,13 +98,7 @@ internal class ProvidesMethodFactoryGenerator : PrivateCodeGenerator() {
 
     val parameters = function.valueParameters.mapToParameter(module)
 
-    // This is a little hacky. The typeElement could be "String", "Abc", etc., but also a generic
-    // type like "List<String>". We simply copy this literal as return type into our generated
-    // code. Kotlinpoet will add an import for this literal like "import String", which we later
-    // will remove again.
-    //
-    // This solution is a lot easier than trying to resolve all FqNames for each type.
-    val returnType = function.requireTypeName(module)
+    val returnType = function.requireTypeReference().requireTypeName(module)
         .withJvmSuppressWildcardsIfNeeded(function)
     val returnTypeIsNullable = function.typeReference?.isNullable() ?: false
 
@@ -254,7 +248,6 @@ internal class ProvidesMethodFactoryGenerator : PrivateCodeGenerator() {
         }
         .build()
         .writeToString()
-        .replaceImports(clazz)
         .addGeneratedByComment()
 
     val directory = File(codeGenDir, packageName.replace('.', File.separatorChar))

--- a/compiler/src/test/java/com/squareup/anvil/compiler/dagger/Factory.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/dagger/Factory.kt
@@ -1,6 +1,0 @@
-@file:Suppress("unused")
-
-package com.squareup.anvil.compiler.dagger
-
-// This Factory is used in some of the unit tests. Don't touch it.
-object Factory

--- a/compiler/src/test/java/com/squareup/anvil/compiler/dagger/InjectConstructorFactoryGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/dagger/InjectConstructorFactoryGeneratorTest.kt
@@ -976,6 +976,64 @@ public final class InjectClass_Factory implements Factory<InjectClass> {
     }
   }
 
+  @Test fun `inner classes in generics are imported correctly`() {
+    /*
+package com.squareup.test;
+
+import dagger.internal.Factory;
+import java.util.Set;
+import javax.annotation.Generated;
+import javax.inject.Provider;
+
+@Generated(
+    value = "dagger.internal.codegen.ComponentProcessor",
+    comments = "https://dagger.dev"
+)
+@SuppressWarnings({
+    "unchecked",
+    "rawtypes"
+})
+public final class InjectClass_Factory implements Factory<InjectClass> {
+  private final Provider<Set<InjectClass.Interceptor>> interceptorsProvider;
+
+  public InjectClass_Factory(Provider<Set<InjectClass.Interceptor>> interceptorsProvider) {
+    this.interceptorsProvider = interceptorsProvider;
+  }
+
+  @Override
+  public InjectClass get() {
+    return newInstance(interceptorsProvider.get());
+  }
+
+  public static InjectClass_Factory create(
+      Provider<Set<InjectClass.Interceptor>> interceptorsProvider) {
+    return new InjectClass_Factory(interceptorsProvider);
+  }
+
+  public static InjectClass newInstance(Set<InjectClass.Interceptor> interceptors) {
+    return new InjectClass(interceptors);
+  }
+}
+     */
+
+    compile(
+        """
+        package com.squareup.test
+        
+        import javax.inject.Inject
+        
+        class InjectClass @Inject constructor(
+          interceptors: Set<@JvmSuppressWildcards Interceptor>
+        ) {
+          interface Interceptor
+        }
+        """
+    ) {
+      val constructor = injectClass.factoryClass().declaredConstructors.single()
+      assertThat(constructor.parameterTypes.toList()).containsExactly(Provider::class.java)
+    }
+  }
+
   private fun compile(
     source: String,
     block: Result.() -> Unit = { }

--- a/compiler/src/test/java/com/squareup/anvil/compiler/dagger/InjectConstructorFactoryGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/dagger/InjectConstructorFactoryGeneratorTest.kt
@@ -1034,6 +1034,64 @@ public final class InjectClass_Factory implements Factory<InjectClass> {
     }
   }
 
+  @Test fun `inner classes from outer type are imported correctly`() {
+    /*
+package com.squareup.test;
+
+import com.squareup.anvil.compiler.dagger.OuterClass;
+import dagger.internal.Factory;
+import javax.annotation.Generated;
+import javax.inject.Provider;
+
+@Generated(
+    value = "dagger.internal.codegen.ComponentProcessor",
+    comments = "https://dagger.dev"
+)
+@SuppressWarnings({
+    "unchecked",
+    "rawtypes"
+})
+public final class InjectClass_Inner_Factory implements Factory<InjectClass.Inner> {
+  private final Provider<OuterClass.InnerClass> innerClassProvider;
+
+  public InjectClass_Inner_Factory(Provider<OuterClass.InnerClass> innerClassProvider) {
+    this.innerClassProvider = innerClassProvider;
+  }
+
+  @Override
+  public InjectClass.Inner get() {
+    return newInstance(innerClassProvider.get());
+  }
+
+  public static InjectClass_Inner_Factory create(
+      Provider<OuterClass.InnerClass> innerClassProvider) {
+    return new InjectClass_Inner_Factory(innerClassProvider);
+  }
+
+  public static InjectClass.Inner newInstance(OuterClass.InnerClass innerClass) {
+    return new InjectClass.Inner(innerClass);
+  }
+}
+     */
+
+    compile(
+        """
+        package com.squareup.test
+        
+        import com.squareup.anvil.compiler.dagger.OuterClass
+        import javax.inject.Inject
+        
+        class InjectClass(innerClass: InnerClass): OuterClass(innerClass) {
+          class Inner @Inject constructor(innerClass: InnerClass)
+        }
+        """
+    ) {
+      val constructor = classLoader.loadClass("com.squareup.test.InjectClass\$Inner")
+          .factoryClass().declaredConstructors.single()
+      assertThat(constructor.parameterTypes.toList()).containsExactly(Provider::class.java)
+    }
+  }
+
   private fun compile(
     source: String,
     block: Result.() -> Unit = { }

--- a/compiler/src/test/java/com/squareup/anvil/compiler/dagger/InjectConstructorFactoryGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/dagger/InjectConstructorFactoryGeneratorTest.kt
@@ -677,6 +677,63 @@ public final class InjectClass_Factory implements Factory<InjectClass> {
   }
 
   @Test
+  fun `a factory class is generated for a class injecting a class starting with a lowercase character`() { // ktlint-disable max-line-length
+    /*
+package com.squareup.test;
+
+import dagger.internal.Factory;
+import javax.annotation.Generated;
+import javax.inject.Provider;
+
+@Generated(
+    value = "dagger.internal.codegen.ComponentProcessor",
+    comments = "https://dagger.dev"
+)
+@SuppressWarnings({
+    "unchecked",
+    "rawtypes"
+})
+public final class InjectClass_Factory implements Factory<InjectClass> {
+  private final Provider<otherClass.inner> innerProvider;
+
+  public InjectClass_Factory(Provider<otherClass.inner> innerProvider) {
+    this.innerProvider = innerProvider;
+  }
+
+  @Override
+  public InjectClass get() {
+    return newInstance(innerProvider.get());
+  }
+
+  public static InjectClass_Factory create(Provider<otherClass.inner> innerProvider) {
+    return new InjectClass_Factory(innerProvider);
+  }
+
+  public static InjectClass newInstance(otherClass.inner inner) {
+    return new InjectClass(inner);
+  }
+}
+     */
+
+    compile(
+        """
+        package com.squareup.test
+        
+        import javax.inject.Inject
+        
+        class InjectClass @Inject constructor(inner: otherClass.inner)
+        
+        class otherClass {
+          class inner @Inject constructor()
+        }
+        """
+    ) {
+      val constructor = injectClass.factoryClass().declaredConstructors.single()
+      assertThat(constructor.parameterTypes.toList()).containsExactly(Provider::class.java)
+    }
+  }
+
+  @Test
   fun `a factory class is generated for an inner class starting with a lowercase character`() {
     /*
 package com.squareup.test;

--- a/compiler/src/test/java/com/squareup/anvil/compiler/dagger/ProvidesMethodFactoryGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/dagger/ProvidesMethodFactoryGeneratorTest.kt
@@ -1659,6 +1659,28 @@ public final class ComponentInterface_InnerModule_ProvideStringFactory implement
     }
   }
 
+  @Test fun `a factory class is generated for a provider method returning an inner class`() {
+    compile(
+        """
+        package com.squareup.test
+        
+        import dagger.Module
+        import dagger.Provides
+        import com.squareup.anvil.compiler.dagger.OuterClass
+        
+        @Module
+        object DaggerModule1 {
+          @Provides fun provideInnerClass(): OuterClass.InnerClass = OuterClass.InnerClass()
+        }
+        """
+    ) {
+      val factoryClass = daggerModule1.moduleFactoryClass("provideInnerClass")
+
+      val constructor = factoryClass.declaredConstructors.single()
+      assertThat(constructor.parameterTypes.toList()).isEmpty()
+    }
+  }
+
   @Test
   fun `a factory class is generated for a provider method in a companion object in an inner module`() { // ktlint-disable max-line-length
     /*

--- a/compiler/src/test/java/com/squareup/anvil/compiler/dagger/ProvidesMethodFactoryGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/dagger/ProvidesMethodFactoryGeneratorTest.kt
@@ -2204,6 +2204,28 @@ public final class DaggerComponentInterface implements ComponentInterface {
     }
   }
 
+  @Test
+  fun `a factory class is generated for a method returning a java class with a star import`() {
+    compile(
+        """
+        package com.squareup.test
+        
+        import dagger.Module
+        import dagger.Provides
+        
+        @Module
+        object DaggerModule1 {
+          @Provides fun provideClass(): Class<*> = java.lang.Runnable::class.java
+        }
+        """
+    ) {
+      val factoryClass = daggerModule1.moduleFactoryClass("provideClass")
+
+      val constructor = factoryClass.declaredConstructors.single()
+      assertThat(constructor.parameterTypes.toList()).isEmpty()
+    }
+  }
+
   private fun compile(
     source: String,
     block: Result.() -> Unit = { }

--- a/compiler/src/test/java/com/squareup/anvil/compiler/dagger/TestClasses.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/dagger/TestClasses.kt
@@ -1,0 +1,11 @@
+@file:Suppress("unused")
+
+package com.squareup.anvil.compiler.dagger
+
+// These classes are used in some of the unit tests. Don't touch them.
+
+object Factory
+
+abstract class OuterClass constructor(innerClass: InnerClass) {
+  class InnerClass
+}


### PR DESCRIPTION
This PR reworks how imports are resolved. Before I implemented an "easy fix, "workaround" or "hack" 🙃  As usual, those things bite one in the long run. Now I resolve all types properly so that Kotlin Poet can add the correct imports.

Fixes #97, #82