### PR TITLE
Dagger Factories Only

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -82,6 +82,7 @@ subprojects {
   }
   // This is an ugly workaround.
   def brokenProjects = [
+      project(':integration-tests:dagger-factories-only'),
       project(':integration-tests:library'),
       project(':integration-tests:tests'),
       project(':sample:library'),
@@ -90,7 +91,10 @@ subprojects {
   brokenProjects.each { brokenProject ->
     brokenProject.configurations.whenObjectAdded {
       if (it.name == 'api') {
-        brokenProject.dependencies.add('api', project(':annotations'))
+        if (brokenProject.path != ':integration-tests:dagger-factories-only' ||
+            !rootProject.ext.generateDaggerFactoriesWithAnvil) {
+          brokenProject.dependencies.add('api', project(':annotations'))
+        }
       }
       if (it.name == 'kotlinCompilerPluginClasspath') {
         brokenProject.dependencies.add('kotlinCompilerPluginClasspath', project(':compiler'))

--- a/compiler/src/main/java/com/squareup/anvil/compiler/AnvilCommandLineProcessor.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/AnvilCommandLineProcessor.kt
@@ -14,6 +14,10 @@ internal const val generateDaggerFactoriesName = "generate-dagger-factories"
 internal val generateDaggerFactoriesKey =
   CompilerConfigurationKey.create<Boolean>("anvil $generateDaggerFactoriesName")
 
+internal const val generateDaggerFactoriesOnlyName = "generate-dagger-factories-only"
+internal val generateDaggerFactoriesOnlyKey =
+  CompilerConfigurationKey.create<Boolean>("anvil $generateDaggerFactoriesOnlyName")
+
 /**
  * Parses arguments from the Gradle plugin for the compiler plugin.
  */
@@ -37,6 +41,14 @@ class AnvilCommandLineProcessor : CommandLineProcessor {
               "constructors.",
           required = false,
           allowMultipleOccurrences = false
+      ),
+      CliOption(
+          optionName = generateDaggerFactoriesOnlyName,
+          valueDescription = "<true|false>",
+          description = "Whether Anvil should generate Factory classes only and no code for " +
+              "contributed code.",
+          required = false,
+          allowMultipleOccurrences = false
       )
   )
 
@@ -49,6 +61,8 @@ class AnvilCommandLineProcessor : CommandLineProcessor {
       srcGenDirName -> configuration.put(srcGenDirKey, value)
       generateDaggerFactoriesName ->
         configuration.put(generateDaggerFactoriesKey, value.toBoolean())
+      generateDaggerFactoriesOnlyName ->
+        configuration.put(generateDaggerFactoriesOnlyKey, value.toBoolean())
     }
   }
 }

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/AnvilAnnotationDetectorCheck.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/AnvilAnnotationDetectorCheck.kt
@@ -1,0 +1,45 @@
+package com.squareup.anvil.compiler.codegen.dagger
+
+import com.squareup.anvil.compiler.AnvilCompilationException
+import com.squareup.anvil.compiler.codegen.PrivateCodeGenerator
+import com.squareup.anvil.compiler.codegen.classesAndInnerClasses
+import com.squareup.anvil.compiler.codegen.hasAnnotation
+import com.squareup.anvil.compiler.contributesBindingFqName
+import com.squareup.anvil.compiler.contributesToFqName
+import com.squareup.anvil.compiler.mergeComponentFqName
+import com.squareup.anvil.compiler.mergeInterfacesFqName
+import com.squareup.anvil.compiler.mergeModulesFqName
+import com.squareup.anvil.compiler.mergeSubcomponentFqName
+import org.jetbrains.kotlin.descriptors.ModuleDescriptor
+import org.jetbrains.kotlin.psi.KtFile
+import java.io.File
+
+internal class AnvilAnnotationDetectorCheck : PrivateCodeGenerator() {
+
+  override fun generateCodePrivate(
+    codeGenDir: File,
+    module: ModuleDescriptor,
+    projectFiles: Collection<KtFile>
+  ) {
+    val clazz = projectFiles
+        .asSequence()
+        .flatMap { it.classesAndInnerClasses() }
+        .firstOrNull {
+          it.hasAnnotation(mergeComponentFqName) ||
+              it.hasAnnotation(mergeSubcomponentFqName) ||
+              it.hasAnnotation(mergeInterfacesFqName) ||
+              it.hasAnnotation(mergeModulesFqName) ||
+              it.hasAnnotation(contributesToFqName) ||
+              it.hasAnnotation(contributesBindingFqName)
+        }
+
+    if (clazz != null) {
+      throw AnvilCompilationException(
+          message = "This Gradle module is configured to ONLY generate Dagger factories with " +
+              "the `generateDaggerFactoriesOnly` flag. However, this module contains code that " +
+              "uses other Anvil annotations. That's not supported.",
+          element = clazz
+      )
+    }
+  }
+}

--- a/compiler/src/test/java/com/squareup/anvil/compiler/TestUtils.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/TestUtils.kt
@@ -21,6 +21,7 @@ internal fun compile(
   vararg sources: String,
   enableDaggerAnnotationProcessor: Boolean = false,
   generateDaggerFactories: Boolean = false,
+  generateDaggerFactoriesOnly: Boolean = false,
   block: Result.() -> Unit = { }
 ): Result {
   return KotlinCompilation()
@@ -47,6 +48,11 @@ internal fun compile(
                 pluginId = commandLineProcessor.pluginId,
                 optionName = generateDaggerFactoriesName,
                 optionValue = generateDaggerFactories.toString()
+            ),
+            PluginOption(
+                pluginId = commandLineProcessor.pluginId,
+                optionName = generateDaggerFactoriesOnlyName,
+                optionValue = generateDaggerFactoriesOnly.toString()
             )
         )
 

--- a/compiler/src/test/java/com/squareup/anvil/compiler/dagger/AnvilAnnotationDetectorCheckTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/dagger/AnvilAnnotationDetectorCheckTest.kt
@@ -1,0 +1,134 @@
+package com.squareup.anvil.compiler.dagger
+
+import com.google.common.truth.Truth.assertThat
+import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.COMPILATION_ERROR
+import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.OK
+import com.tschuchort.compiletesting.KotlinCompilation.Result
+import org.junit.Test
+
+class AnvilAnnotationDetectorCheckTest {
+
+  @Test fun `a Dagger subcomponent is allowed`() {
+    compile(
+        """
+        package com.squareup.test
+        
+        @dagger.Subcomponent
+        interface ComponentInterface
+        """
+    ) {
+      assertThat(exitCode).isEqualTo(OK)
+    }
+  }
+
+  @Test fun `@ContributesTo is not allowed`() {
+    compile(
+        """
+        package com.squareup.test
+        
+        import dagger.Subcomponent
+        
+        @com.squareup.anvil.annotations.ContributesTo(Any::class)
+        class AnyClass
+        """
+    ) {
+      assertError()
+    }
+  }
+
+  @Test fun `@ContributesBinding is not allowed`() {
+    compile(
+        """
+        package com.squareup.test
+        
+        import dagger.Subcomponent
+        
+        @com.squareup.anvil.annotations.ContributesBinding(Any::class)
+        class AnyClass
+        """
+    ) {
+      assertError()
+    }
+  }
+
+  @Test fun `@MergeComponent is not allowed`() {
+    compile(
+        """
+        package com.squareup.test
+        
+        import dagger.Subcomponent
+        
+        @com.squareup.anvil.annotations.MergeComponent(Any::class)
+        class AnyClass
+        """
+    ) {
+      assertError()
+    }
+  }
+
+  @Test fun `@MergeSubcomponent is not allowed`() {
+    compile(
+        """
+        package com.squareup.test
+        
+        import dagger.Subcomponent
+        
+        @com.squareup.anvil.annotations.MergeSubcomponent(Any::class)
+        class AnyClass
+        """
+    ) {
+      assertError()
+    }
+  }
+
+  @Test fun `@MergeModules is not allowed`() {
+    compile(
+        """
+        package com.squareup.test
+        
+        import dagger.Subcomponent
+        
+        @com.squareup.anvil.annotations.compat.MergeModules(Any::class)
+        class AnyClass
+        """
+    ) {
+      assertError()
+    }
+  }
+
+  @Test fun `@MergeInterfaces is not allowed`() {
+    compile(
+        """
+        package com.squareup.test
+        
+        import dagger.Subcomponent
+        
+        @com.squareup.anvil.annotations.compat.MergeInterfaces(Any::class)
+        class AnyClass
+        """
+    ) {
+      assertError()
+    }
+  }
+
+  private fun Result.assertError() {
+    assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+    assertThat(messages).contains("Source.kt: (5, 1")
+    assertThat(messages).contains(
+        "This Gradle module is configured to ONLY generate Dagger factories with the " +
+            "`generateDaggerFactoriesOnly` flag. However, this module contains code that uses " +
+            "other Anvil annotations. That's not supported."
+    )
+  }
+
+  @Suppress("CHANGING_ARGUMENTS_EXECUTION_ORDER_FOR_NAMED_VARARGS")
+  private fun compile(
+    vararg sources: String,
+    block: Result.() -> Unit = { }
+  ): Result = com.squareup.anvil.compiler.compile(
+      sources = sources,
+      generateDaggerFactories = true,
+      generateDaggerFactoriesOnly = true,
+      block = block
+  )
+}

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -62,6 +62,7 @@ ext {
           gradle_plugin: "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion",
           gradle_plugin_api: "org.jetbrains.kotlin:kotlin-gradle-plugin-api:$kotlinVersion",
           stdlib: "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion",
+          test: "org.jetbrains.kotlin:kotlin-test-junit:$kotlinVersion",
       ],
 
       kotlinpoet: "com.squareup:kotlinpoet:1.7.2",

--- a/gradle-plugin/src/main/java/com/squareup/anvil/plugin/AnvilExtension.kt
+++ b/gradle-plugin/src/main/java/com/squareup/anvil/plugin/AnvilExtension.kt
@@ -17,4 +17,12 @@ open class AnvilExtension {
    * By default this feature is disabled.
    */
   var generateDaggerFactories = false
+
+  /**
+   * There are occasions where consumers of Anvil are only interested in generating Dagger
+   * factories to speed up build times and don't want to make use of the other features. With this
+   * flag Anvil will only generate Dagger factories and skip all other steps. If this flag is set
+   * to `true`, then also [generateDaggerFactories] must be set to `true`.
+   */
+  var generateDaggerFactoriesOnly = false
 }

--- a/gradle-plugin/src/main/java/com/squareup/anvil/plugin/AnvilPlugin.kt
+++ b/gradle-plugin/src/main/java/com/squareup/anvil/plugin/AnvilPlugin.kt
@@ -68,7 +68,7 @@ open class AnvilPlugin : KotlinCompilerPluginSupportPlugin {
   }
 
   override fun apply(target: Project) {
-    target.extensions.create("anvil", AnvilExtension::class.java)
+    val extension = target.extensions.create("anvil", AnvilExtension::class.java)
 
     val once = AtomicBoolean()
 
@@ -87,10 +87,10 @@ open class AnvilPlugin : KotlinCompilerPluginSupportPlugin {
     // issue. Also make sure to apply it only once. A module could accidentally apply the JVM and
     // Android Kotlin plugin.
     target.pluginManager.withPluginOnce("org.jetbrains.kotlin.android") {
-      realApply(target, true)
+      realApply(target, true, extension)
     }
     target.pluginManager.withPluginOnce("org.jetbrains.kotlin.jvm") {
-      realApply(target, false)
+      realApply(target, false, extension)
     }
 
     target.afterEvaluate {
@@ -100,22 +100,34 @@ open class AnvilPlugin : KotlinCompilerPluginSupportPlugin {
                 "'${target.path}'. Only Android and Java modules are supported for now."
         )
       }
+
+      if (!extension.generateDaggerFactories && extension.generateDaggerFactoriesOnly) {
+        throw GradleException(
+            "You cannot set generateDaggerFactories to false and generateDaggerFactoriesOnly " +
+                "to true at the same time."
+        )
+      }
     }
   }
 
   private fun realApply(
     project: Project,
-    isAndroidProject: Boolean
+    isAndroidProject: Boolean,
+    extension: AnvilExtension
   ) {
-    disableIncrementalKotlinCompilation(project, isAndroidProject)
+    disableIncrementalKotlinCompilation(project, isAndroidProject, extension)
     disablePreciseJavaTracking(project)
 
-    project.pluginManager.withPlugin("org.jetbrains.kotlin.kapt") {
-      // This needs to be disabled, otherwise compiler plugins fail in weird ways when generating stubs.
-      project.extensions.findByType(KaptExtension::class.java)?.correctErrorTypes = false
-    }
+    project.afterEvaluate {
+      if (!extension.generateDaggerFactoriesOnly) {
+        project.pluginManager.withPlugin("org.jetbrains.kotlin.kapt") {
+          // This needs to be disabled, otherwise compiler plugins fail in weird ways when generating stubs.
+          project.extensions.findByType(KaptExtension::class.java)?.correctErrorTypes = false
+        }
 
-    project.dependencies.add("implementation", "$GROUP:annotations:$VERSION")
+        project.dependencies.add("implementation", "$GROUP:annotations:$VERSION")
+      }
+    }
   }
 
   private fun disablePreciseJavaTracking(
@@ -145,29 +157,47 @@ open class AnvilPlugin : KotlinCompilerPluginSupportPlugin {
   @OptIn(ExperimentalStdlibApi::class)
   private fun disableIncrementalKotlinCompilation(
     project: Project,
-    isAndroidProject: Boolean
+    isAndroidProject: Boolean,
+    extension: AnvilExtension
   ) {
-    project.tasks
-        .withType(KaptGenerateStubsTask::class.java)
-        .configureEach { stubsTask ->
-          // Disable incremental compilation for the stub generating task. Trigger the compiler
-          // plugin if any dependencies in the compile classpath have changed. This will make sure
-          // that we pick up any change from a dependency when merging all the classes. Without
-          // this workaround we could make changes in any library, but these changes wouldn't be
-          // contributed to the Dagger graph, because incremental compilation tricked us.
-          stubsTask.doFirst {
-            stubsTask.incremental = false
-            stubsTask.logger.info(
-                "Anvil: Incremental compilation enabled: ${stubsTask.incremental} (stub)"
-            )
-          }
-        }
-
     // Use this signal to share state between DisableIncrementalCompilationTask and the Kotlin
     // compile task. If the plugin classpath changed, then DisableIncrementalCompilationTask sets
     // the signal to false.
     @Suppress("UnstableApiUsage")
     val incrementalSignal = IncrementalSignal.registerIfAbsent(project)
+
+    if (extension.generateDaggerFactoriesOnly) {
+      // We don't need to disable the incremental compilation for the stub generating task, when we
+      // only generate Dagger factories. That's only needed for merging Dagger modules.
+      if (isAndroidProject) {
+        project.androidVariantsConfigure { variant ->
+          val compileTaskName = "kaptGenerateStubs${variant.name.capitalize(US)}Kotlin"
+          disableIncrementalCompilationAction(project, incrementalSignal, compileTaskName)
+        }
+      } else {
+        disableIncrementalCompilationAction(project, incrementalSignal, "kaptGenerateStubsKotlin")
+        disableIncrementalCompilationAction(
+            project, incrementalSignal, "kaptGenerateStubsTestKotlin"
+        )
+      }
+    } else {
+      project.tasks
+          .withType(KaptGenerateStubsTask::class.java)
+          .configureEach { stubsTask ->
+            // Disable incremental compilation for the stub generating task. Trigger the compiler
+            // plugin if any dependencies in the compile classpath have changed. This will make sure
+            // that we pick up any change from a dependency when merging all the classes. Without
+            // this workaround we could make changes in any library, but these changes wouldn't be
+            // contributed to the Dagger graph, because incremental compilation tricked us.
+            stubsTask.doFirst {
+              stubsTask.incremental = false
+              stubsTask.logger.info(
+                  "Anvil: Incremental compilation enabled: ${stubsTask.incremental} (stub)"
+              )
+            }
+          }
+    }
+
     if (isAndroidProject) {
       project.androidVariantsConfigure { variant ->
         val compileTaskName = "compile${variant.name.capitalize(US)}Kotlin"

--- a/gradle-plugin/src/main/java/com/squareup/anvil/plugin/AnvilPlugin.kt
+++ b/gradle-plugin/src/main/java/com/squareup/anvil/plugin/AnvilPlugin.kt
@@ -62,6 +62,10 @@ open class AnvilPlugin : KotlinCompilerPluginSupportPlugin {
           SubpluginOption(
               key = "generate-dagger-factories",
               value = extension.generateDaggerFactories.toString()
+          ),
+          SubpluginOption(
+              key = "generate-dagger-factories-only",
+              value = extension.generateDaggerFactoriesOnly.toString()
           )
       )
     }

--- a/integration-tests/dagger-factories-only/build.gradle
+++ b/integration-tests/dagger-factories-only/build.gradle
@@ -1,0 +1,23 @@
+apply plugin: 'org.jetbrains.kotlin.jvm'
+apply plugin: 'com.squareup.anvil'
+
+if (rootProject.ext.generateDaggerFactoriesWithAnvil) {
+  anvil {
+    generateDaggerFactories = true
+    generateDaggerFactoriesOnly = true
+  }
+} else {
+  apply plugin: 'org.jetbrains.kotlin.kapt'
+
+  dependencies {
+    kapt deps.dagger2.compiler
+    kaptTest deps.dagger2.compiler
+  }
+}
+
+dependencies {
+  implementation deps.dagger2.dagger
+  testImplementation deps.junit
+  testImplementation deps.kotlin.test
+  testImplementation deps.truth
+}

--- a/integration-tests/dagger-factories-only/src/main/java/com/squareup/anvil/test/DaggerModule.kt
+++ b/integration-tests/dagger-factories-only/src/main/java/com/squareup/anvil/test/DaggerModule.kt
@@ -1,0 +1,10 @@
+package com.squareup.anvil.test
+
+import dagger.Module
+import dagger.Provides
+
+@Module
+@Suppress("unused")
+object DaggerModule {
+  @Provides fun provideString(): String = "Hello Anvil"
+}

--- a/integration-tests/dagger-factories-only/src/test/java/com/squareup/anvil/test/GeneratedFactoryTest.kt
+++ b/integration-tests/dagger-factories-only/src/test/java/com/squareup/anvil/test/GeneratedFactoryTest.kt
@@ -1,0 +1,25 @@
+package com.squareup.anvil.test
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import java.lang.reflect.Modifier
+import kotlin.test.assertFailsWith
+
+class GeneratedFactoryTest {
+
+  @Test fun `a dagger factory is generated for a provider method`() {
+    val string = Class.forName("com.squareup.anvil.test.DaggerModule_ProvideStringFactory")
+        .declaredMethods
+        .filter { Modifier.isStatic(it.modifiers) }
+        .single { it.name == "provideString" }
+        .invoke(null)
+
+    assertThat(string).isEqualTo("Hello Anvil")
+  }
+
+  @Test fun `annotations aren't on the classpath`() {
+    assertFailsWith<ClassNotFoundException> {
+      Class.forName("com.squareup.anvil.annotations.ContributesTo")
+    }
+  }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,6 @@
 include ':annotations'
 include ':compiler'
+include ':integration-tests:dagger-factories-only'
 include ':integration-tests:library'
 include ':integration-tests:tests'
 include ':sample:app'


### PR DESCRIPTION
Add a new flag to the Anvil extension so that Anvil will only generate Dagger factories and no other code. The benefit of this that the stub generating Kotlin task can be incremental.