### PR TITLE
#165 Support Dagger's assisted inject and generate necessary code

### DIFF
--- a/compiler/src/main/java/com/squareup/anvil/compiler/AnvilComponentRegistrar.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/AnvilComponentRegistrar.kt
@@ -7,6 +7,7 @@ import com.squareup.anvil.compiler.codegen.CodeGenerator
 import com.squareup.anvil.compiler.codegen.ContributesBindingGenerator
 import com.squareup.anvil.compiler.codegen.ContributesToGenerator
 import com.squareup.anvil.compiler.codegen.dagger.AnvilAnnotationDetectorCheck
+import com.squareup.anvil.compiler.codegen.dagger.AssistedInjectGenerator
 import com.squareup.anvil.compiler.codegen.dagger.ComponentDetectorCheck
 import com.squareup.anvil.compiler.codegen.dagger.InjectConstructorFactoryGenerator
 import com.squareup.anvil.compiler.codegen.dagger.MembersInjectorGenerator
@@ -50,6 +51,7 @@ class AnvilComponentRegistrar : ComponentRegistrar {
       codeGenerators += InjectConstructorFactoryGenerator()
       codeGenerators += MembersInjectorGenerator()
       codeGenerators += ComponentDetectorCheck()
+      codeGenerators += AssistedInjectGenerator()
     }
 
     // It's important to register our extension at the first position. The compiler calls each

--- a/compiler/src/main/java/com/squareup/anvil/compiler/AnvilComponentRegistrar.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/AnvilComponentRegistrar.kt
@@ -7,6 +7,7 @@ import com.squareup.anvil.compiler.codegen.CodeGenerator
 import com.squareup.anvil.compiler.codegen.ContributesBindingGenerator
 import com.squareup.anvil.compiler.codegen.ContributesToGenerator
 import com.squareup.anvil.compiler.codegen.dagger.AnvilAnnotationDetectorCheck
+import com.squareup.anvil.compiler.codegen.dagger.AssistedFactoryGenerator
 import com.squareup.anvil.compiler.codegen.dagger.AssistedInjectGenerator
 import com.squareup.anvil.compiler.codegen.dagger.ComponentDetectorCheck
 import com.squareup.anvil.compiler.codegen.dagger.InjectConstructorFactoryGenerator
@@ -52,6 +53,7 @@ class AnvilComponentRegistrar : ComponentRegistrar {
       codeGenerators += MembersInjectorGenerator()
       codeGenerators += ComponentDetectorCheck()
       codeGenerators += AssistedInjectGenerator()
+      codeGenerators += AssistedFactoryGenerator()
     }
 
     // It's important to register our extension at the first position. The compiler calls each

--- a/compiler/src/main/java/com/squareup/anvil/compiler/ReflectionTestUtils.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/ReflectionTestUtils.kt
@@ -1,8 +1,8 @@
 package com.squareup.anvil.compiler
 
-import java.lang.reflect.Method
+import java.lang.reflect.Executable
 
