### PR TITLE
Clean up tests

### DIFF
--- a/compiler/src/test/java/com/squareup/anvil/compiler/ReflectionTestUtils.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/ReflectionTestUtils.kt
@@ -6,4 +6,11 @@ import java.lang.reflect.Modifier
 val Member.isStatic: Boolean get() = Modifier.isStatic(modifiers)
 val Member.isAbstract: Boolean get() = Modifier.isAbstract(modifiers)
 
-fun <T : Any> Class<T>.newInstanceNoArgs(): T = getDeclaredConstructor().newInstance()
+/**
+ * Creates a new instance of this class with the given arguments. This method assumes that this
+ * class only declares a single constructor.
+ */
+@Suppress("UNCHECKED_CAST")
+fun <T : Any> Class<T>.createInstance(
+  vararg initargs: Any?
+): T = declaredConstructors.single().use { it.newInstance(*initargs) } as T

--- a/compiler/src/test/java/com/squareup/anvil/compiler/dagger/AssistedFactoryGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/dagger/AssistedFactoryGeneratorTest.kt
@@ -103,7 +103,7 @@ public final class AssistedServiceFactory_Impl implements AssistedServiceFactory
       import dagger.assisted.AssistedFactory
       import dagger.assisted.AssistedInject
       
-      class AssistedService @AssistedInject constructor(
+      data class AssistedService @AssistedInject constructor(
         val int: Int,
         @Assisted val string: String
       )
@@ -136,7 +136,10 @@ public final class AssistedServiceFactory_Impl implements AssistedServiceFactory
         .single { it.name == "create" }
         .invoke(factoryImplInstance, "Hello")
 
-      assertThat(assistedServiceInstance::class.java).isEqualTo(assistedService)
+      assertThat(assistedServiceInstance).isEqualTo(
+        assistedService.declaredConstructors.single()
+          .newInstance(5, "Hello")
+      )
     }
   }
 
@@ -149,7 +152,7 @@ public final class AssistedServiceFactory_Impl implements AssistedServiceFactory
       import dagger.assisted.AssistedFactory
       import dagger.assisted.AssistedInject
       
-      class AssistedService @AssistedInject constructor(
+      data class AssistedService @AssistedInject constructor(
         val int: Int,
         @Assisted val string: String
       )
@@ -184,7 +187,10 @@ public final class AssistedServiceFactory_Impl implements AssistedServiceFactory
         .single { it.name == "create" }
         .invoke(factoryImplInstance, "Hello")
 
-      assertThat(assistedServiceInstance::class.java).isEqualTo(assistedService)
+      assertThat(assistedServiceInstance).isEqualTo(
+        assistedService.declaredConstructors.single()
+          .newInstance(5, "Hello")
+      )
     }
   }
 
@@ -197,7 +203,7 @@ public final class AssistedServiceFactory_Impl implements AssistedServiceFactory
       import dagger.assisted.AssistedFactory
       import dagger.assisted.AssistedInject
       
-      class AssistedService @AssistedInject constructor(
+      data class AssistedService @AssistedInject constructor(
         val int: Int,
         @Assisted val string: String
       )
@@ -230,7 +236,10 @@ public final class AssistedServiceFactory_Impl implements AssistedServiceFactory
         .single { it.name == "create" }
         .invoke(factoryImplInstance, "Hello")
 
-      assertThat(assistedServiceInstance::class.java).isEqualTo(assistedService)
+      assertThat(assistedServiceInstance).isEqualTo(
+        assistedService.declaredConstructors.single()
+          .newInstance(5, "Hello")
+      )
     }
   }
 
@@ -243,7 +252,7 @@ public final class AssistedServiceFactory_Impl implements AssistedServiceFactory
       import dagger.assisted.AssistedFactory
       import dagger.assisted.AssistedInject
       
-      class AssistedService @AssistedInject constructor(
+      data class AssistedService @AssistedInject constructor(
         val int: Int,
         @Assisted val string: String
       )
@@ -278,7 +287,10 @@ public final class AssistedServiceFactory_Impl implements AssistedServiceFactory
           it.invoke(factoryImplInstance, "Hello")
         }
 
-      assertThat(assistedServiceInstance::class.java).isEqualTo(assistedService)
+      assertThat(assistedServiceInstance).isEqualTo(
+        assistedService.declaredConstructors.single()
+          .newInstance(5, "Hello")
+      )
     }
   }
 
@@ -291,7 +303,7 @@ public final class AssistedServiceFactory_Impl implements AssistedServiceFactory
       import dagger.assisted.AssistedFactory
       import dagger.assisted.AssistedInject
       
-      class AssistedService @AssistedInject constructor(
+      data class AssistedService @AssistedInject constructor(
         val int: Int,
         @Assisted val strings: List<String>
       )
@@ -324,7 +336,10 @@ public final class AssistedServiceFactory_Impl implements AssistedServiceFactory
         .single { it.name == "create" }
         .invoke(factoryImplInstance, listOf("Hello"))
 
-      assertThat(assistedServiceInstance::class.java).isEqualTo(assistedService)
+      assertThat(assistedServiceInstance).isEqualTo(
+        assistedService.declaredConstructors.single()
+          .newInstance(5, listOf("Hello"))
+      )
     }
   }
 
@@ -405,7 +420,7 @@ public final class AssistedServiceFactory_Impl<T extends CharSequence> implement
       import dagger.assisted.AssistedFactory
       import dagger.assisted.AssistedInject
       
-      class AssistedService<T : CharSequence> @AssistedInject constructor(
+      data class AssistedService<T : CharSequence> @AssistedInject constructor(
         val int: Int,
         @Assisted val string: T
       )
@@ -438,7 +453,10 @@ public final class AssistedServiceFactory_Impl<T extends CharSequence> implement
         .single { it.name == "create" }
         .invoke(factoryImplInstance, "Hello")
 
-      assertThat(assistedServiceInstance::class.java).isEqualTo(assistedService)
+      assertThat(assistedServiceInstance).isEqualTo(
+        assistedService.declaredConstructors.single()
+          .newInstance(5, "Hello")
+      )
     }
   }
 
@@ -451,7 +469,7 @@ public final class AssistedServiceFactory_Impl<T extends CharSequence> implement
       import dagger.assisted.AssistedFactory
       import dagger.assisted.AssistedInject
       
-      class AssistedService @AssistedInject constructor(
+      data class AssistedService @AssistedInject constructor(
         val int: Int,
         @Assisted val string: String
       ) {
@@ -485,7 +503,10 @@ public final class AssistedServiceFactory_Impl<T extends CharSequence> implement
         .single { it.name == "create" }
         .invoke(factoryImplInstance, "Hello")
 
-      assertThat(assistedServiceInstance::class.java).isEqualTo(assistedService)
+      assertThat(assistedServiceInstance).isEqualTo(
+        assistedService.declaredConstructors.single()
+          .newInstance(5, "Hello")
+      )
     }
   }
 
