### PR TITLE
[#150] Unconventional package names generate correct factories

### DIFF
--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/KotlinPoet.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/KotlinPoet.kt
@@ -62,13 +62,15 @@ internal fun ClassDescriptor.asClassName(): ClassName =
   )
 
 internal fun FqName.asClassName(module: ModuleDescriptor): ClassName {
-  try {
+  val segments = pathSegments().map { it.asString() }
+
+  // If the first sentence case is not the last segment of the path it becomes ambiguous,
+  // for example, com.Foo.Bar could be a inner class Bar or an unconventional package com.Foo.
+  val canGuessClassName = segments.indexOfFirst { it[0].isUpperCase() } == segments.size - 1
+  if (canGuessClassName) {
     return ClassName.bestGuess(asString())
-  } catch (ignored: IllegalArgumentException) {
-    // Probably lowercase class. Try to resolve the class below.
   }
 
-  val segments = pathSegments().map { it.asString() }
   for (index in (segments.size - 1) downTo 1) {
     val packageSegments = segments.subList(0, index)
     val classSegments = segments.subList(index, segments.size)

--- a/compiler/src/test/java/com/squareup/anvil/compiler/dagger/UppercasePackage/TestClassInUppercasePackage.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/dagger/UppercasePackage/TestClassInUppercasePackage.kt
@@ -1,0 +1,13 @@
+@file:Suppress("PackageName")
+
+package com.squareup.anvil.compiler.dagger.UppercasePackage
+
+// These classes are used in unit tests. Don't rename or move them!
+class TestClassInUppercasePackage
+
+@Suppress("ClassName")
+class lowerCaseClassInUppercasePackage
+
+class OuterClass {
+  class InnerClass
+}


### PR DESCRIPTION
Fixes #150 

I decided to remove the `ClassName.bestGuess` instead of using it as a fallback because I could not think of a case where this fallback would be required and be reliable enough for it to produce something useful. However, I don't think I understand the full picture and might be missing something important. 