### PR TITLE
Use Kotlin 1.4.20-M2-158 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       # solution.
       fail-fast: false
       matrix:
-        kotlin-version: [1.3.72, 1.4.10, 1.4.20-M1]
+        kotlin-version: [1.3.72, 1.4.10, 1.4.20-M2-158]
 
     steps:
       - uses: actions/checkout@v2
@@ -53,7 +53,7 @@ jobs:
           java-version: 11.0.7
 
       - name: Test on Ubuntu IR
-        run: ./gradlew assemble test --no-build-cache --no-daemon --stacktrace -Psquare.kotlinVersion=1.4.20-M1 -Psquare.useIR=true
+        run: ./gradlew assemble test --no-build-cache --no-daemon --stacktrace -Psquare.kotlinVersion=1.4.20-M2-158 -Psquare.useIR=true
 
       - name: Upload Test Results
         uses: actions/upload-artifact@v2

--- a/compiler/generate_build_properties.gradle
+++ b/compiler/generate_build_properties.gradle
@@ -1,7 +1,7 @@
 def generatedDirPath = 'generated/sources/build-properties/kotlin/main'
 
 sourceSets {
-  test.java.srcDirs += "$buildDir/$generatedDirPath"
+  main.java.srcDirs += "$buildDir/$generatedDirPath"
 }
 
 def generateBuildProperties = project.tasks.register('generateBuildProperties') {
@@ -21,6 +21,6 @@ def generateBuildProperties = project.tasks.register('generateBuildProperties') 
   }
 }
 
-tasks.named("compileTestKotlin").configure {
+tasks.named("compileKotlin").configure {
   it.dependsOn generateBuildProperties
 }


### PR DESCRIPTION
Use the new public API for registering extensions with a specific order. This will allow us to remove the workaround to register our extension first.

See https://youtrack.jetbrains.com/issue/KT-42103