### PR TITLE
Upgrade Dagger. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Next Version
 
 * `@ContributesBinding` supports qualifiers now, see the README and documentation for examples.  
+* Upgrade Dagger to `2.32`. Generating factories for assisted injection is no longer compatible with older Dagger versions due to the behavior change in Dagger itself. Make sure to use Dagger version `2.32` or newer in your project, too.  
 
 ## 2.1.0 (2021-02-05)
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -2,7 +2,7 @@ ext {
   ci = (System.getenv('CI') ?: 'false').toBoolean()
 
   autoServiceVersion = '1.0-rc7'
-  daggerVersion = '2.31.2'
+  daggerVersion = '2.32'
   espressoVersion = '3.2.0'
   kotlinVersion = project.hasProperty('square.kotlinVersion') ?
       project.getProperty('square.kotlinVersion') : '1.4.30'


### PR DESCRIPTION
Initially, Dagger relied on the order of parameters for assisted injection and parameter types had to match between the inject constructor and the factory method. Dagger now introduced a new string identifier `@Assisted("identifier")`. For each parameter they compute a key, which is like a hash of the identifier and the type. The order of parameters is no longer important. Rather, they rely on the keys. There should be no duplicate key and for each key in the inject constructor must be a key in the factory function.

For this PR I upgraded Dagger, updated all tests with the behavior changes, added tests for new edge cases and then fixed all implementations to make the tests pass. 