@@ -564,7 +585,7 @@ public final class AssistedServiceFactory_Impl implements AssistedServiceFactory
       import dagger.assisted.AssistedFactory
       import dagger.assisted.AssistedInject
       
-      class AssistedService @AssistedInject constructor(
+      data class AssistedService @AssistedInject constructor(
         val int: Int,
         @Assisted val string: String?
       )
@@ -597,7 +618,10 @@ public final class AssistedServiceFactory_Impl implements AssistedServiceFactory
         .single { it.name == "create" }
         .invoke(factoryImplInstance, null)
 
-      assertThat(assistedServiceInstance::class.java).isEqualTo(assistedService)
+      assertThat(assistedServiceInstance).isEqualTo(
+        assistedService.declaredConstructors.single()
+          .newInstance(5, null)
+      )
     }
   }
 
@@ -608,7 +632,7 @@ public final class AssistedServiceFactory_Impl implements AssistedServiceFactory
       
       import dagger.assisted.AssistedFactory
       
-      class AssistedService(
+      data class AssistedService(
         val int: Int,
         val string: String
       )
@@ -751,7 +775,7 @@ public final class AssistedServiceFactory_Impl implements AssistedServiceFactory
       import dagger.assisted.AssistedFactory
       import dagger.assisted.AssistedInject
       
-      class AssistedService @AssistedInject constructor(
+      data class AssistedService @AssistedInject constructor(
         val int: Int,
         @Assisted val string: String,
         @Assisted val long: Long
@@ -783,9 +807,12 @@ public final class AssistedServiceFactory_Impl implements AssistedServiceFactory
       val assistedServiceInstance = factoryImplClass.declaredMethods
         .filterNot { it.isStatic }
         .single { it.name == "create" }
-        .invoke(factoryImplInstance, 5L, "Hello")
+        .invoke(factoryImplInstance, 4L, "Hello")
 
-      assertThat(assistedServiceInstance::class.java).isEqualTo(assistedService)
+      assertThat(assistedServiceInstance).isEqualTo(
+        assistedService.declaredConstructors.single()
+          .newInstance(5, "Hello", 4L)
+      )
     }
   }
 
@@ -1038,7 +1065,7 @@ public final class AssistedServiceFactory_Impl implements AssistedServiceFactory
       import dagger.assisted.AssistedFactory
       import dagger.assisted.AssistedInject
       
-      class AssistedService @AssistedInject constructor(
+      data class AssistedService @AssistedInject constructor(
         val int: Int,
         @Assisted val string: String
       )
@@ -1067,7 +1094,7 @@ public final class AssistedServiceFactory_Impl implements AssistedServiceFactory
       import dagger.assisted.AssistedFactory
       import dagger.assisted.AssistedInject
       
-      class AssistedService @AssistedInject constructor(
+      data class AssistedService @AssistedInject constructor(
         val int: Int,
         @Assisted val string: String
       )
@@ -1099,7 +1126,7 @@ public final class AssistedServiceFactory_Impl implements AssistedServiceFactory
       import dagger.assisted.AssistedFactory
       import dagger.assisted.AssistedInject
       
-      class AssistedService @AssistedInject constructor(
+      data class AssistedService @AssistedInject constructor(
         val int: Int,
         @Assisted val string: String
       )
@@ -1125,7 +1152,7 @@ public final class AssistedServiceFactory_Impl implements AssistedServiceFactory
       import dagger.assisted.AssistedFactory
       import dagger.assisted.AssistedInject
       
-      class AssistedService @AssistedInject constructor(
+      data class AssistedService @AssistedInject constructor(
         val int: Int,
         @Assisted val string: String
       )

--- a/compiler/src/test/java/com/squareup/anvil/compiler/dagger/AssistedFactoryGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/dagger/AssistedFactoryGeneratorTest.kt
@@ -3,10 +3,10 @@ package com.squareup.anvil.compiler.dagger
 import com.google.common.truth.Truth.assertThat
 import com.squareup.anvil.compiler.assistedService
 import com.squareup.anvil.compiler.assistedServiceFactory
+import com.squareup.anvil.compiler.createInstance
 import com.squareup.anvil.compiler.factoryClass
 import com.squareup.anvil.compiler.implClass
 import com.squareup.anvil.compiler.isStatic
-import com.squareup.anvil.compiler.newInstanceNoArgs
 import com.squareup.anvil.compiler.use
 import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.COMPILATION_ERROR
 import com.tschuchort.compiletesting.KotlinCompilation.Result
@@ -115,12 +115,8 @@ public final class AssistedServiceFactory_Impl implements AssistedServiceFactory
       """
     ) {
       val factoryImplClass = assistedServiceFactory.implClass()
-      val generatedFactoryInstance = assistedService.factoryClass()
-        .declaredConstructors.single().newInstance(Provider { 5 })
-
-      val constructor = factoryImplClass.declaredConstructors.single()
-      assertThat(constructor.parameterTypes.toList())
-        .containsExactly(assistedService.factoryClass())
+      val generatedFactoryInstance = assistedService.factoryClass().createInstance(Provider { 5 })
+      val factoryImplInstance = factoryImplClass.createInstance(generatedFactoryInstance)
 
       val staticMethods = factoryImplClass.declaredMethods.filter { it.isStatic }
       assertThat(staticMethods).hasSize(1)
@@ -129,17 +125,12 @@ public final class AssistedServiceFactory_Impl implements AssistedServiceFactory
         .invoke(null, generatedFactoryInstance) as Provider<*>
       assertThat(factoryProvider.get()::class.java).isEqualTo(factoryImplClass)
 
-      val factoryImplInstance = constructor.use { it.newInstance(generatedFactoryInstance) }
-
       val assistedServiceInstance = factoryImplClass.declaredMethods
         .filterNot { it.isStatic }
         .single { it.name == "create" }
         .invoke(factoryImplInstance, "Hello")
 
-      assertThat(assistedServiceInstance).isEqualTo(
-        assistedService.declaredConstructors.single()
-          .newInstance(5, "Hello")
-      )
+      assertThat(assistedServiceInstance).isEqualTo(assistedService.createInstance(5, "Hello"))
     }
   }
 
@@ -166,12 +157,8 @@ public final class AssistedServiceFactory_Impl implements AssistedServiceFactory
       """
     ) {
       val factoryImplClass = assistedServiceFactory.implClass()
-      val generatedFactoryInstance = assistedService.factoryClass()
-        .declaredConstructors.single().newInstance(Provider { 5 })
-
-      val constructor = factoryImplClass.declaredConstructors.single()
-      assertThat(constructor.parameterTypes.toList())
-        .containsExactly(assistedService.factoryClass())
+      val generatedFactoryInstance = assistedService.factoryClass().createInstance(Provider { 5 })
+      val factoryImplInstance = factoryImplClass.createInstance(generatedFactoryInstance)
 
       val staticMethods = factoryImplClass.declaredMethods.filter { it.isStatic }
       assertThat(staticMethods).hasSize(1)
@@ -180,17 +167,12 @@ public final class AssistedServiceFactory_Impl implements AssistedServiceFactory
         .invoke(null, generatedFactoryInstance) as Provider<*>
       assertThat(factoryProvider.get()::class.java).isEqualTo(factoryImplClass)
 
-      val factoryImplInstance = constructor.use { it.newInstance(generatedFactoryInstance) }
-
       val assistedServiceInstance = factoryImplClass.declaredMethods
         .filterNot { it.isStatic }
         .single { it.name == "create" }
         .invoke(factoryImplInstance, "Hello")
 
-      assertThat(assistedServiceInstance).isEqualTo(
-        assistedService.declaredConstructors.single()
-          .newInstance(5, "Hello")
-      )
+      assertThat(assistedServiceInstance).isEqualTo(assistedService.createInstance(5, "Hello"))
     }
   }
 
@@ -215,12 +197,8 @@ public final class AssistedServiceFactory_Impl implements AssistedServiceFactory
       """
     ) {
       val factoryImplClass = assistedServiceFactory.implClass()
-      val generatedFactoryInstance = assistedService.factoryClass()
-        .declaredConstructors.single().newInstance(Provider { 5 })
-
-      val constructor = factoryImplClass.declaredConstructors.single()
-      assertThat(constructor.parameterTypes.toList())
-        .containsExactly(assistedService.factoryClass())
+      val generatedFactoryInstance = assistedService.factoryClass().createInstance(Provider { 5 })
+      val factoryImplInstance = factoryImplClass.createInstance(generatedFactoryInstance)
 
       val staticMethods = factoryImplClass.declaredMethods.filter { it.isStatic }
       assertThat(staticMethods).hasSize(1)
@@ -229,17 +207,12 @@ public final class AssistedServiceFactory_Impl implements AssistedServiceFactory
         .invoke(null, generatedFactoryInstance) as Provider<*>
       assertThat(factoryProvider.get()::class.java).isEqualTo(factoryImplClass)
 
-      val factoryImplInstance = constructor.use { it.newInstance(generatedFactoryInstance) }
-
       val assistedServiceInstance = factoryImplClass.declaredMethods
         .filterNot { it.isStatic }
         .single { it.name == "create" }
         .invoke(factoryImplInstance, "Hello")
 
-      assertThat(assistedServiceInstance).isEqualTo(
-        assistedService.declaredConstructors.single()
-          .newInstance(5, "Hello")
-      )
+      assertThat(assistedServiceInstance).isEqualTo(assistedService.createInstance(5, "Hello"))
     }
   }
 
@@ -264,12 +237,8 @@ public final class AssistedServiceFactory_Impl implements AssistedServiceFactory
       """
     ) {
       val factoryImplClass = assistedServiceFactory.implClass()
-      val generatedFactoryInstance = assistedService.factoryClass()
-        .declaredConstructors.single().newInstance(Provider { 5 })
-
-      val constructor = factoryImplClass.declaredConstructors.single()
-      assertThat(constructor.parameterTypes.toList())
-        .containsExactly(assistedService.factoryClass())
+      val generatedFactoryInstance = assistedService.factoryClass().createInstance(Provider { 5 })
+      val factoryImplInstance = factoryImplClass.createInstance(generatedFactoryInstance)
 
       val staticMethods = factoryImplClass.declaredMethods.filter { it.isStatic }
       assertThat(staticMethods).hasSize(1)
@@ -278,8 +247,6 @@ public final class AssistedServiceFactory_Impl implements AssistedServiceFactory
         .invoke(null, generatedFactoryInstance) as Provider<*>
       assertThat(factoryProvider.get()::class.java).isEqualTo(factoryImplClass)
 
-      val factoryImplInstance = constructor.use { it.newInstance(generatedFactoryInstance) }
-
       val assistedServiceInstance = factoryImplClass.declaredMethods
         .filterNot { it.isStatic }
         .single { it.name == "create" }
@@ -287,10 +254,7 @@ public final class AssistedServiceFactory_Impl implements AssistedServiceFactory
           it.invoke(factoryImplInstance, "Hello")
         }
 
-      assertThat(assistedServiceInstance).isEqualTo(
-        assistedService.declaredConstructors.single()
-          .newInstance(5, "Hello")
-      )
+      assertThat(assistedServiceInstance).isEqualTo(assistedService.createInstance(5, "Hello"))
     }
   }
 
