### PR TITLE
A provider method inside of a companion object is not abstract. 

### DIFF
--- a/compiler/src/test/java/com/squareup/anvil/compiler/dagger/ProvidesMethodFactoryGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/dagger/ProvidesMethodFactoryGeneratorTest.kt
@@ -2883,6 +2883,27 @@ public final class DaggerModule1_GetStringFactory implements Factory<String> {
     }
   }
 
+  @Test fun `an interface with a companion object is allowed to contain a provider method`() {
+    compile(
+      """
+      package com.squareup.test
+      
+      import dagger.Module
+      import dagger.Provides
+      
+      @Module
+      interface DaggerModule1 {
+        companion object {
+          @Provides fun provideString(): String = ""
+        }      
+      }
+      """
+    ) {
+      val factoryClass = daggerModule1.moduleFactoryClass("provideString", companion = true)
+      assertThat(factoryClass).isNotNull()
+    }
+  }
+
   @Suppress("CHANGING_ARGUMENTS_EXECUTION_ORDER_FOR_NAMED_VARARGS")
   private fun compile(
     vararg sources: String,


### PR DESCRIPTION
This was a false positive.

Fixes #187