### PR TITLE
Use TCA apis.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,7 @@ subprojects {
   }
 
   //noinspection UnnecessaryQualifiedReference
-  tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
+  tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
     kotlinOptions.jvmTarget = JavaVersion.VERSION_1_8
     kotlinOptions.useIR = rootProject.ext.kotlinUseIR
   }

--- a/gradle-plugin/src/main/java/com/squareup/anvil/plugin/AnvilSubplugin.kt
+++ b/gradle-plugin/src/main/java/com/squareup/anvil/plugin/AnvilSubplugin.kt
@@ -4,6 +4,7 @@ import com.google.auto.service.AutoService
 import org.gradle.api.Project
 import org.gradle.api.tasks.compile.AbstractCompile
 import org.jetbrains.kotlin.gradle.dsl.KotlinCommonOptions
+import org.jetbrains.kotlin.gradle.internal.KaptGenerateStubsTask
 import org.jetbrains.kotlin.gradle.internal.KaptTask
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
 import org.jetbrains.kotlin.gradle.plugin.KotlinGradleSubplugin
@@ -56,13 +57,18 @@ class AnvilSubplugin : KotlinGradleSubplugin<AbstractCompile> {
       val key = "${getCompilerPluginId()}.${srcGenDirOption.key}"
       val relativePath = srcGenDir.relativeTo(project.buildDir).path
 
-      project.tasks.withType(KotlinCompile::class.java) { task ->
-        task.inputs.property(key, relativePath)
+      project.tasks.withType(KotlinCompile::class.java).configureEach { task ->
+          task.inputs.property(key, relativePath)
       }
-      project.tasks.withType(KaptTask::class.java) { task ->
-        // We don't apply the compiler plugin for KaptTasks. But for some reason the Kotlin Gradle
-        // plugin copies the inputs with the "kotlinCompile" prefix.
-        task.inputs.property("kotlinCompile.$key", relativePath)
+      project.tasks.withType(KaptTask::class.java).configureEach { task ->
+          // We don't apply the compiler plugin for KaptTasks. But for some reason the Kotlin Gradle
+          // plugin copies the inputs with the "kotlinCompile" prefix.
+          task.inputs.property("kotlinCompile.$key", relativePath)
+      }
+      project.tasks.withType(KaptGenerateStubsTask::class.java).configureEach { task ->
+          // We don't apply the compiler plugin for KaptTasks. But for some reason the Kotlin Gradle
+          // plugin copies the inputs with the "kotlinCompile" prefix.
+          task.inputs.property("kotlinCompile.$key", relativePath)
       }
     }
 


### PR DESCRIPTION
3 changes, 1 in the build system of anvil, the other 2 in the plugin itself.
Replaces https://github.com/square/anvil/pull/133