-internal inline fun <T> Method.use(block: (Method) -> T): T {
+internal inline fun <T, E : Executable> E.use(block: (E) -> T): T {
   // Deprecated since Java 9, but many projects still use JDK 8 for compilation.
   @Suppress("DEPRECATION")
   val original = isAccessible

--- a/compiler/src/main/java/com/squareup/anvil/compiler/Utils.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/Utils.kt
@@ -13,6 +13,8 @@ import dagger.Lazy
 import dagger.Module
 import dagger.Provides
 import dagger.Subcomponent
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
 import dagger.internal.DoubleCheck
 import org.jetbrains.kotlin.codegen.asmType
 import org.jetbrains.kotlin.codegen.state.KotlinTypeMapper
@@ -56,6 +58,8 @@ internal val daggerBindsFqName = FqName(Binds::class.java.canonicalName)
 internal val daggerProvidesFqName = FqName(Provides::class.java.canonicalName)
 internal val daggerLazyFqName = FqName(Lazy::class.java.canonicalName)
 internal val injectFqName = FqName(Inject::class.java.canonicalName)
+internal val assistedFqName = FqName(Assisted::class.java.canonicalName)
+internal val assistedInjectFqName = FqName(AssistedInject::class.java.canonicalName)
 internal val providerFqName = FqName(Provider::class.java.canonicalName)
 internal val jvmSuppressWildcardsFqName = FqName(JvmSuppressWildcards::class.java.canonicalName)
 

--- a/compiler/src/main/java/com/squareup/anvil/compiler/Utils.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/Utils.kt
@@ -14,6 +14,7 @@ import dagger.Module
 import dagger.Provides
 import dagger.Subcomponent
 import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.internal.DoubleCheck
 import org.jetbrains.kotlin.codegen.asmType
@@ -59,6 +60,7 @@ internal val daggerProvidesFqName = FqName(Provides::class.java.canonicalName)
 internal val daggerLazyFqName = FqName(Lazy::class.java.canonicalName)
 internal val injectFqName = FqName(Inject::class.java.canonicalName)
 internal val assistedFqName = FqName(Assisted::class.java.canonicalName)
+internal val assistedFactoryFqName = FqName(AssistedFactory::class.java.canonicalName)
 internal val assistedInjectFqName = FqName(AssistedInject::class.java.canonicalName)
 internal val providerFqName = FqName(Provider::class.java.canonicalName)
 internal val jvmSuppressWildcardsFqName = FqName(JvmSuppressWildcards::class.java.canonicalName)

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/KotlinPoet.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/KotlinPoet.kt
@@ -2,6 +2,7 @@ package com.squareup.anvil.compiler.codegen
 
 import com.squareup.anvil.compiler.AnvilCompilationException
 import com.squareup.anvil.compiler.AnvilComponentRegistrar
+import com.squareup.anvil.compiler.assistedFqName
 import com.squareup.anvil.compiler.daggerDoubleCheckFqNameString
 import com.squareup.anvil.compiler.daggerLazyFqName
 import com.squareup.anvil.compiler.jvmSuppressWildcardsFqName
@@ -186,7 +187,8 @@ internal data class Parameter(
   val providerTypeName: ParameterizedTypeName,
   val lazyTypeName: ParameterizedTypeName,
   val isWrappedInProvider: Boolean,
-  val isWrappedInLazy: Boolean
+  val isWrappedInLazy: Boolean,
+  val isAssisted: Boolean
 ) {
   val originalTypeName: TypeName = when {
     isWrappedInProvider -> providerTypeName
@@ -228,7 +230,8 @@ internal fun List<KtCallableDeclaration>.mapToParameter(module: ModuleDescriptor
       providerTypeName = typeName.wrapInProvider(),
       lazyTypeName = typeName.wrapInLazy(),
       isWrappedInProvider = isWrappedInProvider,
-      isWrappedInLazy = isWrappedInLazy
+      isWrappedInLazy = isWrappedInLazy,
+      isAssisted = parameter.hasAnnotation(assistedFqName)
     )
   }
 
@@ -266,6 +269,7 @@ internal fun List<Parameter>.asArgumentList(
             parameter.isWrappedInProvider -> parameter.name
             parameter.isWrappedInLazy ->
               "$daggerDoubleCheckFqNameString.lazy(${parameter.name})"
+            parameter.isAssisted -> parameter.name
             else -> "${parameter.name}.get()"
           }
         }

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/PrivateCodeGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/PrivateCodeGenerator.kt
@@ -7,7 +7,7 @@ import java.io.File
 
 /**
  * Generates code that doesn't impact any other [CodeGenerator], meaning no other code generator
- * will process the generated code produced by this instance. A [PrivateCodeGenerator] in called
+ * will process the generated code produced by this instance. A [PrivateCodeGenerator] is called
  * one last time after [flush] has been called to get a chance to evaluate written results.
  */
 internal abstract class PrivateCodeGenerator : CodeGenerator {

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/PrivateCodeGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/PrivateCodeGenerator.kt
@@ -25,4 +25,23 @@ internal abstract class PrivateCodeGenerator : CodeGenerator {
     module: ModuleDescriptor,
     projectFiles: Collection<KtFile>
   )
+
+  /**
+   * Write [content] into a new file for the given [packageName] and [className].
+   */
+  protected fun createGeneratedFile(
+    codeGenDir: File,
+    packageName: String,
+    className: String,
+    content: String
+  ): GeneratedFile {
+    val directory = File(codeGenDir, packageName.replace('.', File.separatorChar))
+    val file = File(directory, "$className.kt")
+    check(file.parentFile.exists() || file.parentFile.mkdirs()) {
+      "Could not generate package directory: ${file.parentFile}"
+    }
+    file.writeText(content)
+
+    return GeneratedFile(file, content)
+  }
 }

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/AssistedFactoryGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/AssistedFactoryGenerator.kt
@@ -227,13 +227,6 @@ internal class AssistedFactoryGenerator : PrivateCodeGenerator() {
         .let { addType(it) }
     }
 
-    val directory = File(codeGenDir, packageName.replace('.', File.separatorChar))
-    val file = File(directory, "$className.kt")
-    check(file.parentFile.exists() || file.parentFile.mkdirs()) {
-      "Could not generate package directory: ${file.parentFile}"
-    }
-    file.writeText(content)
-
-    return GeneratedFile(file, content)
+    return createGeneratedFile(codeGenDir, packageName, className, content)
   }
 }

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/AssistedFactoryGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/AssistedFactoryGenerator.kt
@@ -1,0 +1,239 @@
+package com.squareup.anvil.compiler.codegen.dagger
+
+import com.squareup.anvil.compiler.AnvilCompilationException
+import com.squareup.anvil.compiler.assistedFactoryFqName
+import com.squareup.anvil.compiler.assistedFqName
+import com.squareup.anvil.compiler.assistedInjectFqName
+import com.squareup.anvil.compiler.classDescriptorForType
+import com.squareup.anvil.compiler.codegen.CodeGenerator.GeneratedFile
+import com.squareup.anvil.compiler.codegen.PrivateCodeGenerator
+import com.squareup.anvil.compiler.codegen.asClassName
+import com.squareup.anvil.compiler.codegen.asTypeName
+import com.squareup.anvil.compiler.codegen.buildFile
+import com.squareup.anvil.compiler.codegen.classesAndInnerClasses
+import com.squareup.anvil.compiler.codegen.fqNameOrNull
+import com.squareup.anvil.compiler.codegen.hasAnnotation
+import com.squareup.anvil.compiler.codegen.requireFqName
+import com.squareup.anvil.compiler.generateClassName
+import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.FileSpec
+import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.KModifier.OVERRIDE
+import com.squareup.kotlinpoet.KModifier.PRIVATE
+import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import com.squareup.kotlinpoet.PropertySpec
+import com.squareup.kotlinpoet.TypeName
+import com.squareup.kotlinpoet.TypeSpec
+import com.squareup.kotlinpoet.TypeVariableName
+import com.squareup.kotlinpoet.asClassName
+import com.squareup.kotlinpoet.jvm.jvmStatic
+import dagger.internal.InstanceFactory
+import org.jetbrains.kotlin.descriptors.DescriptorVisibilities.PROTECTED
+import org.jetbrains.kotlin.descriptors.DescriptorVisibilities.PUBLIC
+import org.jetbrains.kotlin.descriptors.FunctionDescriptor
+import org.jetbrains.kotlin.descriptors.Modality.ABSTRACT
+import org.jetbrains.kotlin.descriptors.ModuleDescriptor
+import org.jetbrains.kotlin.descriptors.resolveClassByFqName
+import org.jetbrains.kotlin.incremental.KotlinLookupLocation
+import org.jetbrains.kotlin.js.resolve.diagnostics.findPsi
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.psi.KtClassOrObject
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.resolve.DescriptorUtils
+import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
+import org.jetbrains.kotlin.resolve.scopes.DescriptorKindFilter.Companion.FUNCTIONS
+import org.jetbrains.kotlin.types.typeUtil.isTypeParameter
+import java.io.File
+import javax.inject.Provider
+
+internal class AssistedFactoryGenerator : PrivateCodeGenerator() {
+
+  override fun generateCodePrivate(
+    codeGenDir: File,
+    module: ModuleDescriptor,
+    projectFiles: Collection<KtFile>
+  ) {
+    projectFiles
+      .asSequence()
+      .flatMap { it.classesAndInnerClasses() }
+      .filter { it.hasAnnotation(assistedFactoryFqName) }
+      .forEach { clazz ->
+        generateFactoryClass(codeGenDir, module, clazz)
+      }
+  }
+
+  private fun generateFactoryClass(
+    codeGenDir: File,
+    module: ModuleDescriptor,
+    clazz: KtClassOrObject
+  ): GeneratedFile {
+    // It's necessary to resolve the class in order to check super types.
+    val classDescriptor = module
+      .resolveClassByFqName(clazz.requireFqName(), KotlinLookupLocation(clazz))
+      ?: throw AnvilCompilationException("Couldn't resolve class for PSI element", element = clazz)
+
+    val functions = classDescriptor.unsubstitutedMemberScope
+      .getContributedDescriptors(FUNCTIONS)
+      .asSequence()
+      .filterIsInstance<FunctionDescriptor>()
+      .filter { it.modality == ABSTRACT }
+      .filter { it.visibility == PUBLIC || it.visibility == PROTECTED }
+      .toList()
+
+    // Check for exact number of functions.
+    val function = when (functions.size) {
+      0 -> throw AnvilCompilationException(
+        "The @AssistedFactory-annotated type is missing an abstract, non-default method " +
+          "whose return type matches the assisted injection type.",
+        element = clazz
+      )
+      1 -> functions[0]
+      else -> throw AnvilCompilationException(
+        "The @AssistedFactory-annotated type should contain a single abstract, non-default " +
+          "method but found multiple.",
+        element = clazz
+      )
+    }
+
+    val returnType = function.returnType?.classDescriptorForType()
+      ?: throw AnvilCompilationException(
+        "Couldn't get return type for function.",
+        element = function.findPsi()
+      )
+
+    // The return type of the function must have an @AssistedInject constructor.
+    val constructor = returnType.constructors
+      .singleOrNull { it.annotations.findAnnotation(assistedInjectFqName) != null }
+      ?: throw AnvilCompilationException(
+        "Invalid return type: ${returnType.fqNameSafe}. An assisted factory's abstract " +
+          "method must return a type with an @AssistedInject-annotated constructor.",
+        element = clazz
+      )
+
+    val functionParameters = function.valueParameters
+    val assistedParameters = constructor.valueParameters.filter {
+      it.annotations.findAnnotation(assistedFqName) != null
+    }
+
+    // Check that the parameters of the function match the @Assisted parameters of the constructor.
+    if (assistedParameters.size != functionParameters.size) {
+      throw AnvilCompilationException(
+        "The parameters of the factory method must be assignable to the list of @Assisted " +
+          "parameters in ${returnType.fqNameSafe}.",
+        element = clazz
+      )
+    }
+
+    functionParameters.forEachIndexed { index, parameter ->
+      val assistedType = assistedParameters[index].type
+      if (parameter.type != assistedType) {
+        if (parameter.type.isTypeParameter() && assistedType.isTypeParameter()) {
+          return@forEachIndexed
+        }
+
+        throw AnvilCompilationException(
+          "The parameters of the factory method must be assignable to the list of @Assisted " +
+            "parameters in ${returnType.fqNameSafe}.",
+          element = clazz
+        )
+      }
+    }
+
+    val packageName = clazz.containingKtFile.packageFqName.asString()
+    val className = "${clazz.generateClassName()}_Impl"
+    val implClass = ClassName(packageName, className)
+
+    val typeParameters = clazz.typeParameterList
+      ?.parameters
+      ?.mapNotNull { parameter ->
+        val extendsBound = parameter.extendsBound?.fqNameOrNull(module)?.asClassName(module)
+        if (parameter.fqNameOrNull(module) == null) {
+          TypeVariableName(parameter.nameAsSafeName.asString(), listOfNotNull(extendsBound))
+        } else {
+          null
+        }
+      }
+      ?: emptyList()
+
+    fun ClassName.parameterized(): TypeName {
+      return if (typeParameters.isEmpty()) this else parameterizedBy(typeParameters)
+    }
+
+    val generatedFactory = FqName(returnType.fqNameSafe.asString() + "_Factory")
+      .asClassName(module).parameterized()
+
+    val classType = clazz.asClassName().parameterized()
+    val delegateFactoryName = "delegateFactory"
+
+    val content = FileSpec.buildFile(packageName, className) {
+      TypeSpec.classBuilder(implClass)
+        .apply {
+          typeParameters.forEach { addTypeVariable(it) }
+
+          if (DescriptorUtils.isInterface(classDescriptor)) {
+            addSuperinterface(classType)
+          } else {
+            superclass(classType)
+          }
+
+          primaryConstructor(
+            FunSpec.constructorBuilder()
+              .addParameter(delegateFactoryName, generatedFactory)
+              .build()
+          )
+
+          addProperty(
+            PropertySpec.builder(delegateFactoryName, generatedFactory)
+              .initializer(delegateFactoryName)
+              .addModifiers(PRIVATE)
+              .build()
+          )
+        }
+        .addFunction(
+          FunSpec.builder("create")
+            .addModifiers(OVERRIDE)
+            .returns(returnType.asClassName().parameterized())
+            .apply {
+              functionParameters.forEach { parameter ->
+                addParameter(parameter.name.asString(), parameter.type.asTypeName())
+              }
+
+              val argumentList = functionParameters.joinToString { it.name.asString() }
+              addStatement("return $delegateFactoryName.get($argumentList)")
+            }
+            .build()
+        )
+        .apply {
+          TypeSpec.companionObjectBuilder()
+            .addFunction(
+              FunSpec.builder("create")
+                .jvmStatic()
+                .addTypeVariables(typeParameters)
+                .addParameter(delegateFactoryName, generatedFactory)
+                .returns(Provider::class.asClassName().parameterizedBy(classType))
+                .addStatement(
+                  "return %T.create(%T($delegateFactoryName))",
+                  InstanceFactory::class,
+                  implClass.parameterized()
+                )
+                .build()
+            )
+            .build()
+            .let {
+              addType(it)
+            }
+        }
+        .build()
+        .let { addType(it) }
+    }
+
+    val directory = File(codeGenDir, packageName.replace('.', File.separatorChar))
+    val file = File(directory, "$className.kt")
+    check(file.parentFile.exists() || file.parentFile.mkdirs()) {
+      "Could not generate package directory: ${file.parentFile}"
+    }
+    file.writeText(content)
+
+    return GeneratedFile(file, content)
+  }
+}

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/AssistedInjectGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/AssistedInjectGenerator.kt
@@ -1,0 +1,197 @@
+package com.squareup.anvil.compiler.codegen.dagger
+
+import com.squareup.anvil.compiler.assistedInjectFqName
+import com.squareup.anvil.compiler.codegen.CodeGenerator.GeneratedFile
+import com.squareup.anvil.compiler.codegen.PrivateCodeGenerator
+import com.squareup.anvil.compiler.codegen.asArgumentList
+import com.squareup.anvil.compiler.codegen.asClassName
+import com.squareup.anvil.compiler.codegen.buildFile
+import com.squareup.anvil.compiler.codegen.classesAndInnerClasses
+import com.squareup.anvil.compiler.codegen.fqNameOrNull
+import com.squareup.anvil.compiler.codegen.hasAnnotation
+import com.squareup.anvil.compiler.codegen.mapToParameter
+import com.squareup.anvil.compiler.generateClassName
+import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.FileSpec
+import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.KModifier.PRIVATE
+import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import com.squareup.kotlinpoet.PropertySpec
+import com.squareup.kotlinpoet.TypeSpec
+import com.squareup.kotlinpoet.TypeVariableName
+import com.squareup.kotlinpoet.jvm.jvmStatic
+import org.jetbrains.kotlin.descriptors.ModuleDescriptor
+import org.jetbrains.kotlin.psi.KtClassOrObject
+import org.jetbrains.kotlin.psi.KtConstructor
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.allConstructors
+import java.io.File
+
+/**
+ * Generates the `_Factory` class for a type with an `@AssistedInject` constructor, e.g. for
+ * ```
+ * class AssistedService @AssistedInject constructor()
+ * ```
+ * this generator would create
+ * ```
+ * class AssistedService_Factory { .. }
+ * ```
+ */
+internal class AssistedInjectGenerator : PrivateCodeGenerator() {
+
+  override fun generateCodePrivate(
+    codeGenDir: File,
+    module: ModuleDescriptor,
+    projectFiles: Collection<KtFile>
+  ) {
+    projectFiles
+      .asSequence()
+      .flatMap { it.classesAndInnerClasses() }
+      .forEach { clazz ->
+        clazz.allConstructors
+          .singleOrNull { it.hasAnnotation(assistedInjectFqName) }
+          ?.let {
+            generateFactoryClass(codeGenDir, module, clazz, it)
+          }
+      }
+  }
+
+  private fun generateFactoryClass(
+    codeGenDir: File,
+    module: ModuleDescriptor,
+    clazz: KtClassOrObject,
+    constructor: KtConstructor<*>
+  ): GeneratedFile {
+    val packageName = clazz.containingKtFile.packageFqName.asString()
+    val className = "${clazz.generateClassName()}_Factory"
+
+    val parameters = constructor.valueParameters.mapToParameter(module)
+    val parametersNotAssisted = parameters.filterNot { it.isAssisted }
+
+    val typeParameters = clazz.typeParameterList
+      ?.parameters
+      ?.mapNotNull { parameter ->
+        val extendsBound = parameter.extendsBound?.fqNameOrNull(module)?.asClassName(module)
+        if (parameter.fqNameOrNull(module) == null) {
+          TypeVariableName(parameter.nameAsSafeName.asString(), listOfNotNull(extendsBound))
+        } else {
+          null
+        }
+      }
+      ?: emptyList()
+
+    val factoryClass = ClassName(packageName, className)
+    val factoryClassParameterized =
+      if (typeParameters.isEmpty()) factoryClass else factoryClass.parameterizedBy(typeParameters)
+
+    val classType = clazz.asClassName().let {
+      if (typeParameters.isEmpty()) it else it.parameterizedBy(typeParameters)
+    }
+
+    val content = FileSpec.buildFile(packageName, className) {
+
+      TypeSpec.classBuilder(factoryClass)
+        .apply {
+          typeParameters.forEach { addTypeVariable(it) }
+
+          primaryConstructor(
+            FunSpec.constructorBuilder()
+              .apply {
+                parametersNotAssisted.forEach { parameter ->
+                  addParameter(parameter.name, parameter.providerTypeName)
+                }
+              }
+              .build()
+          )
+
+          parametersNotAssisted.forEach { parameter ->
+            addProperty(
+              PropertySpec.builder(parameter.name, parameter.providerTypeName)
+                .initializer(parameter.name)
+                .addModifiers(PRIVATE)
+                .build()
+            )
+          }
+        }
+        .addFunction(
+          FunSpec.builder("get")
+            .returns(classType)
+            .apply {
+              parameters.filter { it.isAssisted }.forEach { parameter ->
+                addParameter(parameter.name, parameter.originalTypeName)
+              }
+
+              val argumentList = parameters.asArgumentList(
+                asProvider = true,
+                includeModule = false
+              )
+
+              addStatement("return newInstance($argumentList)")
+            }
+            .build()
+        )
+        .apply {
+          TypeSpec.companionObjectBuilder()
+            .addFunction(
+              FunSpec.builder("create")
+                .jvmStatic()
+                .apply {
+                  if (typeParameters.isNotEmpty()) {
+                    addTypeVariables(typeParameters)
+                  }
+                  parametersNotAssisted.forEach { parameter ->
+                    addParameter(parameter.name, parameter.providerTypeName)
+                  }
+
+                  val argumentList = parametersNotAssisted.asArgumentList(
+                    asProvider = false,
+                    includeModule = false
+                  )
+
+                  addStatement(
+                    "return %T($argumentList)",
+                    factoryClassParameterized
+                  )
+                }
+                .returns(factoryClassParameterized)
+                .build()
+            )
+            .addFunction(
+              FunSpec.builder("newInstance")
+                .jvmStatic()
+                .apply {
+                  if (typeParameters.isNotEmpty()) {
+                    addTypeVariables(typeParameters)
+                  }
+                  parameters.forEach { parameter ->
+                    addParameter(
+                      name = parameter.name,
+                      type = parameter.originalTypeName
+                    )
+                  }
+                  val argumentsWithoutModule = parameters.joinToString { it.name }
+
+                  addStatement("return %T($argumentsWithoutModule)", classType)
+                }
+                .returns(classType)
+                .build()
+            )
+            .build()
+            .let {
+              addType(it)
+            }
+        }
+        .build()
+        .let { addType(it) }
+    }
+
+    val directory = File(codeGenDir, packageName.replace('.', File.separatorChar))
+    val file = File(directory, "$className.kt")
+    check(file.parentFile.exists() || file.parentFile.mkdirs()) {
+      "Could not generate package directory: ${file.parentFile}"
+    }
+    file.writeText(content)
+
+    return GeneratedFile(file, content)
+  }
+}

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/AssistedInjectGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/AssistedInjectGenerator.kt
@@ -185,13 +185,6 @@ internal class AssistedInjectGenerator : PrivateCodeGenerator() {
         .let { addType(it) }
     }
 
