### PR TITLE
Handle inner classes explicitly when resolving the Kotlin type

### DIFF
--- a/compiler/src/main/java/com/squareup/anvil/compiler/InterfaceMerger.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/InterfaceMerger.kt
@@ -111,7 +111,7 @@ internal class InterfaceMerger(
 
     val excludedClasses = (mergeAnnotation.getAnnotationValue("exclude") as? ArrayValue)
         ?.value
-        ?.map { it.getType(module).argumentType().classDescriptorForType() }
+        ?.map { it.argumentType(module).classDescriptorForType() }
         ?.filter { DescriptorUtils.isInterface(it) }
         ?.map { classDescriptorForExclusion ->
           val contributesBindingAnnotation = classDescriptorForExclusion

--- a/compiler/src/main/java/com/squareup/anvil/compiler/ModuleMerger.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/ModuleMerger.kt
@@ -156,7 +156,7 @@ internal class ModuleMerger(
     val excludedModules = (mergeAnnotation.getAnnotationValue("exclude") as? ArrayValue)
         ?.value
         ?.map {
-          val argumentType = it.getType(module).argumentType()
+          val argumentType = it.argumentType(module)
           val classDescriptorForExclusion = argumentType.classDescriptorForType()
 
           val contributesBindingAnnotation = classDescriptorForExclusion

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/BindingModuleGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/BindingModuleGenerator.kt
@@ -112,9 +112,7 @@ internal class BindingModuleGenerator(
           // a binding method for these types.
           (mergeAnnotation.getAnnotationValue("exclude") as? ArrayValue)?.value
               ?.map {
-                it.getType(module)
-                    .argumentType()
-                    .classDescriptorForType()
+                it.argumentType(module).classDescriptorForType()
               }
               ?.let { excludedTypesForScope[scope] = it }
 


### PR DESCRIPTION
When resolving the Kotlin type of inner class from dependencies the compiler might fail. It tries to load `my.package.Class$Inner` and fails whereas is should load `my.package.Class.Inner`. I was only able to reproduce this in our Square repository and confirmed that this workaround fixes the bug.