### PR TITLE
Use the mangled function name to generate the factory for a provider method.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## Next Version
 
 * `@ContributesBinding` supports qualifiers now, see the README and documentation for examples.  
-* Upgrade Dagger to `2.32`. Generating factories for assisted injection is no longer compatible with older Dagger versions due to the behavior change in Dagger itself. Make sure to use Dagger version `2.32` or newer in your project, too.  
+* Upgrade Dagger to `2.32`. Generating factories for assisted injection is no longer compatible with older Dagger versions due to the behavior change in Dagger itself. Make sure to use Dagger version `2.32` or newer in your project, too.
+* Use the mangled function name to generate the factory for a provider method.
 
 ## 2.1.0 (2021-02-05)
 

--- a/compiler/src/main/java/com/squareup/anvil/compiler/Utils.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/Utils.kt
@@ -67,6 +67,7 @@ internal val assistedFactoryFqName = FqName(AssistedFactory::class.java.canonica
 internal val assistedInjectFqName = FqName(AssistedInject::class.java.canonicalName)
 internal val providerFqName = FqName(Provider::class.java.canonicalName)
 internal val jvmSuppressWildcardsFqName = FqName(JvmSuppressWildcards::class.java.canonicalName)
+internal val publishedApiFqName = FqName(PublishedApi::class.java.canonicalName)
 
 internal val daggerDoubleCheckFqNameString = DoubleCheck::class.java.canonicalName
 

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/PsiUtils.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/PsiUtils.kt
@@ -6,6 +6,7 @@ import com.squareup.anvil.compiler.daggerProvidesFqName
 import com.squareup.anvil.compiler.getAllSuperTypes
 import com.squareup.anvil.compiler.injectFqName
 import com.squareup.anvil.compiler.jvmSuppressWildcardsFqName
+import com.squareup.anvil.compiler.publishedApiFqName
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.descriptors.ClassifierDescriptorWithTypeParameters
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
@@ -42,7 +43,7 @@ import org.jetbrains.kotlin.psi.psiUtil.parents
 import org.jetbrains.kotlin.psi.psiUtil.parentsWithSelf
 import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
 
-private val kotlinAnnotations = listOf(jvmSuppressWildcardsFqName)
+private val kotlinAnnotations = listOf(jvmSuppressWildcardsFqName, publishedApiFqName)
 
 internal fun KtFile.classesAndInnerClasses(): Sequence<KtClassOrObject> {
   val children = findChildrenByClass(KtClassOrObject::class.java)

--- a/integration-tests/library/src/main/java/com/squareup/anvil/test/Modules.kt
+++ b/integration-tests/library/src/main/java/com/squareup/anvil/test/Modules.kt
@@ -13,6 +13,7 @@ public abstract class AppModule1
 @ContributesTo(AppScope::class)
 public object AppModule2 {
   @Provides @Singleton public fun provideFunction(): (String) -> Int = { it.length }
+  @Provides internal fun provideType(): CharSequence = "Hello"
 }
 
 @Module

--- a/integration-tests/tests/src/test/java/com/squareup/anvil/test/MergeComponentTest.kt
+++ b/integration-tests/tests/src/test/java/com/squareup/anvil/test/MergeComponentTest.kt
@@ -42,10 +42,12 @@ internal class MergeComponentTest {
 
   @MergeComponent(AppScope::class)
   @Singleton
+  @Suppress("unused")
   interface AppComponent {
     fun subComponent(): SubComponent
     fun parentType(): ParentType
     fun function(): (String) -> Int
+    fun charSequence(): CharSequence
   }
 
   @MergeSubcomponent(SubScope::class)


### PR DESCRIPTION
If a provider function's name is mangled (usually when the function has internal visibility), then use the mangled name to generate the factory.

