### PR TITLE
Generated hint for @ContributesBinding and @ContributesTo explicitly defined as internal to support Kotlin 1.4 Explicit API Mode

### DIFF
--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesBindingGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesBindingGenerator.kt
@@ -52,8 +52,8 @@ internal class ContributesBindingGenerator : CodeGenerator {
           val content = """
             package $generatedPackage
             
-            val ${className.replace('.', '_')}$REFERENCE_SUFFIX = $className::class
-            val ${className.replace('.', '_')}$SCOPE_SUFFIX = $scope::class
+            public val ${className.replace('.', '_')}$REFERENCE_SUFFIX: kotlin.reflect.KClass<$className> = $className::class
+            public val ${className.replace('.', '_')}$SCOPE_SUFFIX: kotlin.reflect.KClass<$scope> = $scope::class
           """.trimIndent()
           file.writeText(content)
 

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesToGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesToGenerator.kt
@@ -64,8 +64,8 @@ internal class ContributesToGenerator : CodeGenerator {
           val content = """
               package $generatedPackage
               
-              val ${className.replace('.', '_')}$REFERENCE_SUFFIX = $className::class
-              val ${className.replace('.', '_')}$SCOPE_SUFFIX = $scope::class
+              public val ${className.replace('.', '_')}$REFERENCE_SUFFIX: kotlin.reflect.KClass<$className> = $className::class
+              public val ${className.replace('.', '_')}$SCOPE_SUFFIX: kotlin.reflect.KClass<$scope> = $scope::class
           """.trimIndent()
           file.writeText(content)
 

--- a/compiler/src/test/java/com/squareup/anvil/compiler/ModuleMergerTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/ModuleMergerTest.kt
@@ -4,7 +4,6 @@ import com.google.common.truth.Truth.assertThat
 import com.squareup.anvil.annotations.MergeComponent
 import com.squareup.anvil.annotations.MergeSubcomponent
 import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.COMPILATION_ERROR
-import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.INTERNAL_ERROR
 import dagger.Component
 import dagger.Subcomponent
 import org.junit.Test
@@ -726,7 +725,7 @@ class ModuleMergerTest(
         }
         """
     ) {
-      assertThat(exitCode).isEqualTo(INTERNAL_ERROR)
+      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
       assertThat(messages).contains("File being compiled: (10,18)")
     }
   }


### PR DESCRIPTION
When using Anvil in a module that has strict API Mode enable, `ContributesBindingGenerator` and `ContributesToGenerator` will generate the hint used internally for merging modules and components interface without a visibility modifier and therefore, Kotlin Explicit API will fail the compilation.

Fixes #140.