### PR TITLE
Add support for registering generated dirs to sourceSets

### DIFF
--- a/gradle-plugin/src/main/java/com/squareup/anvil/plugin/AnvilExtension.kt
+++ b/gradle-plugin/src/main/java/com/squareup/anvil/plugin/AnvilExtension.kt
@@ -43,6 +43,14 @@ abstract class AnvilExtension @Inject constructor(objects: ObjectFactory) {
   val disableComponentMerging: Property<Boolean> = objects.property(Boolean::class.java)
     .convention(false)
 
+  /**
+   * Add Anvil generated source directories to sourceSets in Gradle for indexing visibility. This
+   * can be useful in debugging and is enabled by default but can be disabled if you don't
+   * need/want this.
+   */
+  val addGeneratedDirToSourceSets: Property<Boolean> = objects.property(Boolean::class.java)
+    .convention(true)
+
   /*
    * The below properties are legacy former properties. We do a bit of Kotlin sugar to preserve
    * binary compatibility but not Kotlin source compatibility.

--- a/gradle-plugin/src/main/java/com/squareup/anvil/plugin/AnvilPlugin.kt
+++ b/gradle-plugin/src/main/java/com/squareup/anvil/plugin/AnvilPlugin.kt
@@ -64,6 +64,12 @@ open class AnvilPlugin : KotlinCompilerPluginSupportPlugin {
     val extension = project.extensions.findByType(AnvilExtension::class.java)
       ?: project.objects.newInstance(AnvilExtension::class.java)
 
+    if (extension.addGeneratedDirToSourceSets.get()) {
+      kotlinCompilation.defaultSourceSet {
+        kotlin.srcDir(srcGenDir)
+      }
+    }
+
     return project.provider {
       listOf(
         FilesSubpluginOption(


### PR DESCRIPTION
This way they're visible for debugging, jumping through generated code, etc. Enabled by default per our prior offline chat