@@ -315,12 +279,8 @@ public final class AssistedServiceFactory_Impl implements AssistedServiceFactory
       """
     ) {
       val factoryImplClass = assistedServiceFactory.implClass()
-      val generatedFactoryInstance = assistedService.factoryClass()
-        .declaredConstructors.single().newInstance(Provider { 5 })
-
-      val constructor = factoryImplClass.declaredConstructors.single()
-      assertThat(constructor.parameterTypes.toList())
-        .containsExactly(assistedService.factoryClass())
+      val generatedFactoryInstance = assistedService.factoryClass().createInstance(Provider { 5 })
+      val factoryImplInstance = factoryImplClass.createInstance(generatedFactoryInstance)
 
       val staticMethods = factoryImplClass.declaredMethods.filter { it.isStatic }
       assertThat(staticMethods).hasSize(1)
@@ -329,17 +289,13 @@ public final class AssistedServiceFactory_Impl implements AssistedServiceFactory
         .invoke(null, generatedFactoryInstance) as Provider<*>
       assertThat(factoryProvider.get()::class.java).isEqualTo(factoryImplClass)
 
-      val factoryImplInstance = constructor.use { it.newInstance(generatedFactoryInstance) }
-
       val assistedServiceInstance = factoryImplClass.declaredMethods
         .filterNot { it.isStatic }
         .single { it.name == "create" }
         .invoke(factoryImplInstance, listOf("Hello"))
 
-      assertThat(assistedServiceInstance).isEqualTo(
-        assistedService.declaredConstructors.single()
-          .newInstance(5, listOf("Hello"))
-      )
+      assertThat(assistedServiceInstance)
+        .isEqualTo(assistedService.createInstance(5, listOf("Hello")))
     }
   }
 
@@ -432,12 +388,8 @@ public final class AssistedServiceFactory_Impl<T extends CharSequence> implement
       """
     ) {
       val factoryImplClass = assistedServiceFactory.implClass()
-      val generatedFactoryInstance = assistedService.factoryClass()
-        .declaredConstructors.single().newInstance(Provider { 5 })
-
-      val constructor = factoryImplClass.declaredConstructors.single()
-      assertThat(constructor.parameterTypes.toList())
-        .containsExactly(assistedService.factoryClass())
+      val generatedFactoryInstance = assistedService.factoryClass().createInstance(Provider { 5 })
+      val factoryImplInstance = factoryImplClass.createInstance(generatedFactoryInstance)
 
       val staticMethods = factoryImplClass.declaredMethods.filter { it.isStatic }
       assertThat(staticMethods).hasSize(1)
@@ -446,17 +398,12 @@ public final class AssistedServiceFactory_Impl<T extends CharSequence> implement
         .invoke(null, generatedFactoryInstance) as Provider<*>
       assertThat(factoryProvider.get()::class.java).isEqualTo(factoryImplClass)
 
-      val factoryImplInstance = constructor.use { it.newInstance(generatedFactoryInstance) }
-
       val assistedServiceInstance = factoryImplClass.declaredMethods
         .filterNot { it.isStatic }
         .single { it.name == "create" }
         .invoke(factoryImplInstance, "Hello")
 
-      assertThat(assistedServiceInstance).isEqualTo(
-        assistedService.declaredConstructors.single()
-          .newInstance(5, "Hello")
-      )
+      assertThat(assistedServiceInstance).isEqualTo(assistedService.createInstance(5, "Hello"))
     }
   }
 
