### PR TITLE
Use the Kotlin 1.4 dependencies in the gradle plugin 

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -70,13 +70,6 @@ ext {
           stdlib: "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion",
       ],
 
-      // Required until Gradle uses Kotlin 1.4.
-      kotlin_gradle: [
-          gradle_plugin: "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.72",
-          gradle_plugin_api: "org.jetbrains.kotlin:kotlin-gradle-plugin-api:1.3.72",
-          stdlib: "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.72",
-      ],
-
       kotlinpoet: "com.squareup:kotlinpoet:1.7.2",
 
       truth: "com.google.truth:truth:1.0.1",

--- a/gradle-plugin/build.gradle
+++ b/gradle-plugin/build.gradle
@@ -15,7 +15,7 @@ buildscript {
   }
 
   dependencies {
-    classpath deps.kotlin_gradle.gradle_plugin
+    classpath deps.kotlin.gradle_plugin
     classpath deps.maven_publishing_plugin
     classpath deps.gradle_publishing_plugin
     classpath deps.ktlint_plugin
@@ -75,9 +75,9 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
 }
 
 dependencies {
-  implementation deps.kotlin_gradle.gradle_plugin
-  implementation deps.kotlin_gradle.gradle_plugin_api
-  implementation deps.kotlin_gradle.stdlib
+  implementation deps.kotlin.gradle_plugin
+  implementation deps.kotlin.gradle_plugin_api
+  implementation deps.kotlin.stdlib
 
   // Compile only so that Java / Kotlin modules don't download it unnecessarily.
   compileOnly deps.android_gradle_plugin


### PR DESCRIPTION
Even though Gradle shows a warning. We need the new APIs.

Github's UI somehow tricked me and PR actually failed.