-    val directory = File(codeGenDir, packageName.replace('.', File.separatorChar))
-    val file = File(directory, "$className.kt")
-    check(file.parentFile.exists() || file.parentFile.mkdirs()) {
-      "Could not generate package directory: ${file.parentFile}"
-    }
-    file.writeText(content)
-
-    return GeneratedFile(file, content)
+    return createGeneratedFile(codeGenDir, packageName, className, content)
   }
 }

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/InjectConstructorFactoryGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/InjectConstructorFactoryGenerator.kt
@@ -189,13 +189,6 @@ internal class InjectConstructorFactoryGenerator : PrivateCodeGenerator() {
         .let { addType(it) }
     }
 
-    val directory = File(codeGenDir, packageName.replace('.', File.separatorChar))
-    val file = File(directory, "$className.kt")
-    check(file.parentFile.exists() || file.parentFile.mkdirs()) {
-      "Could not generate package directory: ${file.parentFile}"
-    }
-    file.writeText(content)
-
-    return GeneratedFile(file, content)
+    return createGeneratedFile(codeGenDir, packageName, className, content)
   }
 }

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/MembersInjectorGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/MembersInjectorGenerator.kt
@@ -183,13 +183,6 @@ internal class MembersInjectorGenerator : PrivateCodeGenerator() {
       )
     }
 