@@ -482,12 +429,8 @@ public final class AssistedServiceFactory_Impl<T extends CharSequence> implement
     ) {
       val factoryImplClass = classLoader
         .loadClass("com.squareup.test.AssistedService\$Factory").implClass()
-      val generatedFactoryInstance = assistedService.factoryClass()
-        .declaredConstructors.single().newInstance(Provider { 5 })
-
-      val constructor = factoryImplClass.declaredConstructors.single()
-      assertThat(constructor.parameterTypes.toList())
-        .containsExactly(assistedService.factoryClass())
+      val generatedFactoryInstance = assistedService.factoryClass().createInstance(Provider { 5 })
+      val factoryImplInstance = factoryImplClass.createInstance(generatedFactoryInstance)
 
       val staticMethods = factoryImplClass.declaredMethods.filter { it.isStatic }
       assertThat(staticMethods).hasSize(1)
@@ -496,17 +439,12 @@ public final class AssistedServiceFactory_Impl<T extends CharSequence> implement
         .invoke(null, generatedFactoryInstance) as Provider<*>
       assertThat(factoryProvider.get()::class.java).isEqualTo(factoryImplClass)
 
-      val factoryImplInstance = constructor.use { it.newInstance(generatedFactoryInstance) }
-
       val assistedServiceInstance = factoryImplClass.declaredMethods
         .filterNot { it.isStatic }
         .single { it.name == "create" }
         .invoke(factoryImplInstance, "Hello")
 
-      assertThat(assistedServiceInstance).isEqualTo(
-        assistedService.declaredConstructors.single()
-          .newInstance(5, "Hello")
-      )
+      assertThat(assistedServiceInstance).isEqualTo(assistedService.createInstance(5, "Hello"))
     }
   }
 
@@ -597,12 +535,8 @@ public final class AssistedServiceFactory_Impl implements AssistedServiceFactory
       """
     ) {
       val factoryImplClass = assistedServiceFactory.implClass()
-      val generatedFactoryInstance = assistedService.factoryClass()
-        .declaredConstructors.single().newInstance(Provider { 5 })
-
-      val constructor = factoryImplClass.declaredConstructors.single()
-      assertThat(constructor.parameterTypes.toList())
-        .containsExactly(assistedService.factoryClass())
+      val generatedFactoryInstance = assistedService.factoryClass().createInstance(Provider { 5 })
+      val factoryImplInstance = factoryImplClass.createInstance(generatedFactoryInstance)
 
       val staticMethods = factoryImplClass.declaredMethods.filter { it.isStatic }
       assertThat(staticMethods).hasSize(1)
@@ -611,17 +545,12 @@ public final class AssistedServiceFactory_Impl implements AssistedServiceFactory
         .invoke(null, generatedFactoryInstance) as Provider<*>
       assertThat(factoryProvider.get()::class.java).isEqualTo(factoryImplClass)
 
-      val factoryImplInstance = constructor.use { it.newInstance(generatedFactoryInstance) }
-
       val assistedServiceInstance = factoryImplClass.declaredMethods
         .filterNot { it.isStatic }
         .single { it.name == "create" }
         .invoke(factoryImplInstance, null)
 
-      assertThat(assistedServiceInstance).isEqualTo(
-        assistedService.declaredConstructors.single()
-          .newInstance(5, null)
-      )
+      assertThat(assistedServiceInstance).isEqualTo(assistedService.createInstance(5, null))
     }
   }
 
@@ -788,12 +717,8 @@ public final class AssistedServiceFactory_Impl implements AssistedServiceFactory
       """
     ) {
       val factoryImplClass = assistedServiceFactory.implClass()
-      val generatedFactoryInstance = assistedService.factoryClass()
-        .declaredConstructors.single().newInstance(Provider { 5 })
-
-      val constructor = factoryImplClass.declaredConstructors.single()
-      assertThat(constructor.parameterTypes.toList())
-        .containsExactly(assistedService.factoryClass())
+      val generatedFactoryInstance = assistedService.factoryClass().createInstance(Provider { 5 })
+      val factoryImplInstance = factoryImplClass.createInstance(generatedFactoryInstance)
 
       val staticMethods = factoryImplClass.declaredMethods.filter { it.isStatic }
       assertThat(staticMethods).hasSize(1)
@@ -802,17 +727,13 @@ public final class AssistedServiceFactory_Impl implements AssistedServiceFactory
         .invoke(null, generatedFactoryInstance) as Provider<*>
       assertThat(factoryProvider.get()::class.java).isEqualTo(factoryImplClass)
 
-      val factoryImplInstance = constructor.use { it.newInstance(generatedFactoryInstance) }
-
       val assistedServiceInstance = factoryImplClass.declaredMethods
         .filterNot { it.isStatic }
         .single { it.name == "create" }
         .invoke(factoryImplInstance, 4L, "Hello")
 
-      assertThat(assistedServiceInstance).isEqualTo(
-        assistedService.declaredConstructors.single()
-          .newInstance(5, "Hello", 4L)
-      )
+      assertThat(assistedServiceInstance)
+        .isEqualTo(assistedService.createInstance(5, "Hello", 4L))
     }
   }
 
