### PR TITLE
Support the explicit API mode when generating Dagger factories

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -70,7 +70,7 @@ ext {
           stdlib: "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion",
       ],
 
-      kotlinpoet: "com.squareup:kotlinpoet:1.6.0",
+      kotlinpoet: "com.squareup:kotlinpoet:1.7.2",
 
       truth: "com.google.truth:truth:1.0.1",
   ]

--- a/integration-tests/library/build.gradle
+++ b/integration-tests/library/build.gradle
@@ -17,3 +17,12 @@ dependencies {
   api deps.dagger2.dagger
   api deps.kotlin.stdlib
 }
+
+//noinspection UnnecessaryQualifiedReference
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+  kotlinOptions {
+    freeCompilerArgs += [
+            "-Xexplicit-api=strict",
+    ]
+  }
+}

--- a/integration-tests/library/src/main/java/com/squareup/anvil/test/Bindings.kt
+++ b/integration-tests/library/src/main/java/com/squareup/anvil/test/Bindings.kt
@@ -3,15 +3,15 @@ package com.squareup.anvil.test
 import com.squareup.anvil.annotations.ContributesBinding
 import javax.inject.Inject
 
-interface ParentType
+public interface ParentType
 
-interface MiddleType : ParentType
+public interface MiddleType : ParentType
 
 @ContributesBinding(
     scope = AppScope::class,
     boundType = ParentType::class
 )
-class AppBinding @Inject constructor() : MiddleType
+public class AppBinding @Inject constructor() : MiddleType
 
 @ContributesBinding(SubScope::class)
-object SubcomponentBinding : MiddleType
+public object SubcomponentBinding : MiddleType

--- a/integration-tests/library/src/main/java/com/squareup/anvil/test/Components.kt
+++ b/integration-tests/library/src/main/java/com/squareup/anvil/test/Components.kt
@@ -3,7 +3,7 @@ package com.squareup.anvil.test
 import com.squareup.anvil.annotations.ContributesTo
 
 @ContributesTo(AppScope::class)
-interface AppComponentInterface
+public interface AppComponentInterface
 
 @ContributesTo(SubScope::class)
-interface SubComponentInterface
+public interface SubComponentInterface

--- a/integration-tests/library/src/main/java/com/squareup/anvil/test/Modules.kt
+++ b/integration-tests/library/src/main/java/com/squareup/anvil/test/Modules.kt
@@ -7,20 +7,21 @@ import javax.inject.Singleton
 
 @Module
 @ContributesTo(AppScope::class)
-abstract class AppModule1
+public abstract class AppModule1
 
 @Module
 @ContributesTo(AppScope::class)
-object AppModule2 {
-  @Provides @Singleton fun provideFunction(): (String) -> Int = { it.length }
+public object AppModule2 {
+  @Provides @Singleton public fun provideFunction(): (String) -> Int = { it.length }
 }
 
 @Module
 @ContributesTo(SubScope::class)
-class SubModule1(private val string: String) {
-  @Provides fun provideInput(): String = string
+public class SubModule1(private val string: String) {
+  @Provides
+  public fun provideInput(): String = string
 }
 
 @Module
 @ContributesTo(SubScope::class)
-interface SubModule2
+public interface SubModule2

--- a/integration-tests/library/src/main/java/com/squareup/anvil/test/Scopes.kt
+++ b/integration-tests/library/src/main/java/com/squareup/anvil/test/Scopes.kt
@@ -1,5 +1,5 @@
 package com.squareup.anvil.test
 
-abstract class AppScope private constructor()
+public abstract class AppScope private constructor()
 
-abstract class SubScope private constructor()
+public abstract class SubScope private constructor()

--- a/integration-tests/tests/build.gradle
+++ b/integration-tests/tests/build.gradle
@@ -14,6 +14,15 @@ dependencies {
   kaptTest deps.dagger2.compiler
 }
 
+//noinspection UnnecessaryQualifiedReference
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+  kotlinOptions {
+    freeCompilerArgs += [
+            "-Xexplicit-api=strict",
+    ]
+  }
+}
+
 // Okay, this check is sketchy here. But this module serves as integration test so it's not too
 // terrible. What would be worse is setting up integration tests in the Gradle plugin itself,
 // because it requires so much code and might not represent the real world usage.

--- a/integration-tests/tests/src/test/java/com/squareup/anvil/test/MergeComponentTest.kt
+++ b/integration-tests/tests/src/test/java/com/squareup/anvil/test/MergeComponentTest.kt
@@ -8,7 +8,7 @@ import dagger.Subcomponent
 import org.junit.Test
 import javax.inject.Singleton
 
-class MergeComponentTest {
+internal class MergeComponentTest {
 
   @Test fun `component merges modules and interfaces`() {
     val annotation = AppComponent::class.java.getAnnotation(Component::class.java)!!

--- a/integration-tests/tests/src/test/java/com/squareup/anvil/test/MergeInterfacesTest.kt
+++ b/integration-tests/tests/src/test/java/com/squareup/anvil/test/MergeInterfacesTest.kt
@@ -4,7 +4,7 @@ import com.google.common.truth.Truth.assertThat
 import com.squareup.anvil.annotations.compat.MergeInterfaces
 import org.junit.Test
 
-class MergeInterfacesTest {
+internal class MergeInterfacesTest {
 
   @Test fun `contributed interfaces are merged`() {
     assertThat(CompositeAppComponent::class extends AppComponentInterface::class).isTrue()

--- a/integration-tests/tests/src/test/java/com/squareup/anvil/test/MergeModulesTest.kt
+++ b/integration-tests/tests/src/test/java/com/squareup/anvil/test/MergeModulesTest.kt
@@ -8,7 +8,7 @@ import dagger.Subcomponent
 import org.junit.Test
 import javax.inject.Singleton
 
-class MergeModulesTest {
+internal class MergeModulesTest {
 
   @Test fun `contributed modules are merged app scope`() {
     val annotation = CompositeAppModule::class.java.getAnnotation(Module::class.java)!!


### PR DESCRIPTION
Anvil uses KotlinPoet to generate the Dagger factories in which in the [latest version 1.7.0](https://github.com/square/kotlinpoet/blob/master/docs/changelog.md): _"Generated code is now compatible with the explicit API mode by default."_.

This PR:
- Updates [KotlinPoet to 1.7.2](https://github.com/square/kotlinpoet/releases/tag/1.7.2), as it is required due to the error: [Cannot use KotlinPoet version `1.7.0` with Java 8](https://github.com/square/kotlinpoet/issues/999).
- Updates the sample app to use explicit API mode in the `:sample:scopes` and `:sample:library` modules to show its usage, `:sample:app` module is untouched as it is not a "library" module. If this is not necessary, I can revert the commit.

Fixes #144.