-    val directory = File(codeGenDir, packageName.replace('.', File.separatorChar))
-    val file = File(directory, "$className.kt")
-    check(file.parentFile.exists() || file.parentFile.mkdirs()) {
-      "Could not generate package directory: ${file.parentFile}"
-    }
-    file.writeText(content)
-
-    return GeneratedFile(file, content)
+    return createGeneratedFile(codeGenDir, packageName, className, content)
   }
 }

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/ProvidesMethodFactoryGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/ProvidesMethodFactoryGenerator.kt
@@ -281,13 +281,6 @@ internal class ProvidesMethodFactoryGenerator : PrivateCodeGenerator() {
         .let { addType(it) }
     }
 
-    val directory = File(codeGenDir, packageName.replace('.', File.separatorChar))
-    val file = File(directory, "$className.kt")
-    check(file.parentFile.exists() || file.parentFile.mkdirs()) {
-      "Could not generate package directory: ${file.parentFile}"
-    }
-    file.writeText(content)
-
-    return GeneratedFile(file, content)
+    return createGeneratedFile(codeGenDir, packageName, className, content)
   }
 }

--- a/compiler/src/test/java/com/squareup/anvil/compiler/TestUtils.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/TestUtils.kt
@@ -105,6 +105,9 @@ internal val Result.subcomponentInterfaceAnvilModule: Class<*>
 internal val Result.daggerModule1: Class<*>
   get() = classLoader.loadClass("com.squareup.test.DaggerModule1")
 
+internal val Result.assistedService: Class<*>
+  get() = classLoader.loadClass("com.squareup.test.AssistedService")
+
 internal val Result.daggerModule1AnvilModule: Class<*>
   get() = classLoader
     .loadClass("$MODULE_PACKAGE_PREFIX.com.squareup.test.DaggerModule1AnvilModule")