@@ -844,12 +765,8 @@ public final class AssistedServiceFactory_Impl implements AssistedServiceFactory
       """
     ) {
       val factoryImplClass = assistedServiceFactory.implClass()
-      val generatedFactoryInstance = assistedService.factoryClass()
-        .declaredConstructors.single().newInstance()
-
-      val constructor = factoryImplClass.declaredConstructors.single()
-      assertThat(constructor.parameterTypes.toList())
-        .containsExactly(assistedService.factoryClass())
+      val generatedFactoryInstance = assistedService.factoryClass().createInstance()
+      val factoryImplInstance = factoryImplClass.createInstance(generatedFactoryInstance)
 
       val staticMethods = factoryImplClass.declaredMethods.filter { it.isStatic }
       assertThat(staticMethods).hasSize(1)
@@ -858,17 +775,13 @@ public final class AssistedServiceFactory_Impl implements AssistedServiceFactory
         .invoke(null, generatedFactoryInstance) as Provider<*>
       assertThat(factoryProvider.get()::class.java).isEqualTo(factoryImplClass)
 
-      val factoryImplInstance = constructor.use { it.newInstance(generatedFactoryInstance) }
-
       val assistedServiceInstance = factoryImplClass.declaredMethods
         .filterNot { it.isStatic }
         .single { it.name == "create" }
         .invoke(factoryImplInstance, 1L, "Hello", 3L, 2L)
 
-      assertThat(assistedServiceInstance).isEqualTo(
-        assistedService.declaredConstructors.single()
-          .newInstance("Hello", 1L, 2L, 3L)
-      )
+      assertThat(assistedServiceInstance)
+        .isEqualTo(assistedService.createInstance("Hello", 1L, 2L, 3L))
     }
   }
 
@@ -894,12 +807,8 @@ public final class AssistedServiceFactory_Impl implements AssistedServiceFactory
       """
     ) {
       val factoryImplClass = assistedServiceFactory.implClass()
-      val generatedFactoryInstance = assistedService.factoryClass()
-        .declaredConstructors.single().newInstance()
-
-      val constructor = factoryImplClass.declaredConstructors.single()
-      assertThat(constructor.parameterTypes.toList())
-        .containsExactly(assistedService.factoryClass())
+      val generatedFactoryInstance = assistedService.factoryClass().createInstance()
+      val factoryImplInstance = factoryImplClass.createInstance(generatedFactoryInstance)
 
       val staticMethods = factoryImplClass.declaredMethods.filter { it.isStatic }
       assertThat(staticMethods).hasSize(1)
@@ -908,17 +817,13 @@ public final class AssistedServiceFactory_Impl implements AssistedServiceFactory
         .invoke(null, generatedFactoryInstance) as Provider<*>
       assertThat(factoryProvider.get()::class.java).isEqualTo(factoryImplClass)
 
-      val factoryImplInstance = constructor.use { it.newInstance(generatedFactoryInstance) }
-
       val assistedServiceInstance = factoryImplClass.declaredMethods
         .filterNot { it.isStatic }
         .single { it.name == "create" }
         .invoke(factoryImplInstance, listOf(1, 2), listOf("Hello"))
 
-      assertThat(assistedServiceInstance).isEqualTo(
-        assistedService.declaredConstructors.single()
-          .newInstance(listOf("Hello"), listOf(1, 2))
-      )
+      assertThat(assistedServiceInstance)
+        .isEqualTo(assistedService.createInstance(listOf("Hello"), listOf(1, 2)))
     }
   }
 
@@ -943,11 +848,8 @@ public final class AssistedServiceFactory_Impl implements AssistedServiceFactory
       """
     ) {
       val factoryImplClass = assistedServiceFactory.implClass()
-      val generatedFactoryInstance = assistedService.factoryClass().newInstanceNoArgs()
-
-      val constructor = factoryImplClass.declaredConstructors.single()
-      assertThat(constructor.parameterTypes.toList())
-        .containsExactly(assistedService.factoryClass())
+      val generatedFactoryInstance = assistedService.factoryClass().createInstance()
+      val factoryImplInstance = factoryImplClass.createInstance(generatedFactoryInstance)
 
       val staticMethods = factoryImplClass.declaredMethods.filter { it.isStatic }
       assertThat(staticMethods).hasSize(1)
@@ -956,16 +858,13 @@ public final class AssistedServiceFactory_Impl implements AssistedServiceFactory
         .invoke(null, generatedFactoryInstance) as Provider<*>
       assertThat(factoryProvider.get()::class.java).isEqualTo(factoryImplClass)
 
-      val factoryImplInstance = constructor.use { it.newInstance(generatedFactoryInstance) }
-
       val assistedServiceInstance = factoryImplClass.declaredMethods
         .filterNot { it.isStatic }
         .single { it.name == "create" }
         .invoke(factoryImplInstance, 1, "Hello")
 
       assertThat(assistedServiceInstance).isEqualTo(
-        assistedService.declaredConstructors.single()
-          .newInstance("Hello", 1)
+        assistedService.createInstance("Hello", 1)
       )
     }
   }
@@ -994,12 +893,8 @@ public final class AssistedServiceFactory_Impl implements AssistedServiceFactory
       """
     ) {
       val factoryImplClass = assistedServiceFactory.implClass()
-      val generatedFactoryInstance = assistedService.factoryClass()
-        .declaredConstructors.single().newInstance()
-
-      val constructor = factoryImplClass.declaredConstructors.single()
-      assertThat(constructor.parameterTypes.toList())
-        .containsExactly(assistedService.factoryClass())
+      val generatedFactoryInstance = assistedService.factoryClass().createInstance()
+      val factoryImplInstance = factoryImplClass.createInstance(generatedFactoryInstance)
 
       val staticMethods = factoryImplClass.declaredMethods.filter { it.isStatic }
       assertThat(staticMethods).hasSize(1)
@@ -1008,18 +903,13 @@ public final class AssistedServiceFactory_Impl implements AssistedServiceFactory
         .invoke(null, generatedFactoryInstance) as Provider<*>
       assertThat(factoryProvider.get()::class.java).isEqualTo(factoryImplClass)
 
-      val factoryImplInstance = constructor.use { it.newInstance(generatedFactoryInstance) }
-
       val assistedServiceInstance = factoryImplClass.declaredMethods
         .filterNot { it.isStatic }
         .single { it.name == "create" }
         .invoke(factoryImplInstance, "Hello", "World")
 
-      assertThat(assistedServiceInstance).isEqualTo(
-        assistedService
-          .getDeclaredConstructor(String::class.java, String::class.java)
-          .newInstance("World", "Hello")
-      )
+      assertThat(assistedServiceInstance)
+        .isEqualTo(assistedService.createInstance("World", "Hello"))
     }
   }
 

