### PR TITLE
Add error message for missing scope

### DIFF
--- a/compiler/src/main/java/com/squareup/anvil/compiler/AnvilCompilationException.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/AnvilCompilationException.kt
@@ -4,7 +4,9 @@ import org.jetbrains.kotlin.codegen.CompilationException
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.com.intellij.psi.PsiNameIdentifierOwner
 import org.jetbrains.kotlin.descriptors.ClassDescriptor
+import org.jetbrains.kotlin.descriptors.annotations.AnnotationDescriptor
 import org.jetbrains.kotlin.js.resolve.diagnostics.findPsi
+import org.jetbrains.kotlin.resolve.source.KotlinSourceElement
 
 class AnvilCompilationException(
   message: String,
@@ -16,7 +18,15 @@ class AnvilCompilationException(
     message: String,
     cause: Throwable? = null
   ) : this(message, cause = cause, element = classDescriptor.identifier)
+  constructor(
+    annotationDescriptor: AnnotationDescriptor,
+    message: String,
+    cause: Throwable? = null
+  ) : this(message, cause = cause, element = annotationDescriptor.identifier)
 }
 
 private val ClassDescriptor.identifier: PsiElement?
   get() = (findPsi() as? PsiNameIdentifierOwner)?.identifyingElement
+
+private val AnnotationDescriptor.identifier: PsiElement?
+  get() = (source as? KotlinSourceElement)?.psi

--- a/compiler/src/main/java/com/squareup/anvil/compiler/Utils.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/Utils.kt
@@ -136,7 +136,9 @@ internal fun AnnotationDescriptor.getAnnotationValue(key: String): ConstantValue
   allValueArguments[Name.identifier(key)]
 
 internal fun AnnotationDescriptor.scope(module: ModuleDescriptor): ClassDescriptor {
-  val kClassValue = requireNotNull(getAnnotationValue("scope")) as KClassValue
+  val annotationValue = getAnnotationValue("scope")
+    ?: throw AnvilCompilationException(message = "Couldn't find scope for $fqName")
+  val kClassValue = annotationValue as KClassValue
   return kClassValue.argumentType(module).classDescriptorForType()
 }
 

--- a/compiler/src/main/java/com/squareup/anvil/compiler/Utils.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/Utils.kt
@@ -136,10 +136,13 @@ internal fun AnnotationDescriptor.getAnnotationValue(key: String): ConstantValue
   allValueArguments[Name.identifier(key)]
 
 internal fun AnnotationDescriptor.scope(module: ModuleDescriptor): ClassDescriptor {
-  val annotationValue = getAnnotationValue("scope")
-    ?: throw AnvilCompilationException(message = "Couldn't find scope for $fqName")
-  val kClassValue = annotationValue as KClassValue
-  return kClassValue.argumentType(module).classDescriptorForType()
+  val annotationValue = getAnnotationValue("scope") as? KClassValue
+    ?: throw AnvilCompilationException(
+      annotationDescriptor = this,
+      message = "Couldn't find scope for $fqName."
+    )
+
+  return annotationValue.argumentType(module).classDescriptorForType()
 }
 
 internal fun AnnotationDescriptor.replaces(module: ModuleDescriptor): List<ClassDescriptor> {

--- a/compiler/src/test/java/com/squareup/anvil/compiler/ModuleMergerTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/ModuleMergerTest.kt
@@ -788,6 +788,25 @@ class ModuleMergerTest(
     }
   }
 
+  @Test fun `error message if annotation is missing scope`() {
+    compile(
+      """
+      package com.squareup.test
+      
+      $import
+      
+      $annotation()
+      interface ComponentInterface
+      """
+    ) {
+      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+      val annotationFqName = annotation.substring(1)
+      assertThat(messages).contains(
+        "Couldn't find scope for com.squareup.anvil.annotations.$annotationFqName"
+      )
+    }
+  }
+
   private val Class<*>.anyDaggerComponent: AnyDaggerComponent
     get() = anyDaggerComponent(annotationClass)
 }

--- a/compiler/src/test/java/com/squareup/anvil/compiler/ModuleMergerTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/ModuleMergerTest.kt
@@ -788,21 +788,20 @@ class ModuleMergerTest(
     }
   }
 
-  @Test fun `error message if annotation is missing scope`() {
+  @Test fun `an error is thrown when the scope parameter is missing`() {
     compile(
       """
       package com.squareup.test
       
       $import
       
-      $annotation()
+      $annotation
       interface ComponentInterface
       """
     ) {
       assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
-      val annotationFqName = annotation.substring(1)
       assertThat(messages).contains(
-        "Couldn't find scope for com.squareup.anvil.annotations.$annotationFqName"
+        "Couldn't find scope for ${annotationClass.java.canonicalName}"
       )
     }
   }


### PR DESCRIPTION
While debugging an issue, I was unable to find the module this scope threw an exception for, so I added an error message to make it easier to find.

I tried to add a test, but I couldn't figure out where to place it, let me know if any changes are needed.