@@ -222,3 +225,8 @@ internal fun assumeMergeComponent(annotationClass: KClass<*>) {
 internal fun Array<KClass<*>>.withoutAnvilModule(): List<KClass<*>> = toList().withoutAnvilModule()
 internal fun Collection<KClass<*>>.withoutAnvilModule(): List<KClass<*>> =
   filterNot { FqName(it.qualifiedName!!).isAnvilModule() }
+
+internal fun Any.invokeGet(vararg args: Any): Any {
+  val method = this::class.java.declaredMethods.single { it.name == "get" }
+  return method.invoke(this, *args)
+}

--- a/compiler/src/test/java/com/squareup/anvil/compiler/TestUtils.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/TestUtils.kt
@@ -108,6 +108,9 @@ internal val Result.daggerModule1: Class<*>
 internal val Result.assistedService: Class<*>
   get() = classLoader.loadClass("com.squareup.test.AssistedService")
 
+internal val Result.assistedServiceFactory: Class<*>
+  get() = classLoader.loadClass("com.squareup.test.AssistedServiceFactory")
+
 internal val Result.daggerModule1AnvilModule: Class<*>
   get() = classLoader
     .loadClass("$MODULE_PACKAGE_PREFIX.com.squareup.test.DaggerModule1AnvilModule")
@@ -170,6 +173,12 @@ internal fun Class<*>.factoryClass(): Class<*> {
   val enclosingClassString = enclosingClass?.let { "${it.simpleName}_" } ?: ""
 
   return classLoader.loadClass("${`package`.name}.$enclosingClassString${simpleName}_Factory")
+}
+
+internal fun Class<*>.implClass(): Class<*> {
+  val enclosingClassString = enclosingClass?.let { "${it.simpleName}_" } ?: ""
+
+  return classLoader.loadClass("${`package`.name}.$enclosingClassString${simpleName}_Impl")
 }
 
 internal fun Class<*>.membersInjector(): Class<*> {

--- a/compiler/src/test/java/com/squareup/anvil/compiler/dagger/AssistedFactoryGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/dagger/AssistedFactoryGeneratorTest.kt
@@ -1,0 +1,726 @@
+package com.squareup.anvil.compiler.dagger
+
+import com.google.common.truth.Truth.assertThat
+import com.squareup.anvil.compiler.assistedService
+import com.squareup.anvil.compiler.assistedServiceFactory
+import com.squareup.anvil.compiler.factoryClass
+import com.squareup.anvil.compiler.implClass
+import com.squareup.anvil.compiler.isStatic
+import com.squareup.anvil.compiler.use
+import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.COMPILATION_ERROR
+import com.tschuchort.compiletesting.KotlinCompilation.Result
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import org.junit.runners.Parameterized.Parameters
+import javax.inject.Provider
+
+@RunWith(Parameterized::class)
+class AssistedFactoryGeneratorTest(
+  private val useDagger: Boolean
+) {
+
+  companion object {
+    @Parameters(name = "Use Dagger: {0}")
+    @JvmStatic fun useDagger(): Collection<Any> {
+      return listOf(true, false)
+    }
+  }
+
+  @Test fun `an implementation for a factory class is generated`() {
+    /*
+package com.squareup.test;
+
+import javax.annotation.processing.Generated;
+import javax.inject.Provider;
+
+@Generated(
+    value = "dagger.internal.codegen.ComponentProcessor",
+    comments = "https://dagger.dev"
+)
+@SuppressWarnings({
+    "unchecked",
+    "rawtypes"
+})
+public final class AssistedService_Factory {
+  private final Provider<Integer> p0_52215Provider;
+
+  public AssistedService_Factory(Provider<Integer> p0_52215Provider) {
+    this.p0_52215Provider = p0_52215Provider;
+  }
+
+  public AssistedService get(String string) {
+    return newInstance(p0_52215Provider.get(), string);
+  }
+
+  public static AssistedService_Factory create(Provider<Integer> p0_52215Provider) {
+    return new AssistedService_Factory(p0_52215Provider);
+  }
+
+  public static AssistedService newInstance(int p0_52215, String string) {
+    return new AssistedService(p0_52215, string);
+  }
+}
+     */
+    /*
+package com.squareup.test;
+
+import dagger.internal.InstanceFactory;
+import javax.annotation.processing.Generated;
+import javax.inject.Provider;
+
+@Generated(
+    value = "dagger.internal.codegen.ComponentProcessor",
+    comments = "https://dagger.dev"
+)
+@SuppressWarnings({
+    "unchecked",
+    "rawtypes"
+})
+public final class AssistedServiceFactory_Impl implements AssistedServiceFactory {
+  private final AssistedService_Factory delegateFactory;
+
+  AssistedServiceFactory_Impl(AssistedService_Factory delegateFactory) {
+    this.delegateFactory = delegateFactory;
+  }
+
+  @Override
+  public AssistedService create(String string) {
+    return delegateFactory.get(string);
+  }
+
+  public static Provider<AssistedServiceFactory> create(AssistedService_Factory delegateFactory) {
+    return InstanceFactory.create(new AssistedServiceFactory_Impl(delegateFactory));
+  }
+}
+     */
+    compile(
+      """
+      package com.squareup.test
+      
+      import dagger.assisted.Assisted
+      import dagger.assisted.AssistedFactory
+      import dagger.assisted.AssistedInject
+      
+      class AssistedService @AssistedInject constructor(
+        val int: Int,
+        @Assisted val string: String
+      )
+      
+      @AssistedFactory
+      interface AssistedServiceFactory {
+        fun create(string: String): AssistedService
+      }
+      """
+    ) {
+      val factoryImplClass = assistedServiceFactory.implClass()
+      val generatedFactoryInstance = assistedService.factoryClass()
+        .declaredConstructors.single().newInstance(Provider { 5 })
+
+      val constructor = factoryImplClass.declaredConstructors.single()
+      assertThat(constructor.parameterTypes.toList())
+        .containsExactly(assistedService.factoryClass())
+
+      val staticMethods = factoryImplClass.declaredMethods.filter { it.isStatic }
+      assertThat(staticMethods).hasSize(1)
+
+      val factoryProvider = staticMethods.single { it.name == "create" }
+        .invoke(null, generatedFactoryInstance) as Provider<*>
+      assertThat(factoryProvider.get()::class.java).isEqualTo(factoryImplClass)
+
+      val factoryImplInstance = constructor.use { it.newInstance(generatedFactoryInstance) }
+
+      val assistedServiceInstance = factoryImplClass.declaredMethods
+        .filterNot { it.isStatic }
+        .single { it.name == "create" }
+        .invoke(factoryImplInstance, "Hello")
+
+      assertThat(assistedServiceInstance::class.java).isEqualTo(assistedService)
+    }
+  }
+
+  @Test fun `the factory function is allowed to be provided by a super type`() {
+    compile(
+      """
+      package com.squareup.test
+      
+      import dagger.assisted.Assisted
+      import dagger.assisted.AssistedFactory
+      import dagger.assisted.AssistedInject
+      
+      class AssistedService @AssistedInject constructor(
+        val int: Int,
+        @Assisted val string: String
+      )
+      
+      interface AssistedServiceFactorySuper {
+        fun create(string: String): AssistedService
+      }
+      
+      @AssistedFactory
+      interface AssistedServiceFactory : AssistedServiceFactorySuper
+      """
+    ) {
+      val factoryImplClass = assistedServiceFactory.implClass()
+      val generatedFactoryInstance = assistedService.factoryClass()
+        .declaredConstructors.single().newInstance(Provider { 5 })
+
+      val constructor = factoryImplClass.declaredConstructors.single()
+      assertThat(constructor.parameterTypes.toList())
+        .containsExactly(assistedService.factoryClass())
+
+      val staticMethods = factoryImplClass.declaredMethods.filter { it.isStatic }
+      assertThat(staticMethods).hasSize(1)
+
+      val factoryProvider = staticMethods.single { it.name == "create" }
+        .invoke(null, generatedFactoryInstance) as Provider<*>
+      assertThat(factoryProvider.get()::class.java).isEqualTo(factoryImplClass)
+
+      val factoryImplInstance = constructor.use { it.newInstance(generatedFactoryInstance) }
+
+      val assistedServiceInstance = factoryImplClass.declaredMethods
+        .filterNot { it.isStatic }
+        .single { it.name == "create" }
+        .invoke(factoryImplInstance, "Hello")
+
+      assertThat(assistedServiceInstance::class.java).isEqualTo(assistedService)
+    }
+  }
+
+  @Test fun `an abstract class is supported`() {
+    compile(
+      """
+      package com.squareup.test
+      
+      import dagger.assisted.Assisted
+      import dagger.assisted.AssistedFactory
+      import dagger.assisted.AssistedInject
+      
+      class AssistedService @AssistedInject constructor(
+        val int: Int,
+        @Assisted val string: String
+      )
+      
+      @AssistedFactory
+      abstract class AssistedServiceFactory {
+        abstract fun create(string: String): AssistedService
+      }
+      """
+    ) {
+      val factoryImplClass = assistedServiceFactory.implClass()
+      val generatedFactoryInstance = assistedService.factoryClass()
+        .declaredConstructors.single().newInstance(Provider { 5 })
+
+      val constructor = factoryImplClass.declaredConstructors.single()
+      assertThat(constructor.parameterTypes.toList())
+        .containsExactly(assistedService.factoryClass())
+
+      val staticMethods = factoryImplClass.declaredMethods.filter { it.isStatic }
+      assertThat(staticMethods).hasSize(1)
+
+      val factoryProvider = staticMethods.single { it.name == "create" }
+        .invoke(null, generatedFactoryInstance) as Provider<*>
+      assertThat(factoryProvider.get()::class.java).isEqualTo(factoryImplClass)
+
+      val factoryImplInstance = constructor.use { it.newInstance(generatedFactoryInstance) }
+
+      val assistedServiceInstance = factoryImplClass.declaredMethods
+        .filterNot { it.isStatic }
+        .single { it.name == "create" }
+        .invoke(factoryImplInstance, "Hello")
+
+      assertThat(assistedServiceInstance::class.java).isEqualTo(assistedService)
+    }
+  }
+
+  @Test fun `a protected factory function in an abstract class is supported`() {
+    compile(
+      """
+      package com.squareup.test
+      
+      import dagger.assisted.Assisted
+      import dagger.assisted.AssistedFactory
+      import dagger.assisted.AssistedInject
+      
+      class AssistedService @AssistedInject constructor(
+        val int: Int,
+        @Assisted val string: String
+      )
+      
+      @AssistedFactory
+      abstract class AssistedServiceFactory {
+        protected abstract fun create(string: String): AssistedService
+      }
+      """
+    ) {
+      val factoryImplClass = assistedServiceFactory.implClass()
+      val generatedFactoryInstance = assistedService.factoryClass()
+        .declaredConstructors.single().newInstance(Provider { 5 })
+
+      val constructor = factoryImplClass.declaredConstructors.single()
+      assertThat(constructor.parameterTypes.toList())
+        .containsExactly(assistedService.factoryClass())
+
+      val staticMethods = factoryImplClass.declaredMethods.filter { it.isStatic }
+      assertThat(staticMethods).hasSize(1)
+
+      val factoryProvider = staticMethods.single { it.name == "create" }
+        .invoke(null, generatedFactoryInstance) as Provider<*>
+      assertThat(factoryProvider.get()::class.java).isEqualTo(factoryImplClass)
+
+      val factoryImplInstance = constructor.use { it.newInstance(generatedFactoryInstance) }
+
+      val assistedServiceInstance = factoryImplClass.declaredMethods
+        .filterNot { it.isStatic }
+        .single { it.name == "create" }
+        .use {
+          it.invoke(factoryImplInstance, "Hello")
+        }
+
+      assertThat(assistedServiceInstance::class.java).isEqualTo(assistedService)
+    }
+  }
+
+  @Test fun `an implementation for a factory class with generic parameters is generated`() {
+    compile(
+      """
+      package com.squareup.test
+      
+      import dagger.assisted.Assisted
+      import dagger.assisted.AssistedFactory
+      import dagger.assisted.AssistedInject
+      
+      class AssistedService @AssistedInject constructor(
+        val int: Int,
+        @Assisted val strings: List<String>
+      )
+      
+      @AssistedFactory
+      interface AssistedServiceFactory {
+        fun create(strings: List<String>): AssistedService
+      }
+      """
+    ) {
+      val factoryImplClass = assistedServiceFactory.implClass()
+      val generatedFactoryInstance = assistedService.factoryClass()
+        .declaredConstructors.single().newInstance(Provider { 5 })
+
+      val constructor = factoryImplClass.declaredConstructors.single()
+      assertThat(constructor.parameterTypes.toList())
+        .containsExactly(assistedService.factoryClass())
+
+      val staticMethods = factoryImplClass.declaredMethods.filter { it.isStatic }
+      assertThat(staticMethods).hasSize(1)
+
+      val factoryProvider = staticMethods.single { it.name == "create" }
+        .invoke(null, generatedFactoryInstance) as Provider<*>
+      assertThat(factoryProvider.get()::class.java).isEqualTo(factoryImplClass)
+
+      val factoryImplInstance = constructor.use { it.newInstance(generatedFactoryInstance) }
+
+      val assistedServiceInstance = factoryImplClass.declaredMethods
+        .filterNot { it.isStatic }
+        .single { it.name == "create" }
+        .invoke(factoryImplInstance, listOf("Hello"))
+
+      assertThat(assistedServiceInstance::class.java).isEqualTo(assistedService)
+    }
+  }
+
+  @Test fun `an implementation for a factory class with type parameters is generated`() {
+    /*
+package com.squareup.test;
+
+import javax.annotation.processing.Generated;
+import javax.inject.Provider;
+
+@Generated(
+    value = "dagger.internal.codegen.ComponentProcessor",
+    comments = "https://dagger.dev"
+)
+@SuppressWarnings({
+    "unchecked",
+    "rawtypes"
+})
+public final class AssistedService_Factory<T extends CharSequence> {
+  private final Provider<Integer> p0_52215Provider;
+
+  public AssistedService_Factory(Provider<Integer> p0_52215Provider) {
+    this.p0_52215Provider = p0_52215Provider;
+  }
+
+  public AssistedService<T> get(T string) {
+    return newInstance(p0_52215Provider.get(), string);
+  }
+
+  public static <T extends CharSequence> AssistedService_Factory<T> create(
+      Provider<Integer> p0_52215Provider) {
+    return new AssistedService_Factory<T>(p0_52215Provider);
+  }
+
+  public static <T extends CharSequence> AssistedService<T> newInstance(int p0_52215, T string) {
+    return new AssistedService<T>(p0_52215, string);
+  }
+}
+     */
+    /*
+package com.squareup.test;
+
+import dagger.internal.InstanceFactory;
+import javax.annotation.processing.Generated;
+import javax.inject.Provider;
+
+@Generated(
+    value = "dagger.internal.codegen.ComponentProcessor",
+    comments = "https://dagger.dev"
+)
+@SuppressWarnings({
+    "unchecked",
+    "rawtypes"
+})
+public final class AssistedServiceFactory_Impl<T extends CharSequence> implements AssistedServiceFactory<T> {
+  private final AssistedService_Factory<T> delegateFactory;
+
+  AssistedServiceFactory_Impl(AssistedService_Factory<T> delegateFactory) {
+    this.delegateFactory = delegateFactory;
+  }
+
+  @Override
+  public AssistedService<T> create(T string) {
+    return delegateFactory.get(string);
+  }
+
+  public static <T extends CharSequence> Provider<AssistedServiceFactory<T>> create(
+      AssistedService_Factory<T> delegateFactory) {
+    return InstanceFactory.create(new AssistedServiceFactory_Impl(delegateFactory));
+  }
+}
+     */
+    compile(
+      """
+      package com.squareup.test
+      
+      import dagger.assisted.Assisted
+      import dagger.assisted.AssistedFactory
+      import dagger.assisted.AssistedInject
+      
+      class AssistedService<T : CharSequence> @AssistedInject constructor(
+        val int: Int,
+        @Assisted val string: T
+      )
+      
+      @AssistedFactory
+      interface AssistedServiceFactory<T : CharSequence> {
+        fun create(string: T): AssistedService<T>
+      }
+      """
+    ) {
+      val factoryImplClass = assistedServiceFactory.implClass()
+      val generatedFactoryInstance = assistedService.factoryClass()
+        .declaredConstructors.single().newInstance(Provider { 5 })
+
+      val constructor = factoryImplClass.declaredConstructors.single()
+      assertThat(constructor.parameterTypes.toList())
+        .containsExactly(assistedService.factoryClass())
+
+      val staticMethods = factoryImplClass.declaredMethods.filter { it.isStatic }
+      assertThat(staticMethods).hasSize(1)
+
+      val factoryProvider = staticMethods.single { it.name == "create" }
+        .invoke(null, generatedFactoryInstance) as Provider<*>
+      assertThat(factoryProvider.get()::class.java).isEqualTo(factoryImplClass)
+
+      val factoryImplInstance = constructor.use { it.newInstance(generatedFactoryInstance) }
+
+      val assistedServiceInstance = factoryImplClass.declaredMethods
+        .filterNot { it.isStatic }
+        .single { it.name == "create" }
+        .invoke(factoryImplInstance, "Hello")
+
+      assertThat(assistedServiceInstance::class.java).isEqualTo(assistedService)
+    }
+  }
+
+  @Test fun `an implementation for an inner factory class is generated`() {
+    compile(
+      """
+      package com.squareup.test
+      
+      import dagger.assisted.Assisted
+      import dagger.assisted.AssistedFactory
+      import dagger.assisted.AssistedInject
+      
+      class AssistedService @AssistedInject constructor(
+        val int: Int,
+        @Assisted val string: String
+      ) {
+        @AssistedFactory
+        interface Factory {
+          fun create(string: String): AssistedService
+        }
+      }
+      """
+    ) {
+      val factoryImplClass = classLoader
+        .loadClass("com.squareup.test.AssistedService\$Factory").implClass()
+      val generatedFactoryInstance = assistedService.factoryClass()
+        .declaredConstructors.single().newInstance(Provider { 5 })
+
+      val constructor = factoryImplClass.declaredConstructors.single()
+      assertThat(constructor.parameterTypes.toList())
+        .containsExactly(assistedService.factoryClass())
+
+      val staticMethods = factoryImplClass.declaredMethods.filter { it.isStatic }
+      assertThat(staticMethods).hasSize(1)
+
+      val factoryProvider = staticMethods.single { it.name == "create" }
+        .invoke(null, generatedFactoryInstance) as Provider<*>
+      assertThat(factoryProvider.get()::class.java).isEqualTo(factoryImplClass)
+
+      val factoryImplInstance = constructor.use { it.newInstance(generatedFactoryInstance) }
+
+      val assistedServiceInstance = factoryImplClass.declaredMethods
+        .filterNot { it.isStatic }
+        .single { it.name == "create" }
+        .invoke(factoryImplInstance, "Hello")
+
+      assertThat(assistedServiceInstance::class.java).isEqualTo(assistedService)
+    }
+  }
+
+  @Test fun `an assisted inject type must be returned`() {
+    compile(
+      """
+      package com.squareup.test
+      
+      import dagger.assisted.AssistedFactory
+      
+      class AssistedService(
+        val int: Int,
+        val string: String
+      )
+        
+      @AssistedFactory
+      interface Factory {
+        fun create(string: String): AssistedService
+      }
+      """
+    ) {
+      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+      assertThat(messages).contains(
+        "Invalid return type: com.squareup.test.AssistedService. An assisted factory's " +
+          "abstract method must return a type with an @AssistedInject-annotated constructor."
+      )
+    }
+  }
+
+  @Test fun `an assisted inject type must be returned - no return type`() {
+    compile(
+      """
+      package com.squareup.test
+      
+      import dagger.assisted.AssistedFactory
+      
+      class AssistedService(
+        val int: Int,
+        val string: String
+      )
+        
+      @AssistedFactory
+      interface Factory {
+        fun create(string: String)
+      }
+      """
+    ) {
+      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+      assertThat(messages).contains("Invalid return type:")
+      assertThat(messages).contains(
+        "An assisted factory's abstract method must return a type with an " +
+          "@AssistedInject-annotated constructor."
+      )
+    }
+  }
+
+  @Test fun `the parameters of the factory function must match`() {
+    compile(
+      """
+      package com.squareup.test
+      
+      import dagger.assisted.Assisted
+      import dagger.assisted.AssistedFactory
+      import dagger.assisted.AssistedInject
+      
+      class AssistedService @AssistedInject constructor(
+        val int: Int,
+        @Assisted val string: String
+      )
+      
+      @AssistedFactory
+      interface AssistedServiceFactory {
+        fun create(string: String, other: String): AssistedService
+      }
+      """
+    ) {
+      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+      assertThat(messages).contains(
+        "The parameters of the factory method must be assignable to the list of @Assisted " +
+          "parameters in com.squareup.test.AssistedService."
+      )
+    }
+  }
+
+  @Test fun `the parameters of the factory function must match - different order`() {
+    compile(
+      """
+      package com.squareup.test
+      
+      import dagger.assisted.Assisted
+      import dagger.assisted.AssistedFactory
+      import dagger.assisted.AssistedInject
+      
+      class AssistedService @AssistedInject constructor(
+        val int: Int,
+        @Assisted val string: String,
+        @Assisted val string2: CharSequence
+      )
+      
+      @AssistedFactory
+      interface AssistedServiceFactory {
+        fun create(string: CharSequence, other: String): AssistedService
+      }
+      """
+    ) {
+      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+      assertThat(messages).contains(
+        "The parameters of the factory method must be assignable to the list of @Assisted " +
+          "parameters in com.squareup.test.AssistedService."
+      )
+    }
+  }
+
+  @Test fun `two factory functions aren't supported`() {
+    compile(
+      """
+      package com.squareup.test
+      
+      import dagger.assisted.Assisted
+      import dagger.assisted.AssistedFactory
+      import dagger.assisted.AssistedInject
+      
+      class AssistedService @AssistedInject constructor(
+        val int: Int,
+        @Assisted val string: String
+      )
+      
+      @AssistedFactory
+      interface AssistedServiceFactory {
+        fun create(string: String): AssistedService
+        fun create2(string: String): AssistedService
+      }
+      """
+    ) {
+      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+      assertThat(messages).contains(
+        "The @AssistedFactory-annotated type should contain a single abstract, non-default " +
+          "method but found multiple"
+      )
+    }
+  }
+
+  @Test fun `two factory functions aren't supported - extended class`() {
+    compile(
+      """
+      package com.squareup.test
+      
+      import dagger.assisted.Assisted
+      import dagger.assisted.AssistedFactory
+      import dagger.assisted.AssistedInject
+      
+      class AssistedService @AssistedInject constructor(
+        val int: Int,
+        @Assisted val string: String
+      )
+      
+      interface AssistedServiceFactory1 {
+        fun createParent(string: String): AssistedService
+      }
+      
+      @AssistedFactory
+      interface AssistedServiceFactory : AssistedServiceFactory1 {
+        fun create(string: String): AssistedService
+      }
+      """
+    ) {
+      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+      assertThat(messages).contains(
+        "The @AssistedFactory-annotated type should contain a single abstract, non-default " +
+          "method but found multiple"
+      )
+    }
+  }
+
+  @Test fun `a factory function is required`() {
+    compile(
+      """
+      package com.squareup.test
+      
+      import dagger.assisted.Assisted
+      import dagger.assisted.AssistedFactory
+      import dagger.assisted.AssistedInject
+      
+      class AssistedService @AssistedInject constructor(
+        val int: Int,
+        @Assisted val string: String
+      )
+      
+      @AssistedFactory
+      interface AssistedServiceFactory
+      """
+    ) {
+      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+      assertThat(messages).contains(
+        "The @AssistedFactory-annotated type is missing an abstract, non-default method " +
+          "whose return type matches the assisted injection type."
+      )
+    }
+  }
+
+  @Test fun `in an abstract class the factory function must be abstract`() {
+    compile(
+      """
+      package com.squareup.test
+      
+      import dagger.assisted.Assisted
+      import dagger.assisted.AssistedFactory
+      import dagger.assisted.AssistedInject
+      
+      class AssistedService @AssistedInject constructor(
+        val int: Int,
+        @Assisted val string: String
+      )
+      
+      @AssistedFactory
+      abstract class AssistedServiceFactory {
+        fun create(string: String): AssistedService = TODO()
+      }
+      """
+    ) {
+      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+      assertThat(messages).contains(
+        "The @AssistedFactory-annotated type is missing an abstract, non-default method " +
+          "whose return type matches the assisted injection type."
+      )
+    }
+  }
+
+  @Suppress("CHANGING_ARGUMENTS_EXECUTION_ORDER_FOR_NAMED_VARARGS")
+  private fun compile(
+    vararg sources: String,
+    block: Result.() -> Unit = { }
+  ): Result = com.squareup.anvil.compiler.compile(
+    sources = sources,
+    enableDaggerAnnotationProcessor = useDagger,
+    generateDaggerFactories = !useDagger,
+    block = block
+  )
+}

--- a/compiler/src/test/java/com/squareup/anvil/compiler/dagger/AssistedInjectGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/dagger/AssistedInjectGeneratorTest.kt
@@ -1,0 +1,472 @@
+package com.squareup.anvil.compiler.dagger
+
+import com.google.common.truth.Truth.assertThat
+import com.squareup.anvil.compiler.assistedService
+import com.squareup.anvil.compiler.factoryClass
+import com.squareup.anvil.compiler.invokeGet
+import com.squareup.anvil.compiler.isStatic
+import com.tschuchort.compiletesting.KotlinCompilation.Result
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import org.junit.runners.Parameterized.Parameters
+import javax.inject.Provider
+
+@RunWith(Parameterized::class)
+class AssistedInjectGeneratorTest(
+  private val useDagger: Boolean
+) {
+
+  companion object {
+    @Parameters(name = "Use Dagger: {0}")
+    @JvmStatic fun useDagger(): Collection<Any> {
+      return listOf(true, false)
+    }
+  }
+
+  @Test fun `a factory class is generated with one assisted parameter`() {
+    /*
+package com.squareup.test;
+
+import javax.annotation.processing.Generated;
+import javax.inject.Provider;
+
+@Generated(
+    value = "dagger.internal.codegen.ComponentProcessor",
+    comments = "https://dagger.dev"
+)
+@SuppressWarnings({
+    "unchecked",
+    "rawtypes"
+})
+public final class AssistedService_Factory {
+  private final Provider<Integer> integerProvider;
+
+  public AssistedService_Factory(Provider<Integer> integerProvider) {
+    this.integerProvider = integerProvider;
+  }
+
+  public AssistedService get(String string) {
+    return newInstance(integerProvider.get(), string);
+  }
+
+  public static AssistedService_Factory create(Provider<Integer> integerProvider) {
+    return new AssistedService_Factory(integerProvider);
+  }
+
+  public static AssistedService newInstance(int integer, String string) {
+    return new AssistedService(integer, string);
+  }
+}
+     */
+    compile(
+      """
+      package com.squareup.test
+      
+      import dagger.assisted.Assisted
+      import dagger.assisted.AssistedInject
+      
+      class AssistedService @AssistedInject constructor(
+        val int: Int,
+        @Assisted val string: String
+      ) {
+        override fun equals(other: Any?): Boolean {
+          if (this === other) return true
+          if (javaClass != other?.javaClass) return false
+      
+          other as AssistedService
+      
+          if (int != other.int) return false
+          if (string != other.string) return false
+      
+          return true
+        } 
+      }
+      """
+    ) {
+      val factoryClass = assistedService.factoryClass()
+
+      val constructor = factoryClass.declaredConstructors.single()
+      assertThat(constructor.parameterTypes.toList()).containsExactly(Provider::class.java)
+
+      val staticMethods = factoryClass.declaredMethods.filter { it.isStatic }
+      assertThat(staticMethods).hasSize(2)
+
+      val factoryInstance = staticMethods.single { it.name == "create" }
+        .invoke(null, Provider { 5 })
+      assertThat(factoryInstance::class.java).isEqualTo(factoryClass)
+
+      val newInstance = staticMethods.single { it.name == "newInstance" }
+        .invoke(null, 5, "Hello")
+
+      assertThat(factoryInstance.invokeGet("Hello")).isEqualTo(newInstance)
+    }
+  }
+
+  @Test fun `a factory class is generated without any parameter`() {
+    compile(
+      """
+      package com.squareup.test
+      
+      import dagger.assisted.Assisted
+      import dagger.assisted.AssistedInject
+      
+      class AssistedService @AssistedInject constructor() {
+        override fun equals(other: Any?): Boolean {
+          if (this === other) return true
+          if (javaClass != other?.javaClass) return false
+      
+          other as AssistedService
+      
+          return true
+        } 
+      }
+      """
+    ) {
+      val factoryClass = assistedService.factoryClass()
+
+      val constructor = factoryClass.declaredConstructors.single()
+      assertThat(constructor.parameterTypes.toList()).isEmpty()
+
+      val staticMethods = factoryClass.declaredMethods.filter { it.isStatic }
+      assertThat(staticMethods).hasSize(2)
+
+      val factoryInstance = staticMethods.single { it.name == "create" }.invoke(null)
+      assertThat(factoryInstance::class.java).isEqualTo(factoryClass)
+
+      val newInstance = staticMethods.single { it.name == "newInstance" }.invoke(null)
+
+      assertThat(factoryInstance.invokeGet()).isEqualTo(newInstance)
+    }
+  }
+
+  @Test fun `a factory class is generated with two assisted parameters`() {
+    compile(
+      """
+      package com.squareup.test
+      
+      import dagger.assisted.Assisted
+      import dagger.assisted.AssistedInject
+      
+      class AssistedService @AssistedInject constructor(
+        val int: Int,
+        @Assisted val string1: String,
+        @Assisted val string2: String
+      ) {
+        override fun equals(other: Any?): Boolean {
+          if (this === other) return true
+          if (javaClass != other?.javaClass) return false
+      
+          other as AssistedService
+      
+          if (int != other.int) return false
+          if (string1 != other.string1) return false
+          if (string2 != other.string2) return false
+      
+          return true
+        } 
+      }
+      """
+    ) {
+      val factoryClass = assistedService.factoryClass()
+
+      val constructor = factoryClass.declaredConstructors.single()
+      assertThat(constructor.parameterTypes.toList()).containsExactly(Provider::class.java)
+
+      val staticMethods = factoryClass.declaredMethods.filter { it.isStatic }
+      assertThat(staticMethods).hasSize(2)
+
+      val factoryInstance = staticMethods.single { it.name == "create" }
+        .invoke(null, Provider { 5 })
+      assertThat(factoryInstance::class.java).isEqualTo(factoryClass)
+
+      val newInstance = staticMethods.single { it.name == "newInstance" }
+        .invoke(null, 5, "Hello", "World")
+
+      assertThat(factoryInstance.invokeGet("Hello", "World")).isEqualTo(newInstance)
+    }
+  }
+
+  @Test fun `a factory class is generated with only two assisted parameters`() {
+    compile(
+      """
+      package com.squareup.test
+      
+      import dagger.assisted.Assisted
+      import dagger.assisted.AssistedInject
+      
+      class AssistedService @AssistedInject constructor(
+        @Assisted val string1: String,
+        @Assisted val string2: String
+      ) {
+        override fun equals(other: Any?): Boolean {
+          if (this === other) return true
+          if (javaClass != other?.javaClass) return false
+      
+          other as AssistedService
+      
+          if (string1 != other.string1) return false
+          if (string2 != other.string2) return false
+      
+          return true
+        } 
+      }
+      """
+    ) {
+      val factoryClass = assistedService.factoryClass()
+
+      val constructor = factoryClass.declaredConstructors.single()
+      assertThat(constructor.parameterTypes.toList()).isEmpty()
+
+      val staticMethods = factoryClass.declaredMethods.filter { it.isStatic }
+      assertThat(staticMethods).hasSize(2)
+
+      val factoryInstance = staticMethods.single { it.name == "create" }.invoke(null)
+      assertThat(factoryInstance::class.java).isEqualTo(factoryClass)
+
+      val newInstance = staticMethods.single { it.name == "newInstance" }
+        .invoke(null, "Hello", "World")
+
+      assertThat(factoryInstance.invokeGet("Hello", "World")).isEqualTo(newInstance)
+    }
+  }
+
+  @Test fun `a factory class is generated for without an assisted parameter`() {
+    compile(
+      """
+      package com.squareup.test
+      
+      import dagger.assisted.Assisted
+      import dagger.assisted.AssistedInject
+      
+      class AssistedService @AssistedInject constructor(
+        val int: Int
+      ) {
+        override fun equals(other: Any?): Boolean {
+          if (this === other) return true
+          if (javaClass != other?.javaClass) return false
+      
+          other as AssistedService
+      
+          if (int != other.int) return false
+      
+          return true
+        } 
+      }
+      """
+    ) {
+      val factoryClass = assistedService.factoryClass()
+
+      val constructor = factoryClass.declaredConstructors.single()
+      assertThat(constructor.parameterTypes.toList()).containsExactly(Provider::class.java)
+
+      val staticMethods = factoryClass.declaredMethods.filter { it.isStatic }
+      assertThat(staticMethods).hasSize(2)
+
+      val factoryInstance = staticMethods.single { it.name == "create" }
+        .invoke(null, Provider { 5 })
+      assertThat(factoryInstance::class.java).isEqualTo(factoryClass)
+
+      val newInstance = staticMethods.single { it.name == "newInstance" }
+        .invoke(null, 5)
+
+      assertThat(factoryInstance.invokeGet()).isEqualTo(newInstance)
+    }
+  }
+
+  @Test fun `a factory class is generated with one generic parameter`() {
+    compile(
+      """
+      package com.squareup.test
+      
+      import dagger.assisted.Assisted
+      import dagger.assisted.AssistedInject
+      
+      class AssistedService<T : CharSequence> @AssistedInject constructor(
+        val int: Int,
+        @Assisted val strings: List<String>
+      ) {
+        override fun equals(other: Any?): Boolean {
+          if (this === other) return true
+          if (javaClass != other?.javaClass) return false
+      
+          other as AssistedService<*>
+      
+          if (int != other.int) return false
+          if (strings != other.strings) return false
+      
+          return true
+        } 
+      }
+      """
+    ) {
+      val factoryClass = assistedService.factoryClass()
+
+      val constructor = factoryClass.declaredConstructors.single()
+      assertThat(constructor.parameterTypes.toList()).containsExactly(Provider::class.java)
+
+      val staticMethods = factoryClass.declaredMethods.filter { it.isStatic }
+      assertThat(staticMethods).hasSize(2)
+
+      val factoryInstance = staticMethods.single { it.name == "create" }
+        .invoke(null, Provider { 5 })
+      assertThat(factoryInstance::class.java).isEqualTo(factoryClass)
+
+      val newInstance = staticMethods.single { it.name == "newInstance" }
+        .invoke(null, 5, listOf("Hello"))
+
+      assertThat(factoryInstance.invokeGet(listOf("Hello"))).isEqualTo(newInstance)
+    }
+  }
+
+  @Test fun `a factory class is generated with one assisted type parameter`() {
+    compile(
+      """
+      package com.squareup.test
+      
+      import dagger.assisted.Assisted
+      import dagger.assisted.AssistedInject
+      
+      class AssistedService<T : CharSequence> @AssistedInject constructor(
+        val int: Int,
+        @Assisted val string: T
+      ) {
+        override fun equals(other: Any?): Boolean {
+          if (this === other) return true
+          if (javaClass != other?.javaClass) return false
+      
+          other as AssistedService<*>
+      
+          if (int != other.int) return false
+          if (string != other.string) return false
+      
+          return true
+        } 
+      }
+      """
+    ) {
+      val factoryClass = assistedService.factoryClass()
+
+      val constructor = factoryClass.declaredConstructors.single()
+      assertThat(constructor.parameterTypes.toList()).containsExactly(Provider::class.java)
+
+      val staticMethods = factoryClass.declaredMethods.filter { it.isStatic }
+      assertThat(staticMethods).hasSize(2)
+
+      val factoryInstance = staticMethods.single { it.name == "create" }
+        .invoke(null, Provider { 5 })
+      assertThat(factoryInstance::class.java).isEqualTo(factoryClass)
+
+      val newInstance = staticMethods.single { it.name == "newInstance" }
+        .invoke(null, 5, "Hello")
+
+      assertThat(factoryInstance.invokeGet("Hello")).isEqualTo(newInstance)
+    }
+  }
+
+  @Test fun `a factory class is generated with two type parameters`() {
+    compile(
+      """
+      package com.squareup.test
+      
+      import dagger.assisted.Assisted
+      import dagger.assisted.AssistedInject
+      
+      class AssistedService<S : Any, T : CharSequence> @AssistedInject constructor(
+        val int: S,
+        @Assisted val string: T
+      ) {
+        override fun equals(other: Any?): Boolean {
+          if (this === other) return true
+          if (javaClass != other?.javaClass) return false
+      
+          other as AssistedService<*, *>
+      
+          if (int != other.int) return false
+          if (string != other.string) return false
+      
+          return true
+        } 
+      }
+      """
+    ) {
+      val factoryClass = assistedService.factoryClass()
+
+      val constructor = factoryClass.declaredConstructors.single()
+      assertThat(constructor.parameterTypes.toList()).containsExactly(Provider::class.java)
+
+      val staticMethods = factoryClass.declaredMethods.filter { it.isStatic }
+      assertThat(staticMethods).hasSize(2)
+
+      val factoryInstance = staticMethods.single { it.name == "create" }
+        .invoke(null, Provider { 5 })
+      assertThat(factoryInstance::class.java).isEqualTo(factoryClass)
+
+      val newInstance = staticMethods.single { it.name == "newInstance" }
+        .invoke(null, 5, "Hello")
+
+      assertThat(factoryInstance.invokeGet("Hello")).isEqualTo(newInstance)
+    }
+  }
+
+  @Test fun `a factory class is generated for an inner class`() {
+    compile(
+      """
+      package com.squareup.test
+      
+      import dagger.assisted.Assisted
+      import dagger.assisted.AssistedInject
+      
+      class Outer {
+        class AssistedService @AssistedInject constructor(
+          val int: Int,
+          @Assisted val string: String
+        ) {
+          override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (javaClass != other?.javaClass) return false
+        
+            other as AssistedService
+        
+            if (int != other.int) return false
+            if (string != other.string) return false
+        
+            return true
+          } 
+        }
+      }
+      
+      """
+    ) {
+      val factoryClass = classLoader
+        .loadClass("com.squareup.test.Outer\$AssistedService")
+        .factoryClass()
+
+      val constructor = factoryClass.declaredConstructors.single()
+      assertThat(constructor.parameterTypes.toList()).containsExactly(Provider::class.java)
+
+      val staticMethods = factoryClass.declaredMethods.filter { it.isStatic }
+      assertThat(staticMethods).hasSize(2)
+
+      val factoryInstance = staticMethods.single { it.name == "create" }
+        .invoke(null, Provider { 5 })
+      assertThat(factoryInstance::class.java).isEqualTo(factoryClass)
+
+      val newInstance = staticMethods.single { it.name == "newInstance" }
+        .invoke(null, 5, "Hello")
+
+      assertThat(factoryInstance.invokeGet("Hello")).isEqualTo(newInstance)
+    }
+  }
+
+  @Suppress("CHANGING_ARGUMENTS_EXECUTION_ORDER_FOR_NAMED_VARARGS")
+  private fun compile(
+    vararg sources: String,
+    block: Result.() -> Unit = { }
+  ): Result = com.squareup.anvil.compiler.compile(
+    sources = sources,
+    enableDaggerAnnotationProcessor = useDagger,
+    generateDaggerFactories = !useDagger,
+    block = block
+  )
+}

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -2,7 +2,7 @@ ext {
   ci = (System.getenv('CI') ?: 'false').toBoolean()
 
   autoServiceVersion = '1.0-rc7'
-  daggerVersion = '2.28'
+  daggerVersion = '2.31.2'
   espressoVersion = '3.2.0'
   kotlinVersion = project.hasProperty('square.kotlinVersion') ?
       project.getProperty('square.kotlinVersion') : '1.4.20'

--- a/integration-tests/library/src/main/java/com/squareup/anvil/test/AssistedService.kt
+++ b/integration-tests/library/src/main/java/com/squareup/anvil/test/AssistedService.kt
@@ -1,0 +1,16 @@
+package com.squareup.anvil.test
+
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+
+public class AssistedService @AssistedInject constructor(
+  public val integer: Int,
+  @Assisted public val string: String
+) {
+
+  @AssistedFactory
+  public interface Factory {
+    public fun create(string: String): AssistedService
+  }
+}

--- a/integration-tests/tests/src/test/java/com/squareup/anvil/test/AssistedInjectionTest.kt
+++ b/integration-tests/tests/src/test/java/com/squareup/anvil/test/AssistedInjectionTest.kt
@@ -1,0 +1,28 @@
+package com.squareup.anvil.test
+
+import com.google.common.truth.Truth.assertThat
+import dagger.Component
+import dagger.Module
+import dagger.Provides
+import org.junit.Test
+
+internal class AssistedInjectionTest {
+
+  @Test fun `assisted injection code is generated`() {
+    val assistedService = DaggerAssistedInjectionTest_AppComponent.create()
+      .serviceFactory()
+      .create("Hello")
+
+    assertThat(assistedService.string).isEqualTo("Hello")
+  }
+
+  @Component(modules = [DaggerModule::class])
+  interface AppComponent {
+    fun serviceFactory(): AssistedService.Factory
+  }
+
+  @Module
+  object DaggerModule {
+    @Provides fun provideInt(): Int = 5
+  }
+}


### PR DESCRIPTION
Dagger 2.31 has built-in support for assisted injection. Dagger generates code for the classes using the new annotations. Anvil allows to replace the Dagger annotation processor in many modules and generates the necessary code. This PR adds support for assisted injection.