--- a/compiler/src/test/java/com/squareup/anvil/compiler/dagger/AssistedInjectGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/dagger/AssistedInjectGeneratorTest.kt
@@ -68,22 +68,10 @@ public final class AssistedService_Factory {
       import dagger.assisted.Assisted
       import dagger.assisted.AssistedInject
       
-      class AssistedService @AssistedInject constructor(
+      data class AssistedService @AssistedInject constructor(
         val int: Int,
         @Assisted val string: String
-      ) {
-        override fun equals(other: Any?): Boolean {
-          if (this === other) return true
-          if (javaClass != other?.javaClass) return false
-      
-          other as AssistedService
-      
-          if (int != other.int) return false
-          if (string != other.string) return false
-      
-          return true
-        } 
-      }
+      )
       """
     ) {
       val factoryClass = assistedService.factoryClass()
@@ -150,24 +138,11 @@ public final class AssistedService_Factory {
       import dagger.assisted.Assisted
       import dagger.assisted.AssistedInject
       
-      class AssistedService @AssistedInject constructor(
+      data class AssistedService @AssistedInject constructor(
         val int: Int,
         @Assisted("one") val string1: String,
         @Assisted("two") val string2: String
-      ) {
-        override fun equals(other: Any?): Boolean {
-          if (this === other) return true
-          if (javaClass != other?.javaClass) return false
-      
-          other as AssistedService
-      
-          if (int != other.int) return false
-          if (string1 != other.string1) return false
-          if (string2 != other.string2) return false
-      
-          return true
-        } 
-      }
+      )
       """
     ) {
       val factoryClass = assistedService.factoryClass()
@@ -197,22 +172,10 @@ public final class AssistedService_Factory {
       import dagger.assisted.Assisted
       import dagger.assisted.AssistedInject
       
-      class AssistedService @AssistedInject constructor(
+      data class AssistedService @AssistedInject constructor(
         @Assisted("one") val string1: String,
         @Assisted("two") val string2: String
-      ) {
-        override fun equals(other: Any?): Boolean {
-          if (this === other) return true
-          if (javaClass != other?.javaClass) return false
-      
-          other as AssistedService
-      
-          if (string1 != other.string1) return false
-          if (string2 != other.string2) return false
-      
-          return true
-        } 
-      }
+      )
       """
     ) {
       val factoryClass = assistedService.factoryClass()
@@ -243,22 +206,10 @@ public final class AssistedService_Factory {
       
       data class SomeType(val int: Int)
       
-      class AssistedService @AssistedInject constructor(
+      data class AssistedService @AssistedInject constructor(
         @Assisted val type1: SomeType,
         @Assisted val type2: SomeType
-      ) {
-        override fun equals(other: Any?): Boolean {
-          if (this === other) return true
-          if (javaClass != other?.javaClass) return false
-      
-          other as AssistedService
-      
-          if (type1 != other.type1) return false
-          if (type2 != other.type2) return false
-      
-          return true
-        } 
-      }
+      )
       """
     ) {
       assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
@@ -279,22 +230,10 @@ public final class AssistedService_Factory {
       
       data class SomeType(val int: Int)
       
-      class AssistedService @AssistedInject constructor(
+      data class AssistedService @AssistedInject constructor(
         @Assisted("one") val type1: SomeType,
         @Assisted(value = "one") val type2: SomeType
-      ) {
-        override fun equals(other: Any?): Boolean {
-          if (this === other) return true
-          if (javaClass != other?.javaClass) return false
-      
-          other as AssistedService
-      
-          if (type1 != other.type1) return false
-          if (type2 != other.type2) return false
-      
-          return true
-        } 
-      }
+      )
       """
     ) {
       assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
@@ -313,20 +252,9 @@ public final class AssistedService_Factory {
       import dagger.assisted.Assisted
       import dagger.assisted.AssistedInject
       
-      class AssistedService @AssistedInject constructor(
+      data class AssistedService @AssistedInject constructor(
         val int: Int
-      ) {
-        override fun equals(other: Any?): Boolean {
-          if (this === other) return true
-          if (javaClass != other?.javaClass) return false
-      
-          other as AssistedService
-      
-          if (int != other.int) return false
-      
-          return true
-        } 
-      }
+      )
       """
     ) {
       val factoryClass = assistedService.factoryClass()
@@ -356,22 +284,10 @@ public final class AssistedService_Factory {
       import dagger.assisted.Assisted
       import dagger.assisted.AssistedInject
       
-      class AssistedService<T : CharSequence> @AssistedInject constructor(
+      data class AssistedService<T : CharSequence> @AssistedInject constructor(
         val int: Int,
         @Assisted val strings: List<String>
-      ) {
-        override fun equals(other: Any?): Boolean {
-          if (this === other) return true
-          if (javaClass != other?.javaClass) return false
-      
-          other as AssistedService<*>
-      
-          if (int != other.int) return false
-          if (strings != other.strings) return false
-      
-          return true
-        } 
-      }
+      )
       """
     ) {
       val factoryClass = assistedService.factoryClass()
@@ -401,24 +317,11 @@ public final class AssistedService_Factory {
       import dagger.assisted.Assisted
       import dagger.assisted.AssistedInject
       
-      class AssistedService<T : CharSequence> @AssistedInject constructor(
+      data class AssistedService<T : CharSequence> @AssistedInject constructor(
         val int: Int,
         @Assisted val strings: List<String>,
         @Assisted val ints: List<Int>
-      ) {
-        override fun equals(other: Any?): Boolean {
-          if (this === other) return true
-          if (javaClass != other?.javaClass) return false
-      
-          other as AssistedService<*>
-      
-          if (int != other.int) return false
-          if (strings != other.strings) return false
-          if (ints != other.ints) return false
-      
-          return true
-        } 
-      }
+      )
       """
     ) {
       val factoryClass = assistedService.factoryClass()
@@ -448,22 +351,10 @@ public final class AssistedService_Factory {
       import dagger.assisted.Assisted
       import dagger.assisted.AssistedInject
       
-      class AssistedService<T : CharSequence> @AssistedInject constructor(
+      data class AssistedService<T : CharSequence> @AssistedInject constructor(
         val int: Int,
         @Assisted val string: T
-      ) {
-        override fun equals(other: Any?): Boolean {
-          if (this === other) return true
-          if (javaClass != other?.javaClass) return false
-      
-          other as AssistedService<*>
-      
-          if (int != other.int) return false
-          if (string != other.string) return false
-      
-          return true
-        } 
-      }
+      )
       """
     ) {
       val factoryClass = assistedService.factoryClass()
@@ -493,22 +384,10 @@ public final class AssistedService_Factory {
       import dagger.assisted.Assisted
       import dagger.assisted.AssistedInject
       
-      class AssistedService<S : Any, T : CharSequence> @AssistedInject constructor(
+      data class AssistedService<S : Any, T : CharSequence> @AssistedInject constructor(
         val int: S,
         @Assisted val string: T
-      ) {
-        override fun equals(other: Any?): Boolean {
-          if (this === other) return true
-          if (javaClass != other?.javaClass) return false
-      
-          other as AssistedService<*, *>
-      
-          if (int != other.int) return false
-          if (string != other.string) return false
-      
-          return true
-        } 
-      }
+      )
       """
     ) {
       val factoryClass = assistedService.factoryClass()
@@ -539,22 +418,10 @@ public final class AssistedService_Factory {
       import dagger.assisted.AssistedInject
       
       class Outer {
-        class AssistedService @AssistedInject constructor(
+        data class AssistedService @AssistedInject constructor(
           val int: Int,
           @Assisted val string: String
-        ) {
-          override fun equals(other: Any?): Boolean {
-            if (this === other) return true
-            if (javaClass != other?.javaClass) return false
-        
-            other as AssistedService
-        
-            if (int != other.int) return false
-            if (string != other.string) return false
-        
-            return true
-          } 
-        }
+        )
       }
       
       """
@@ -622,22 +489,10 @@ public final class AssistedService_Factory {
       import dagger.assisted.Assisted
       import dagger.assisted.AssistedInject
       
-      class AssistedService @AssistedInject constructor(
+      data class AssistedService @AssistedInject constructor(
         val int: Int?,
         @Assisted val string: String?
-      ) {
-        override fun equals(other: Any?): Boolean {
-          if (this === other) return true
-          if (javaClass != other?.javaClass) return false
-      
-          other as AssistedService
-      
-          if (int != other.int) return false
-          if (string != other.string) return false
-      
-          return true
-        } 
-      }
+      )
       """
     ) {
       val factoryClass = assistedService.factoryClass()

--- a/compiler/src/test/java/com/squareup/anvil/compiler/dagger/MembersInjectorGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/dagger/MembersInjectorGeneratorTest.kt
@@ -1,10 +1,10 @@
 package com.squareup.anvil.compiler.dagger
 
 import com.google.common.truth.Truth.assertThat
+import com.squareup.anvil.compiler.createInstance
 import com.squareup.anvil.compiler.injectClass
 import com.squareup.anvil.compiler.isStatic
 import com.squareup.anvil.compiler.membersInjector
-import com.squareup.anvil.compiler.newInstanceNoArgs
 import com.tschuchort.compiletesting.KotlinCompilation.Result
 import dagger.Lazy
 import dagger.MembersInjector
@@ -181,10 +181,10 @@ public final class InjectClass_MembersInjector implements MembersInjector<Inject
         )
         as MembersInjector<Any>
 
-      val injectInstanceConstructor = injectClass.newInstanceNoArgs()
+      val injectInstanceConstructor = injectClass.createInstance()
       membersInjectorInstance.injectMembers(injectInstanceConstructor)
 
-      val injectInstanceStatic = injectClass.newInstanceNoArgs()
+      val injectInstanceStatic = injectClass.createInstance()
 
       membersInjector.staticInjectMethod("string")
         .invoke(null, injectInstanceStatic, "a")
@@ -320,10 +320,10 @@ public final class InjectClass_MembersInjector implements MembersInjector<Inject
         )
         as MembersInjector<Any>
 
-      val injectInstanceConstructor = injectClass.newInstanceNoArgs()
+      val injectInstanceConstructor = injectClass.createInstance()
       membersInjectorInstance.injectMembers(injectInstanceConstructor)
 
-      val injectInstanceStatic = injectClass.newInstanceNoArgs()
+      val injectInstanceStatic = injectClass.createInstance()
 
       membersInjector.staticInjectMethod("string")
         .invoke(null, injectInstanceStatic, "a")
@@ -432,10 +432,10 @@ public final class InjectClass_MembersInjector implements MembersInjector<Inject
         .newInstance(Provider { File("") }, Provider { File("").toPath() })
         as MembersInjector<Any>
 
-      val injectInstanceConstructor = injectClass.newInstanceNoArgs()
+      val injectInstanceConstructor = injectClass.createInstance()
       membersInjectorInstance.injectMembers(injectInstanceConstructor)
 
-      val injectInstanceStatic = injectClass.newInstanceNoArgs()
+      val injectInstanceStatic = injectClass.createInstance()
 
       membersInjector.staticInjectMethod("file")
         .invoke(null, injectInstanceStatic, File(""))
@@ -554,10 +554,10 @@ public final class OuterClass_InjectClass_MembersInjector implements MembersInje
         .newInstance(Provider { "a" }, Provider<CharSequence> { "b" }, Provider { listOf("c") })
         as MembersInjector<Any>
 
-      val injectInstanceConstructor = injectClass.newInstanceNoArgs()
+      val injectInstanceConstructor = injectClass.createInstance()
       membersInjectorInstance.injectMembers(injectInstanceConstructor)
 
-      val injectInstanceStatic = injectClass.newInstanceNoArgs()
+      val injectInstanceStatic = injectClass.createInstance()
 
       membersInjector.staticInjectMethod("string")
         .invoke(null, injectInstanceStatic, "a")

--- a/compiler/src/test/java/com/squareup/anvil/compiler/dagger/ProvidesMethodFactoryGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/dagger/ProvidesMethodFactoryGeneratorTest.kt
@@ -2,6 +2,7 @@ package com.squareup.anvil.compiler.dagger
 
 import com.google.common.truth.Truth.assertThat
 import com.squareup.anvil.compiler.componentInterfaceAnvilModule
+import com.squareup.anvil.compiler.createInstance
 import com.squareup.anvil.compiler.dagger.UppercasePackage.OuterClass.InnerClass
 import com.squareup.anvil.compiler.dagger.UppercasePackage.TestClassInUppercasePackage
 import com.squareup.anvil.compiler.dagger.UppercasePackage.lowerCaseClassInUppercasePackage
@@ -9,7 +10,6 @@ import com.squareup.anvil.compiler.daggerModule1
 import com.squareup.anvil.compiler.innerModule
 import com.squareup.anvil.compiler.isStatic
 import com.squareup.anvil.compiler.moduleFactoryClass
-import com.squareup.anvil.compiler.newInstanceNoArgs
 import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.COMPILATION_ERROR
 import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.INTERNAL_ERROR
 import com.tschuchort.compiletesting.KotlinCompilation.Result
@@ -93,7 +93,7 @@ public final class DaggerModule1_ProvideStringFactory implements Factory<String>
       val staticMethods = factoryClass.declaredMethods.filter { it.isStatic }
       assertThat(staticMethods).hasSize(2)
 
-      val module = daggerModule1.newInstanceNoArgs()
+      val module = daggerModule1.createInstance()
 
       val factoryInstance = staticMethods.single { it.name == "create" }
         .invoke(null, module)
@@ -164,7 +164,7 @@ public final class DaggerModule1_ProvideFactoryFactory implements Factory<com.sq
       val staticMethods = factoryClass.declaredMethods.filter { it.isStatic }
       assertThat(staticMethods).hasSize(2)
 
-      val module = daggerModule1.newInstanceNoArgs()
+      val module = daggerModule1.createInstance()
 
       val factoryInstance = staticMethods.single { it.name == "create" }
         .invoke(null, module)
@@ -236,7 +236,7 @@ public final class DaggerModule1_ProvideStringFactory implements Factory<String>
       val staticMethods = factoryClass.declaredMethods.filter { it.isStatic }
       assertThat(staticMethods).hasSize(2)
 
-      val module = daggerModule1.newInstanceNoArgs()
+      val module = daggerModule1.createInstance()
 
       val factoryInstance = staticMethods.single { it.name == "create" }
         .invoke(null, module)
@@ -311,7 +311,7 @@ public final class DaggerModule1_ProvideFileFactory implements Factory<File> {
       val staticMethods = factoryClass.declaredMethods.filter { it.isStatic }
       assertThat(staticMethods).hasSize(2)
 
-      val module = daggerModule1.newInstanceNoArgs()
+      val module = daggerModule1.createInstance()
 
       val factoryInstance = staticMethods.single { it.name == "create" }
         .invoke(null, module)
@@ -385,7 +385,7 @@ public final class DaggerModule1_ProvideFileFactory implements Factory<File> {
       val staticMethods = factoryClass.declaredMethods.filter { it.isStatic }
       assertThat(staticMethods).hasSize(2)
 
-      val module = daggerModule1.newInstanceNoArgs()
+      val module = daggerModule1.createInstance()
 
       val factoryInstance = staticMethods.single { it.name == "create" }
         .invoke(null, module)
@@ -456,7 +456,7 @@ public final class DaggerModule1_ProvideStringListFactory implements Factory<Lis
       val staticMethods = factoryClass.declaredMethods.filter { it.isStatic }
       assertThat(staticMethods).hasSize(2)
 
-      val module = daggerModule1.newInstanceNoArgs()
+      val module = daggerModule1.createInstance()
 
       val factoryInstance = staticMethods.single { it.name == "create" }
         .invoke(null, module)
@@ -529,7 +529,7 @@ public final class DaggerModule1_ProvidePairFactory implements Factory<Pair<Pair
 
       val staticMethods = factoryClass.declaredMethods.filter { it.isStatic }
 
-      val module = daggerModule1.newInstanceNoArgs()
+      val module = daggerModule1.createInstance()
 
       val factoryInstance = staticMethods.single { it.name == "create" }
         .invoke(null, module)
@@ -641,7 +641,7 @@ public final class DaggerModule1_ProvideIntFactory implements Factory<Integer> {
         val staticMethods = factoryClass.declaredMethods.filter { it.isStatic }
         assertThat(staticMethods).hasSize(2)
 
-        val module = daggerModule1.newInstanceNoArgs()
+        val module = daggerModule1.createInstance()
 
         val factoryInstance = staticMethods.single { it.name == "create" }
           .invoke(null, module)
@@ -797,7 +797,7 @@ public final class DaggerModule1_ProvideStringFactory implements Factory<String>
 
       val staticMethods = factoryClass.declaredMethods.filter { it.isStatic }
 
-      val module = daggerModule1.newInstanceNoArgs()
+      val module = daggerModule1.createInstance()
 
       val factoryInstance = staticMethods.single { it.name == "create" }
         .invoke(null, module, Provider { "a" }, Provider<CharSequence> { "b" })
@@ -897,7 +897,7 @@ public final class DaggerModule1_ProvideStringFactory implements Factory<String>
 
       val staticMethods = factoryClass.declaredMethods.filter { it.isStatic }
 
-      val module = daggerModule1.newInstanceNoArgs()
+      val module = daggerModule1.createInstance()
 
       val factoryInstance = staticMethods.single { it.name == "create" }
         .invoke(null, module, Provider { "a" }, Provider { "b" }, Provider { listOf("c") })
@@ -1000,7 +1000,7 @@ public final class DaggerModule1_ProvideStringFactory implements Factory<String>
 
       val staticMethods = factoryClass.declaredMethods.filter { it.isStatic }
 
-      val module = daggerModule1.newInstanceNoArgs()
+      val module = daggerModule1.createInstance()
 
       val factoryInstance = staticMethods.single { it.name == "create" }
         .invoke(null, module, Provider { "a" }, Provider { "b" }, Provider { listOf("c") })
@@ -1042,7 +1042,7 @@ public final class DaggerModule1_ProvideStringFactory implements Factory<String>
 
       val staticMethods = factoryClass.declaredMethods.filter { it.isStatic }
 
-      val module = daggerModule1.newInstanceNoArgs()
+      val module = daggerModule1.createInstance()
 
       val factoryInstance = staticMethods.single { it.name == "create" }
         .invoke(null, module, Provider { "a" })
@@ -1136,7 +1136,7 @@ public final class DaggerModule1_ProvideStringFactory implements Factory<String>
 
       val staticMethods = factoryClass.declaredMethods.filter { it.isStatic }
 
-      val module = daggerModule1.newInstanceNoArgs()
+      val module = daggerModule1.createInstance()
 
       val factoryInstance = staticMethods.single { it.name == "create" }
         .invoke(
@@ -1385,7 +1385,7 @@ public final class DaggerModule1_ProvideStringFactory implements Factory<String>
 
       val staticMethods = factoryClass.declaredMethods.filter { it.isStatic }
 
-      val module = daggerModule1.newInstanceNoArgs()
+      val module = daggerModule1.createInstance()
 
       val factoryInstance = staticMethods.single { it.name == "create" }
         .invoke(null, module)
@@ -1550,7 +1550,7 @@ public final class DaggerModule1_ProvideStringFactory implements Factory<String>
 
       val staticMethods = factoryClass.declaredMethods.filter { it.isStatic }
 
-      val module = daggerModule1.newInstanceNoArgs()
+      val module = daggerModule1.createInstance()
 
       val factoryInstance = staticMethods.single { it.name == "create" }
         .invoke(null, module, Provider { null }, Provider { null })
@@ -2550,7 +2550,7 @@ public final class DaggerModule1_GetStringFactory implements Factory<String> {
 
       val staticMethods = factoryClass.declaredMethods.filter { it.isStatic }
 
-      val module = daggerModule1.newInstanceNoArgs()
+      val module = daggerModule1.createInstance()
 
       val factoryInstance = staticMethods.single { it.name == "create" }
         .invoke(null, module)
@@ -2762,7 +2762,7 @@ public final class DaggerModule1_GetStringFactory implements Factory<String> {
 
       val staticMethods = factoryClass.declaredMethods.filter { it.isStatic }
 
-      val module = daggerModule1.newInstanceNoArgs()
+      val module = daggerModule1.createInstance()
 
       val factoryInstance = staticMethods.single { it.name == "create" }
         .invoke(null, module)
@@ -2872,7 +2872,7 @@ public final class DaggerModule1_GetStringFactory implements Factory<String> {
       val staticMethods = factoryClass.declaredMethods.filter { it.isStatic }
       assertThat(staticMethods).hasSize(2)
 
-      val module = daggerModule1.newInstanceNoArgs()
+      val module = daggerModule1.createInstance()
 
       val factoryInstance = staticMethods.single { it.name == "create" }
         .invoke(null, module)


### PR DESCRIPTION
* Use data classes in tests instead of implementing equals() manually now that Dagger supports assisted injection for data classes.
* Use a utility function to create objects for a given class object.