### PR TITLE
Generate methods for contributed multibindings

### DIFF
--- a/annotations/src/main/java/com/squareup/anvil/annotations/ContributesBinding.kt
+++ b/annotations/src/main/java/com/squareup/anvil/annotations/ContributesBinding.kt
@@ -49,10 +49,19 @@ import kotlin.reflect.KClass
  * abstract fun bindRealAuthenticator(authenticator: RealAuthenticator): Authenticator
  * ```
  *
+ * [ContributesMultibinding] allows you to generate multibinding methods. Both annotations can be
+ * used in conjunction. If a qualifier is only meant for one of the annotations, then you can set
+ * [ignoreQualifier] to `true` and the qualifier won't be added to the generated binding method.
+ * ```
+ * @ContributesBinding(AppScope::class, ignoreQualifier = true)
+ * @ContributesMultibinding(AppScope::class)
+ * @Named("Prod")
+ * object MainListener : Listener
+ * ```
+ *
  * [ContributesBinding] is a convenience for a very simple but the most common scenario. Multiple
  * bound types or generic types are not supported. In these cases it's still required to write
- * a Dagger module. [ContributesMultibinding] allows you to generate multibinding methods. Both
- * annotations can be used in conjunction.
+ * a Dagger module.
  *
  * Contributed bindings can replace other contributed modules and bindings with the [replaces]
  * parameter. This is especially helpful for different bindings in instrumentation tests.
@@ -76,5 +85,6 @@ import kotlin.reflect.KClass
 public annotation class ContributesBinding(
   val scope: KClass<*>,
   val boundType: KClass<*> = Unit::class,
-  val replaces: Array<KClass<*>> = []
+  val replaces: Array<KClass<*>> = [],
+  val ignoreQualifier: Boolean = false
 )

--- a/annotations/src/main/java/com/squareup/anvil/annotations/ContributesBinding.kt
+++ b/annotations/src/main/java/com/squareup/anvil/annotations/ContributesBinding.kt
@@ -44,14 +44,15 @@ import kotlin.reflect.KClass
  * @Named("Prod")
  * class RealAuthenticator @Inject constructor() : Authenticator
  *
- * // Will generated this binding method.
+ * // Will generate this binding method.
  * @Binds @Named("Prod")
  * abstract fun bindRealAuthenticator(authenticator: RealAuthenticator): Authenticator
  * ```
  *
  * [ContributesBinding] is a convenience for a very simple but the most common scenario. Multiple
- * bound types, generic types or multibindings are not supported. In these cases it's still
- * required to write a Dagger module.
+ * bound types or generic types are not supported. In these cases it's still required to write
+ * a Dagger module. [ContributesMultibinding] allows you to generate multibinding methods. Both
+ * annotations can be used in conjunction.
  *
  * Contributed bindings can replace other contributed modules and bindings with the [replaces]
  * parameter. This is especially helpful for different bindings in instrumentation tests.

--- a/annotations/src/main/java/com/squareup/anvil/annotations/ContributesMultibinding.kt
+++ b/annotations/src/main/java/com/squareup/anvil/annotations/ContributesMultibinding.kt
@@ -51,7 +51,7 @@ import kotlin.reflect.KClass
  * ```
  *
  * Contributed multibindings can replace other contributed modules and contributed multibindings
- * with the [replaces] parameter. This is especially helpful for different bindings in
+ * with the [replaces] parameter. This is especially helpful for different multibindings in
  * tests.
  * ```
  * @ContributesMultibinding(
@@ -69,10 +69,14 @@ import kotlin.reflect.KClass
  * `@Provides @IntoSet` method returning [boundType].
  *
  * [ContributesMultibinding] can be used in conjunction with [ContributesBinding]. Each annotation
- * will generate the respective binding or multibindings method.
+ * will generate the respective binding or multibindings method. If a qualifier is only meant for
+ * one of the annotations, then you can set [ignoreQualifier] to `true` and the qualifier won't
+ * be added to the generated multibinding method.
  * ```
  * @ContributesBinding(AppScope::class)
- * @ContributesMultibinding(AppScope::class)
+ * @ContributesMultibinding(AppScope::class, ignoreQualifier = true)
+ * @Named("Prod")
+ * object MainListener : Listener
  * object MainListener : Listener
  * ```
  */
@@ -81,5 +85,6 @@ import kotlin.reflect.KClass
 public annotation class ContributesMultibinding(
   val scope: KClass<*>,
   val boundType: KClass<*> = Unit::class,
-  val replaces: Array<KClass<*>> = []
+  val replaces: Array<KClass<*>> = [],
+  val ignoreQualifier: Boolean = false
 )

--- a/annotations/src/main/java/com/squareup/anvil/annotations/ContributesMultibinding.kt
+++ b/annotations/src/main/java/com/squareup/anvil/annotations/ContributesMultibinding.kt
@@ -1,0 +1,85 @@
+package com.squareup.anvil.annotations
+
+import kotlin.annotation.AnnotationRetention.RUNTIME
+import kotlin.annotation.AnnotationTarget.CLASS
+import kotlin.reflect.KClass
+
+/**
+ * Generate a Dagger multibinding method for an annotated class and contributes this multibinding
+ * method to the given [scope]. Imagine this example:
+ * ```
+ * interface Listener
+ *
+ * class MainListener @Inject constructor() : Listener
+ *
+ * @Module
+ * @ContributesTo(AppScope::class)
+ * abstract class MainListenerModule {
+ *   @Binds @IntoSet
+ *   abstract fun bindMainListener(listener: MainListener): Listener
+ * }
+ * ```
+ * This is a lot of boilerplate. You can replace this entire module with the
+ * [ContributesMultibinding] annotation. The equivalent would be:
+ * ```
+ * interface Listener
+ *
+ * @ContributesMultibinding(AppScope::class)
+ * class MainListener @Inject constructor() : Listener
+ * ```
+ * Notice that it's optional to specify [boundType], if there is only exactly one super type. If
+ * there are multiple super types, then it's required to specify the parameter:
+ * ```
+ * @ContributesMultibinding(
+ *   scope = AppScope::class,
+ *   boundType = Listener::class
+ * )
+ * class MainListener @Inject constructor() : Activity(), Listener
+ * ```
+ *
+ * [ContributesMultibinding] supports qualifiers. If you annotate the class additionally with a
+ * qualifier, then the generated multibinding method will be annotated with the same qualifier,
+ * e.g.
+ * ```
+ * @ContributesMultibinding(AppScope::class)
+ * @Named("Prod")
+ * class MainListener @Inject constructor() : Listener
+ *
+ * // Will generate this binding method.
+ * @Binds @IntoSet @Named("Prod")
+ * abstract fun bindMainListener(listener: MainListener): Listener
+ * ```
+ *
+ * Contributed multibindings can replace other contributed modules and contributed multibindings
+ * with the [replaces] parameter. This is especially helpful for different bindings in
+ * tests.
+ * ```
+ * @ContributesMultibinding(
+ *   scope = AppScope::class,
+ *   replaces = [MainListener::class]
+ * )
+ * class FakeListener @Inject constructor() : Listener
+ * ```
+ * [ContributesMultibinding] supports Kotlin objects, e.g.
+ * ```
+ * @ContributesMultibinding(AppScope::class)
+ * object MainListener : Listener
+ * ```
+ * In this scenario instead of generating a `@Binds @IntoSet` method Anvil will generate a
+ * `@Provides @IntoSet` method returning [boundType].
+ *
+ * [ContributesMultibinding] can be used in conjunction with [ContributesBinding]. Each annotation
+ * will generate the respective binding or multibindings method.
+ * ```
+ * @ContributesBinding(AppScope::class)
+ * @ContributesMultibinding(AppScope::class)
+ * object MainListener : Listener
+ * ```
+ */
+@Target(CLASS)
+@Retention(RUNTIME)
+public annotation class ContributesMultibinding(
+  val scope: KClass<*>,
+  val boundType: KClass<*> = Unit::class,
+  val replaces: Array<KClass<*>> = []
+)

--- a/compiler/src/main/java/com/squareup/anvil/compiler/AnvilComponentRegistrar.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/AnvilComponentRegistrar.kt
@@ -5,6 +5,7 @@ import com.squareup.anvil.compiler.codegen.BindingModuleGenerator
 import com.squareup.anvil.compiler.codegen.CodeGenerationExtension
 import com.squareup.anvil.compiler.codegen.CodeGenerator
 import com.squareup.anvil.compiler.codegen.ContributesBindingGenerator
+import com.squareup.anvil.compiler.codegen.ContributesMultibindingGenerator
 import com.squareup.anvil.compiler.codegen.ContributesToGenerator
 import com.squareup.anvil.compiler.codegen.dagger.AnvilAnnotationDetectorCheck
 import com.squareup.anvil.compiler.codegen.dagger.AssistedFactoryGenerator
@@ -42,6 +43,7 @@ class AnvilComponentRegistrar : ComponentRegistrar {
     if (!generateDaggerFactoriesOnly) {
       codeGenerators += ContributesToGenerator()
       codeGenerators += ContributesBindingGenerator()
+      codeGenerators += ContributesMultibindingGenerator()
       codeGenerators += BindingModuleGenerator(scanner)
     } else {
       codeGenerators += AnvilAnnotationDetectorCheck()

--- a/compiler/src/main/java/com/squareup/anvil/compiler/InterfaceMerger.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/InterfaceMerger.kt
@@ -81,14 +81,17 @@ internal class InterfaceMerger(
               )
             }
 
-            val contributesBindingAnnotation = classDescriptorForReplacement
-              .annotationOrNull(contributesBindingFqName)
             val contributesToAnnotation = classDescriptorForReplacement
               .annotationOrNull(contributesToFqName)
+            val contributesBindingAnnotation = classDescriptorForReplacement
+              .annotationOrNull(contributesBindingFqName)
+            val contributesMultibindingAnnotation = classDescriptorForReplacement
+              .annotationOrNull(contributesMultibindingFqName)
 
             // Verify that the the replaced classes use the same scope.
             val scopeOfReplacement = contributesToAnnotation?.scope(module)
               ?: contributesBindingAnnotation?.scope(module)
+              ?: contributesMultibindingAnnotation?.scope(module)
               ?: throw AnvilCompilationException(
                 classDescriptor,
                 "Could not determine the scope of the replaced class " +
@@ -114,14 +117,17 @@ internal class InterfaceMerger(
       ?.map { it.argumentType(module).classDescriptorForType() }
       ?.filter { DescriptorUtils.isInterface(it) }
       ?.map { classDescriptorForExclusion ->
-        val contributesBindingAnnotation = classDescriptorForExclusion
-          .annotationOrNull(contributesBindingFqName)
         val contributesToAnnotation = classDescriptorForExclusion
           .annotationOrNull(contributesToFqName)
+        val contributesBindingAnnotation = classDescriptorForExclusion
+          .annotationOrNull(contributesBindingFqName)
+        val contributesMultibindingAnnotation = classDescriptorForExclusion
+          .annotationOrNull(contributesMultibindingFqName)
 
         // Verify that the the replaced classes use the same scope.
         val scopeOfExclusion = contributesToAnnotation?.scope(module)
           ?: contributesBindingAnnotation?.scope(module)
+          ?: contributesMultibindingAnnotation?.scope(module)
           ?: throw AnvilCompilationException(
             thisDescriptor,
             "Could not determine the scope of the excluded class " +

--- a/compiler/src/main/java/com/squareup/anvil/compiler/Utils.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/Utils.kt
@@ -1,6 +1,7 @@
 package com.squareup.anvil.compiler
 
 import com.squareup.anvil.annotations.ContributesBinding
+import com.squareup.anvil.annotations.ContributesMultibinding
 import com.squareup.anvil.annotations.ContributesTo
 import com.squareup.anvil.annotations.MergeComponent
 import com.squareup.anvil.annotations.MergeSubcomponent
@@ -54,6 +55,8 @@ internal val mergeInterfacesFqName = FqName(MergeInterfaces::class.java.canonica
 internal val mergeModulesFqName = FqName(MergeModules::class.java.canonicalName)
 internal val contributesToFqName = FqName(ContributesTo::class.java.canonicalName)
 internal val contributesBindingFqName = FqName(ContributesBinding::class.java.canonicalName)
+internal val contributesMultibindingFqName =
+  FqName(ContributesMultibinding::class.java.canonicalName)
 internal val daggerComponentFqName = FqName(Component::class.java.canonicalName)
 internal val daggerSubcomponentFqName = FqName(Subcomponent::class.java.canonicalName)
 internal val daggerModuleFqName = FqName(Module::class.java.canonicalName)
@@ -73,6 +76,7 @@ internal val daggerDoubleCheckFqNameString = DoubleCheck::class.java.canonicalNa
 
 internal const val HINT_CONTRIBUTES_PACKAGE_PREFIX = "anvil.hint.merge"
 internal const val HINT_BINDING_PACKAGE_PREFIX = "anvil.hint.binding"
+internal const val HINT_MULTIBINDING_PACKAGE_PREFIX = "anvil.hint.multibinding"
 internal const val MODULE_PACKAGE_PREFIX = "anvil.module"
 
 internal const val ANVIL_MODULE_SUFFIX = "AnvilModule"

--- a/compiler/src/main/java/com/squareup/anvil/compiler/Utils.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/Utils.kt
@@ -33,6 +33,7 @@ import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.psi.psiUtil.parentsWithSelf
 import org.jetbrains.kotlin.resolve.DescriptorUtils
 import org.jetbrains.kotlin.resolve.constants.ArrayValue
+import org.jetbrains.kotlin.resolve.constants.BooleanValue
 import org.jetbrains.kotlin.resolve.constants.ConstantValue
 import org.jetbrains.kotlin.resolve.constants.KClassValue
 import org.jetbrains.kotlin.resolve.constants.KClassValue.Value.NormalClass
@@ -209,6 +210,10 @@ internal fun AnnotationDescriptor.boundType(
       "If there are multiple or none, then the bound type must be explicitly defined in " +
       "the @${annotationFqName.shortName()} annotation."
   )
+}
+
+internal fun AnnotationDescriptor.ignoreQualifier(): Boolean {
+  return (getAnnotationValue("ignoreQualifier") as? BooleanValue)?.value ?: false
 }
 
 internal fun KtClassOrObject.generateClassName(

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/BindingModuleGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/BindingModuleGenerator.kt
@@ -22,6 +22,7 @@ import com.squareup.anvil.compiler.contributesToFqName
 import com.squareup.anvil.compiler.daggerModuleFqName
 import com.squareup.anvil.compiler.generateClassName
 import com.squareup.anvil.compiler.getAnnotationValue
+import com.squareup.anvil.compiler.ignoreQualifier
 import com.squareup.anvil.compiler.isQualifier
 import com.squareup.anvil.compiler.mergeComponentFqName
 import com.squareup.anvil.compiler.mergeModulesFqName
@@ -236,9 +237,13 @@ internal class BindingModuleGenerator(
 
             val concreteType = contributedClass.fqNameSafe
 
-            val qualifiers = contributedClass.annotations
-              .filter { it.isQualifier() }
-              .map { it.toAnnotationSpec(module) }
+            val qualifiers = if (annotation.ignoreQualifier()) {
+              emptyList()
+            } else {
+              contributedClass.annotations
+                .filter { it.isQualifier() }
+                .map { it.toAnnotationSpec(module) }
+            }
 
             if (DescriptorUtils.isObject(contributedClass)) {
               ProviderMethod(

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/BindingModuleGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/BindingModuleGenerator.kt
@@ -6,6 +6,7 @@ import com.squareup.anvil.compiler.AnvilCompilationException
 import com.squareup.anvil.compiler.ClassScanner
 import com.squareup.anvil.compiler.HINT_BINDING_PACKAGE_PREFIX
 import com.squareup.anvil.compiler.HINT_CONTRIBUTES_PACKAGE_PREFIX
+import com.squareup.anvil.compiler.HINT_MULTIBINDING_PACKAGE_PREFIX
 import com.squareup.anvil.compiler.MODULE_PACKAGE_PREFIX
 import com.squareup.anvil.compiler.annotation
 import com.squareup.anvil.compiler.annotationOrNull
@@ -16,6 +17,7 @@ import com.squareup.anvil.compiler.codegen.CodeGenerator.GeneratedFile
 import com.squareup.anvil.compiler.codegen.GeneratedMethod.BindingMethod
 import com.squareup.anvil.compiler.codegen.GeneratedMethod.ProviderMethod
 import com.squareup.anvil.compiler.contributesBindingFqName
+import com.squareup.anvil.compiler.contributesMultibindingFqName
 import com.squareup.anvil.compiler.contributesToFqName
 import com.squareup.anvil.compiler.daggerModuleFqName
 import com.squareup.anvil.compiler.generateClassName
@@ -34,6 +36,7 @@ import com.squareup.kotlinpoet.TypeSpec
 import dagger.Binds
 import dagger.Module
 import dagger.Provides
+import dagger.multibindings.IntoSet
 import org.jetbrains.kotlin.descriptors.ClassDescriptor
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 import org.jetbrains.kotlin.descriptors.resolveClassByFqName
@@ -70,6 +73,7 @@ internal class BindingModuleGenerator(
   private val excludedTypesForScope = mutableMapOf<FqName, List<ClassDescriptor>>()
 
   private val contributedBindingClasses = mutableListOf<FqName>()
+  private val contributedMultibindingClasses = mutableListOf<FqName>()
   private val contributedModuleAndInterfaceClasses = mutableListOf<FqName>()
 
   override fun generateCode(
@@ -81,7 +85,16 @@ internal class BindingModuleGenerator(
     // It's possible that we use the @ContributesBinding annotation in the module in which we
     // merge components. Remember for which classes a hint was generated and generate a @Binds
     // method for them later.
-    findContributedBindingClasses(module, projectFiles)
+    contributedBindingClasses += findContributedBindingClasses(
+      module = module,
+      projectFiles = projectFiles,
+      hintPackagePrefix = HINT_BINDING_PACKAGE_PREFIX
+    )
+    contributedMultibindingClasses += findContributedBindingClasses(
+      module = module,
+      projectFiles = projectFiles,
+      hintPackagePrefix = HINT_MULTIBINDING_PACKAGE_PREFIX
+    )
 
     val classes = projectFiles.flatMap {
       it.classesAndInnerClasses()
@@ -151,29 +164,13 @@ internal class BindingModuleGenerator(
     module: ModuleDescriptor
   ): Collection<GeneratedFile> {
     return mergedScopes.flatMap { (scope, daggerModuleFiles) ->
-      val contributedBindingsThisModule = contributedBindingClasses
-        .asSequence()
-        .mapNotNull { clazz ->
-          module.resolveClassByFqName(clazz, NoLookupLocation.FROM_BACKEND)
-        }
-      val contributedBindingsDependencies = classScanner.findContributedClasses(
-        module,
-        packageName = HINT_BINDING_PACKAGE_PREFIX,
-        annotation = contributesBindingFqName,
-        scope = scope
-      )
-
-      val replacedBindings = (contributedBindingsThisModule + contributedBindingsDependencies)
-        .flatMap {
-          it.annotationOrNull(contributesBindingFqName, scope = scope)
-            ?.replaces(module)
-            ?.asSequence()
-            ?: emptySequence()
-        }
-
       // Contributed Dagger modules can replace other Dagger modules but also contributed bindings.
       // If a binding is replaced, then we must not generate the binding method.
-      val bindingsReplacedInDaggerModules = contributedModuleAndInterfaceClasses.asSequence()
+      //
+      // We precompute this list here and share the result in the methods below. Resolving classes
+      // and types can be an expensive operation, so avoid doing it twice.
+      val bindingsReplacedInDaggerModules = contributedModuleAndInterfaceClasses
+        .asSequence()
         .mapNotNull { module.resolveClassByFqName(it, NoLookupLocation.FROM_BACKEND) }
         .plus(
           classScanner.findContributedClasses(
@@ -190,67 +187,131 @@ internal class BindingModuleGenerator(
             ?.asSequence()
             ?: emptySequence()
         }
-
-      val generatedMethods = (contributedBindingsThisModule + contributedBindingsDependencies)
-        .minus(replacedBindings)
-        .minus(bindingsReplacedInDaggerModules)
-        .minus(excludedTypesForScope[scope].orEmpty())
-        .filter {
-          val annotation = it.annotationOrNull(contributesBindingFqName)
-          annotation != null && scope == annotation.scope(module).fqNameSafe
-        }
-        .map { contributedClass ->
-          val annotation = contributedClass.annotation(contributesBindingFqName)
-          val boundType = annotation.boundType(module, contributedClass)
-
-          checkExtendsBoundType(type = contributedClass, boundType = boundType)
-          checkNotGeneric(type = contributedClass, boundTypeDescriptor = boundType)
-
-          val concreteType = contributedClass.fqNameSafe
-
-          val qualifiers = contributedClass.annotations
-            .filter { it.isQualifier() }
-            .map { it.toAnnotationSpec(module) }
-
-          if (DescriptorUtils.isObject(contributedClass)) {
-            ProviderMethod(
-              FunSpec
-                .builder(
-                  name = concreteType
-                    .asString()
-                    .split(".")
-                    .joinToString(separator = "", prefix = "provide") {
-                      it.capitalize(US)
-                    }
-                )
-                .addAnnotation(Provides::class)
-                .addAnnotations(qualifiers)
-                .returns(boundType.asClassName())
-                .addStatement("return %T", contributedClass.asClassName())
-                .build()
-            )
-          } else {
-            BindingMethod(
-              FunSpec
-                .builder(
-                  name = concreteType
-                    .asString()
-                    .split(".")
-                    .joinToString(separator = "", prefix = "bind") { it.capitalize(US) }
-                )
-                .addAnnotation(Binds::class)
-                .addAnnotations(qualifiers)
-                .addModifiers(ABSTRACT)
-                .addParameter(
-                  name = concreteType.shortName().asString().decapitalize(US),
-                  type = contributedClass.asClassName()
-                )
-                .returns(boundType.asClassName())
-                .build()
-            )
-          }
-        }
         .toList()
+
+      // Note that this is an inner function to share some of the parameters. It computes all
+      // generated functions for contributed bindings and multibindings. The generated functions
+      // are so similar that it makes sense to share the code between normal binding and
+      // multibinding methods.
+      fun getContributedBindingClasses(
+        collectedClasses: List<FqName>,
+        hintPackagePrefix: String,
+        annotationFqName: FqName,
+        isMultibinding: Boolean
+      ): List<GeneratedMethod> {
+        val contributedBindingsThisModule = collectedClasses
+          .asSequence()
+          .mapNotNull { clazz ->
+            module.resolveClassByFqName(clazz, NoLookupLocation.FROM_BACKEND)
+          }
+        val contributedBindingsDependencies = classScanner.findContributedClasses(
+          module,
+          packageName = hintPackagePrefix,
+          annotation = annotationFqName,
+          scope = scope
+        )
+
+        val replacedBindings = (contributedBindingsThisModule + contributedBindingsDependencies)
+          .flatMap {
+            it.annotationOrNull(annotationFqName, scope = scope)
+              ?.replaces(module)
+              ?.asSequence()
+              ?: emptySequence()
+          }
+
+        return (contributedBindingsThisModule + contributedBindingsDependencies)
+          .minus(replacedBindings)
+          .minus(bindingsReplacedInDaggerModules)
+          .minus(excludedTypesForScope[scope].orEmpty())
+          .filter {
+            val annotation = it.annotationOrNull(annotationFqName)
+            annotation != null && scope == annotation.scope(module).fqNameSafe
+          }
+          .map { contributedClass ->
+            val annotation = contributedClass.annotation(annotationFqName)
+            val boundType = annotation.boundType(module, contributedClass, isMultibinding)
+
+            checkExtendsBoundType(type = contributedClass, boundType = boundType)
+            checkNotGeneric(type = contributedClass, boundTypeDescriptor = boundType)
+
+            val concreteType = contributedClass.fqNameSafe
+
+            val qualifiers = contributedClass.annotations
+              .filter { it.isQualifier() }
+              .map { it.toAnnotationSpec(module) }
+
+            if (DescriptorUtils.isObject(contributedClass)) {
+              ProviderMethod(
+                FunSpec
+                  .builder(
+                    name = concreteType
+                      .asString()
+                      .split(".")
+                      .joinToString(
+                        separator = "",
+                        prefix = "provide",
+                        postfix = if (isMultibinding) "Multi" else ""
+                      ) {
+                        it.capitalize(US)
+                      }
+                  )
+                  .addAnnotation(Provides::class)
+                  .apply {
+                    if (isMultibinding) {
+                      addAnnotation(IntoSet::class)
+                    }
+                  }
+                  .addAnnotations(qualifiers)
+                  .returns(boundType.asClassName())
+                  .addStatement("return %T", contributedClass.asClassName())
+                  .build()
+              )
+            } else {
+              BindingMethod(
+                FunSpec
+                  .builder(
+                    name = concreteType
+                      .asString()
+                      .split(".")
+                      .joinToString(
+                        separator = "",
+                        prefix = "bind",
+                        postfix = if (isMultibinding) "Multi" else ""
+                      ) {
+                        it.capitalize(US)
+                      }
+                  )
+                  .addAnnotation(Binds::class)
+                  .apply {
+                    if (isMultibinding) {
+                      addAnnotation(IntoSet::class)
+                    }
+                  }
+                  .addAnnotations(qualifiers)
+                  .addModifiers(ABSTRACT)
+                  .addParameter(
+                    name = concreteType.shortName().asString().decapitalize(US),
+                    type = contributedClass.asClassName()
+                  )
+                  .returns(boundType.asClassName())
+                  .build()
+              )
+            }
+          }
+          .toList()
+      }
+
+      val generatedMethods = getContributedBindingClasses(
+        collectedClasses = contributedBindingClasses,
+        hintPackagePrefix = HINT_BINDING_PACKAGE_PREFIX,
+        annotationFqName = contributesBindingFqName,
+        isMultibinding = false
+      ) + getContributedBindingClasses(
+        collectedClasses = contributedMultibindingClasses,
+        hintPackagePrefix = HINT_MULTIBINDING_PACKAGE_PREFIX,
+        annotationFqName = contributesMultibindingFqName,
+        isMultibinding = true
+      )
 
       daggerModuleFiles.map { (file, psiClass) ->
         val content = daggerModuleContent(
@@ -295,11 +356,12 @@ internal class BindingModuleGenerator(
 
   private fun findContributedBindingClasses(
     module: ModuleDescriptor,
-    projectFiles: Collection<KtFile>
-  ) {
-    contributedBindingClasses += projectFiles
+    projectFiles: Collection<KtFile>,
+    hintPackagePrefix: String
+  ): List<FqName> {
+    return projectFiles
       .filter {
-        it.packageFqName.asString().startsWith(HINT_BINDING_PACKAGE_PREFIX)
+        it.packageFqName.asString().startsWith(hintPackagePrefix)
       }
       .flatMap {
         it.findChildrenByClass(KtProperty::class.java).toList()

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesMultibindingGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesMultibindingGenerator.kt
@@ -1,0 +1,78 @@
+package com.squareup.anvil.compiler.codegen
+
+import com.squareup.anvil.compiler.HINT_MULTIBINDING_PACKAGE_PREFIX
+import com.squareup.anvil.compiler.REFERENCE_SUFFIX
+import com.squareup.anvil.compiler.SCOPE_SUFFIX
+import com.squareup.anvil.compiler.codegen.CodeGenerator.GeneratedFile
+import com.squareup.anvil.compiler.contributesMultibindingFqName
+import com.squareup.kotlinpoet.FileSpec
+import com.squareup.kotlinpoet.KModifier.PUBLIC
+import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import com.squareup.kotlinpoet.PropertySpec
+import com.squareup.kotlinpoet.asClassName
+import org.jetbrains.kotlin.descriptors.ModuleDescriptor
+import org.jetbrains.kotlin.psi.KtFile
+import java.io.File
+import kotlin.reflect.KClass
+
+/**
+ * Generates a hint for each contributed class in the `anvil.hint.multibinding` package. This
+ * allows the compiler plugin to find all contributed multibindings a lot faster when merging
+ * modules and component interfaces.
+ */
+internal class ContributesMultibindingGenerator : CodeGenerator {
+  override fun generateCode(
+    codeGenDir: File,
+    module: ModuleDescriptor,
+    projectFiles: Collection<KtFile>
+  ): Collection<GeneratedFile> {
+    return projectFiles.asSequence()
+      .flatMap { it.classesAndInnerClasses() }
+      .filter { it.hasAnnotation(contributesMultibindingFqName) }
+      .onEach { clazz ->
+        clazz.checkClassIsPublic()
+        clazz.checkNotMoreThanOneQualifier(module, contributesMultibindingFqName)
+      }
+      .map { clazz ->
+        val generatedPackage =
+          "$HINT_MULTIBINDING_PACKAGE_PREFIX.${clazz.containingKtFile.packageFqName}"
+        val className = clazz.asClassName()
+        val classFqName = clazz.requireFqName().toString()
+        val propertyName = classFqName.replace('.', '_')
+        val scope = clazz.scope(contributesMultibindingFqName, module).asClassName(module)
+
+        val content =
+          FileSpec.buildFile(generatedPackage, propertyName) {
+            addProperty(
+              PropertySpec
+                .builder(
+                  name = propertyName + REFERENCE_SUFFIX,
+                  type = KClass::class.asClassName().parameterizedBy(className)
+                )
+                .initializer("%T::class", className)
+                .addModifiers(PUBLIC)
+                .build()
+            )
+
+            addProperty(
+              PropertySpec
+                .builder(
+                  name = propertyName + SCOPE_SUFFIX,
+                  type = KClass::class.asClassName().parameterizedBy(scope)
+                )
+                .initializer("%T::class", scope)
+                .addModifiers(PUBLIC)
+                .build()
+            )
+          }
+
+        createGeneratedFile(
+          codeGenDir = codeGenDir,
+          packageName = generatedPackage,
+          fileName = propertyName,
+          content = content
+        )
+      }
+      .toList()
+  }
+}

--- a/compiler/src/test/java/com/squareup/anvil/compiler/TestUtils.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/TestUtils.kt
@@ -134,26 +134,30 @@ internal val Result.anyQualifier: Class<*>
   get() = classLoader.loadClass("com.squareup.test.AnyQualifier")
 
 internal val Class<*>.hintContributes: KClass<*>?
-  get() = contributedProperties(HINT_CONTRIBUTES_PACKAGE_PREFIX)
-    ?.filter { it.java == this }
-    ?.also { assertThat(it.size).isEqualTo(1) }
-    ?.first()
+  get() = getHint(HINT_CONTRIBUTES_PACKAGE_PREFIX)
 
 internal val Class<*>.hintContributesScope: KClass<*>?
-  get() = contributedProperties(HINT_CONTRIBUTES_PACKAGE_PREFIX)
-    ?.also { assertThat(it.size).isEqualTo(2) }
-    ?.filter { it.java != this }
-    ?.also { assertThat(it.size).isEqualTo(1) }
-    ?.first()
+  get() = getHintScope(HINT_CONTRIBUTES_PACKAGE_PREFIX)
 
 internal val Class<*>.hintBinding: KClass<*>?
-  get() = contributedProperties(HINT_BINDING_PACKAGE_PREFIX)
-    ?.filter { it.java == this }
-    ?.also { assertThat(it.size).isEqualTo(1) }
-    ?.first()
+  get() = getHint(HINT_BINDING_PACKAGE_PREFIX)
 
 internal val Class<*>.hintBindingScope: KClass<*>?
-  get() = contributedProperties(HINT_BINDING_PACKAGE_PREFIX)
+  get() = getHintScope(HINT_BINDING_PACKAGE_PREFIX)
+
+internal val Class<*>.hintMultibinding: KClass<*>?
+  get() = getHint(HINT_MULTIBINDING_PACKAGE_PREFIX)
+
+internal val Class<*>.hintMultibindingScope: KClass<*>?
+  get() = getHintScope(HINT_MULTIBINDING_PACKAGE_PREFIX)
+
+private fun Class<*>.getHint(prefix: String): KClass<*>? = contributedProperties(prefix)
+  ?.filter { it.java == this }
+  ?.also { assertThat(it.size).isEqualTo(1) }
+  ?.first()
+
+private fun Class<*>.getHintScope(prefix: String): KClass<*>? =
+  contributedProperties(prefix)
     ?.also { assertThat(it.size).isEqualTo(2) }
     ?.filter { it.java != this }
     ?.also { assertThat(it.size).isEqualTo(1) }

--- a/compiler/src/test/java/com/squareup/anvil/compiler/codegen/BindingModuleMultibindingSetTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/codegen/BindingModuleMultibindingSetTest.kt
@@ -1,0 +1,429 @@
+package com.squareup.anvil.compiler.codegen
+
+import com.google.common.truth.Truth.assertThat
+import com.squareup.anvil.annotations.MergeComponent
+import com.squareup.anvil.annotations.MergeSubcomponent
+import com.squareup.anvil.annotations.compat.MergeModules
+import com.squareup.anvil.compiler.AnyDaggerComponent
+import com.squareup.anvil.compiler.anyDaggerComponent
+import com.squareup.anvil.compiler.compile
+import com.squareup.anvil.compiler.componentInterface
+import com.squareup.anvil.compiler.componentInterfaceAnvilModule
+import com.squareup.anvil.compiler.contributingInterface
+import com.squareup.anvil.compiler.daggerModule
+import com.squareup.anvil.compiler.isAbstract
+import com.squareup.anvil.compiler.parentInterface
+import com.squareup.anvil.compiler.secondContributingInterface
+import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.COMPILATION_ERROR
+import dagger.Binds
+import dagger.Provides
+import dagger.multibindings.IntoSet
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import org.junit.runners.Parameterized.Parameters
+import kotlin.reflect.KClass
+
+@RunWith(Parameterized::class)
+class BindingModuleMultibindingSetTest(
+  private val annotationClass: KClass<*>
+) {
+
+  private val annotation = "@${annotationClass.simpleName}"
+  private val import = "import ${annotationClass.java.canonicalName}"
+
+  companion object {
+    @Parameters(name = "{0}")
+    @JvmStatic fun annotationClasses(): Collection<Any> {
+      return listOf(MergeComponent::class, MergeSubcomponent::class, MergeModules::class)
+    }
+  }
+
+  @Test fun `the Dagger multibinding method is generated for non-objects`() {
+    compile(
+      """
+      package com.squareup.test
+
+      import com.squareup.anvil.annotations.ContributesMultibinding
+      $import
+
+      interface ParentInterface
+
+      interface Middle : ParentInterface
+
+      @ContributesMultibinding(Any::class, ParentInterface::class)
+      interface ContributingInterface : Middle
+
+      $annotation(Any::class)
+      interface ComponentInterface
+      """
+    ) {
+      val modules = if (annotationClass == MergeModules::class) {
+        componentInterface.daggerModule.includes.toList()
+      } else {
+        componentInterface.anyDaggerComponent.modules
+      }
+
+      val methods = modules.single().java.declaredMethods
+      assertThat(methods).hasLength(1)
+
+      with(methods[0]) {
+        assertThat(returnType).isEqualTo(parentInterface)
+        assertThat(parameterTypes.toList()).containsExactly(contributingInterface)
+        assertThat(isAbstract).isTrue()
+        assertThat(isAnnotationPresent(Binds::class.java)).isTrue()
+        assertThat(isAnnotationPresent(IntoSet::class.java)).isTrue()
+      }
+    }
+  }
+
+  @Test fun `the Dagger provider method is generated for objects`() {
+    compile(
+      """
+      package com.squareup.test
+
+      import com.squareup.anvil.annotations.ContributesMultibinding
+      $import
+
+      interface ParentInterface
+
+      interface Middle : ParentInterface
+
+      @ContributesMultibinding(Any::class, ParentInterface::class)
+      object ContributingInterface : Middle
+
+      $annotation(Any::class)
+      interface ComponentInterface
+      """
+    ) {
+      val modules = if (annotationClass == MergeModules::class) {
+        componentInterface.daggerModule.includes.toList()
+      } else {
+        componentInterface.anyDaggerComponent.modules
+      }
+      assertThat(modules).containsExactly(componentInterfaceAnvilModule.kotlin)
+
+      val methods = modules.single().java.declaredMethods
+      assertThat(methods).hasLength(1)
+
+      with(methods[0]) {
+        assertThat(returnType).isEqualTo(parentInterface)
+        assertThat(parameterTypes.toList()).isEmpty()
+        assertThat(isAbstract).isFalse()
+        assertThat(isAnnotationPresent(Provides::class.java)).isTrue()
+        assertThat(isAnnotationPresent(IntoSet::class.java)).isTrue()
+
+        val moduleInstance = modules.first().java.declaredFields
+          .first { it.name == "INSTANCE" }
+          .get(null)
+
+        assertThat(invoke(moduleInstance)::class.java.canonicalName)
+          .isEqualTo("com.squareup.test.ContributingInterface")
+      }
+    }
+  }
+
+  // TODO: move this test?
+  @Test fun `the bound type is implied when there is only one super type`() {
+    compile(
+      """
+      package com.squareup.test
+
+      import com.squareup.anvil.annotations.ContributesMultibinding
+      $import
+
+      interface ParentInterface
+
+      @ContributesMultibinding(Any::class)
+      interface ContributingInterface : ParentInterface
+
+      $annotation(Any::class)
+      interface ComponentInterface
+      """
+    ) {
+      val modules = if (annotationClass == MergeModules::class) {
+        componentInterface.daggerModule.includes.toList()
+      } else {
+        componentInterface.anyDaggerComponent.modules
+      }
+
+      val methods = modules.single().java.declaredMethods
+      assertThat(methods).hasLength(1)
+
+      with(methods[0]) {
+        assertThat(returnType).isEqualTo(parentInterface)
+        assertThat(parameterTypes.toList()).containsExactly(contributingInterface)
+        assertThat(isAbstract).isTrue()
+        assertThat(isAnnotationPresent(Binds::class.java)).isTrue()
+        assertThat(isAnnotationPresent(IntoSet::class.java)).isTrue()
+      }
+    }
+  }
+
+  // TODO: move this test
+  @Test fun `the bound type can only be implied with one super type (2 interfaces)`() {
+    compile(
+      """
+      package com.squareup.test
+
+      import com.squareup.anvil.annotations.ContributesMultibinding
+      $import
+
+      interface ParentInterface
+
+      @ContributesMultibinding(Any::class)
+      interface ContributingInterface : ParentInterface, CharSequence
+
+      $annotation(Any::class)
+      interface ComponentInterface
+      """
+    ) {
+      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+
+      assertThat(messages).contains("Source.kt: (9, 11)")
+      assertThat(messages).contains(
+        "com.squareup.test.ContributingInterface contributes a binding, but does not specify " +
+          "the bound type. This is only allowed with exactly one direct super type. If there " +
+          "are multiple or none, then the bound type must be explicitly defined in the " +
+          "@ContributesMultibinding annotation."
+      )
+    }
+  }
+
+  // TODO: move this test
+  @Test fun `the bound type can only be implied with one super type (class and interface)`() {
+    compile(
+      """
+      package com.squareup.test
+
+      import com.squareup.anvil.annotations.ContributesMultibinding
+      $import
+
+      interface ParentInterface
+
+      open class Abc
+
+      @ContributesMultibinding(Any::class)
+      interface ContributingInterface : Abc(), ParentInterface
+
+      $annotation(Any::class)
+      interface ComponentInterface
+      """
+    ) {
+      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+
+      assertThat(messages).contains("Source.kt: (11, 11)")
+      assertThat(messages).contains(
+        "com.squareup.test.ContributingInterface contributes a binding, but does not specify " +
+          "the bound type. This is only allowed with exactly one direct super type. If there " +
+          "are multiple or none, then the bound type must be explicitly defined in the " +
+          "@ContributesMultibinding annotation."
+      )
+    }
+  }
+
+  // TODO: move this test
+  @Test fun `the bound type can only be implied with one super type (no super type)`() {
+    compile(
+      """
+      package com.squareup.test
+
+      import com.squareup.anvil.annotations.ContributesMultibinding
+      $import
+
+      @ContributesMultibinding(Any::class)
+      object ContributingInterface
+
+      $annotation(Any::class)
+      interface ComponentInterface
+      """
+    ) {
+      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+
+      assertThat(messages).contains("Source.kt: (7, 1)")
+      assertThat(messages).contains(
+        "com.squareup.test.ContributingInterface contributes a binding, but does not specify " +
+          "the bound type. This is only allowed with exactly one direct super type. If there " +
+          "are multiple or none, then the bound type must be explicitly defined in the " +
+          "@ContributesMultibinding annotation."
+      )
+    }
+  }
+
+  // TODO: move this test
+  @Test fun `the contributed multibinding class must extend the bound type`() {
+    compile(
+      """
+      package com.squareup.test
+
+      import com.squareup.anvil.annotations.ContributesMultibinding
+      $import
+
+      interface ParentInterface
+
+      @ContributesMultibinding(Any::class, ParentInterface::class)
+      interface ContributingInterface
+
+      $annotation(Any::class)
+      interface ComponentInterface
+      """
+    ) {
+      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+
+      assertThat(messages).contains("Source.kt: (9, 11)")
+      assertThat(messages).contains(
+        "com.squareup.test.ContributingInterface contributes a binding for " +
+          "com.squareup.test.ParentInterface, but doesn't extend this type."
+      )
+    }
+  }
+
+  @Test fun `contributed multibindings can replace other contributed multibindings`() {
+    compile(
+      """
+      package com.squareup.test
+
+      import com.squareup.anvil.annotations.ContributesMultibinding
+      $import
+
+      interface ParentInterface
+
+      @ContributesMultibinding(Any::class)
+      interface ContributingInterface : ParentInterface
+
+      @ContributesMultibinding(
+          Any::class,
+          replaces = [ContributingInterface::class]
+      )
+      interface SecondContributingInterface : ParentInterface
+
+      $annotation(Any::class)
+      interface ComponentInterface
+      """
+    ) {
+      val modules = if (annotationClass == MergeModules::class) {
+        componentInterface.daggerModule.includes.toList()
+      } else {
+        componentInterface.anyDaggerComponent.modules
+      }
+      assertThat(modules).containsExactly(componentInterfaceAnvilModule.kotlin)
+
+      val methods = modules.first().java.declaredMethods
+      assertThat(methods).hasLength(1)
+
+      with(methods[0]) {
+        assertThat(returnType).isEqualTo(parentInterface)
+        assertThat(parameterTypes.toList()).containsExactly(secondContributingInterface)
+        assertThat(isAbstract).isTrue()
+        assertThat(isAnnotationPresent(Binds::class.java)).isTrue()
+        assertThat(isAnnotationPresent(IntoSet::class.java)).isTrue()
+      }
+    }
+  }
+
+  @Test fun `contributed multibindings for an object can replace other contributed bindings`() {
+    compile(
+      """
+      package com.squareup.test
+
+      import com.squareup.anvil.annotations.ContributesMultibinding
+      $import
+
+      interface ParentInterface
+
+      @ContributesMultibinding(Any::class)
+      interface ContributingInterface : ParentInterface
+
+      @ContributesMultibinding(
+          Any::class,
+          replaces = [ContributingInterface::class]
+      )
+      object SecondContributingInterface : ParentInterface
+
+      $annotation(Any::class)
+      interface ComponentInterface
+      """
+    ) {
+      val modules = if (annotationClass == MergeModules::class) {
+        componentInterface.daggerModule.includes.toList()
+      } else {
+        componentInterface.anyDaggerComponent.modules
+      }
+      assertThat(modules).containsExactly(componentInterfaceAnvilModule.kotlin)
+
+      val methods = modules.first().java.declaredMethods
+      assertThat(methods).hasLength(1)
+
+      with(methods[0]) {
+        assertThat(returnType).isEqualTo(parentInterface)
+        assertThat(parameterTypes.toList()).isEmpty()
+        assertThat(isAbstract).isFalse()
+        assertThat(isAnnotationPresent(Provides::class.java)).isTrue()
+        assertThat(isAnnotationPresent(IntoSet::class.java)).isTrue()
+      }
+    }
+  }
+
+  @Test fun `the contributed multibinding class must not have a generic type parameter`() {
+    compile(
+      """
+      package com.squareup.test
+
+      import com.squareup.anvil.annotations.ContributesMultibinding
+      $import
+
+      interface ParentInterface<T, S>
+
+      class SomeOtherType
+
+      @ContributesMultibinding(Any::class, ParentInterface::class)
+      interface ContributingInterface :
+              ParentInterface<Map<String, List<Pair<String, Int>>>, SomeOtherType>
+
+      $annotation(Any::class)
+      interface ComponentInterface
+      """
+    ) {
+      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+
+      assertThat(messages).contains("Source.kt: (6, 11)")
+      assertThat(messages).contains(
+        "Binding com.squareup.test.ParentInterface contains type parameters(s)" +
+          " <Map<String, List<Pair<String, Int>>>, SomeOtherType>"
+      )
+    }
+  }
+
+  @Test fun `you can contribute bindings and multibindings at the same time`() {
+    compile(
+      """
+      package com.squareup.test
+
+      import com.squareup.anvil.annotations.ContributesBinding
+      import com.squareup.anvil.annotations.ContributesMultibinding
+      $import
+
+      interface ParentInterface
+
+      @ContributesBinding(Any::class)
+      @ContributesMultibinding(Any::class)
+      interface ContributingInterface : ParentInterface
+
+      $annotation(Any::class)
+      interface ComponentInterface
+      """
+    ) {
+      val modules = if (annotationClass == MergeModules::class) {
+        componentInterface.daggerModule.includes.toList()
+      } else {
+        componentInterface.anyDaggerComponent.modules
+      }
+
+      val methods = modules.single().java.declaredMethods
+      assertThat(methods).hasLength(2)
+    }
+  }
+
+  private val Class<*>.anyDaggerComponent: AnyDaggerComponent
+    get() = anyDaggerComponent(annotationClass)
+}

--- a/compiler/src/test/java/com/squareup/anvil/compiler/codegen/BindingModuleQualifierTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/codegen/BindingModuleQualifierTest.kt
@@ -12,6 +12,7 @@ import com.squareup.anvil.compiler.isAbstract
 import com.squareup.anvil.compiler.parentInterface
 import dagger.Binds
 import dagger.Provides
+import dagger.multibindings.IntoSet
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
@@ -69,6 +70,41 @@ class BindingModuleQualifierTest(
     }
   }
 
+  @Test fun `the Dagger multibinding method has a qualifier without parameter`() {
+    compile(
+      """
+      package com.squareup.test
+      
+      import com.squareup.anvil.annotations.ContributesMultibinding
+      import javax.inject.Qualifier
+      $import
+      
+      @Qualifier
+      annotation class AnyQualifier
+
+      interface ParentInterface
+      
+      @ContributesMultibinding(Any::class)
+      @AnyQualifier
+      interface ContributingInterface : ParentInterface
+      
+      $annotation(Any::class)
+      interface ComponentInterface
+      """
+    ) {
+      val bindingMethod = componentInterfaceAnvilModule.declaredMethods.single()
+
+      with(bindingMethod) {
+        assertThat(returnType).isEqualTo(parentInterface)
+        assertThat(parameterTypes.toList()).containsExactly(contributingInterface)
+        assertThat(isAbstract).isTrue()
+
+        assertThat(annotations.map { it.annotationClass })
+          .containsExactly(Binds::class, IntoSet::class, anyQualifier.kotlin)
+      }
+    }
+  }
+
   @Test fun `the Dagger provider method for an object has a qualifier`() {
     compile(
       """
@@ -100,6 +136,41 @@ class BindingModuleQualifierTest(
 
         assertThat(annotations.map { it.annotationClass })
           .containsExactly(Provides::class, anyQualifier.kotlin)
+      }
+    }
+  }
+
+  @Test fun `the Dagger multibind provider method for an object has a qualifier`() {
+    compile(
+      """
+      package com.squareup.test
+      
+      import com.squareup.anvil.annotations.ContributesMultibinding
+      import javax.inject.Qualifier
+      $import
+      
+      @Qualifier
+      annotation class AnyQualifier
+
+      interface ParentInterface
+      
+      @ContributesMultibinding(Any::class)
+      @AnyQualifier
+      object ContributingInterface : ParentInterface
+      
+      $annotation(Any::class)
+      interface ComponentInterface
+      """
+    ) {
+      val bindingMethod = componentInterfaceAnvilModule.declaredMethods.single()
+
+      with(bindingMethod) {
+        assertThat(returnType).isEqualTo(parentInterface)
+        assertThat(parameterTypes.toList()).isEmpty()
+        assertThat(isAbstract).isFalse()
+
+        assertThat(annotations.map { it.annotationClass })
+          .containsExactly(Provides::class, IntoSet::class, anyQualifier.kotlin)
       }
     }
   }
@@ -180,7 +251,7 @@ class BindingModuleQualifierTest(
     }
   }
 
-  @Test fun `the Dagger binding method has a qualifier with an value`() {
+  @Test fun `the Dagger binding method has a qualifier with a value`() {
     compile(
       """
       package com.squareup.test

--- a/compiler/src/test/java/com/squareup/anvil/compiler/codegen/BindingModuleQualifierTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/codegen/BindingModuleQualifierTest.kt
@@ -372,4 +372,64 @@ class BindingModuleQualifierTest(
       }
     }
   }
+
+  @Test fun `the Dagger binding method has no qualifier when disabled`() {
+    compile(
+      """
+      package com.squareup.test
+      
+      import com.squareup.anvil.annotations.ContributesBinding
+      import javax.inject.Qualifier
+      $import
+      
+      @Qualifier
+      annotation class AnyQualifier
+
+      interface ParentInterface
+      
+      @ContributesBinding(Any::class, ignoreQualifier = true)
+      @AnyQualifier
+      interface ContributingInterface : ParentInterface
+      
+      $annotation(Any::class)
+      interface ComponentInterface
+      """
+    ) {
+      val bindingMethod = componentInterfaceAnvilModule.declaredMethods.single()
+      val annotations = bindingMethod.annotations.map { it.annotationClass }
+
+      assertThat(annotations).doesNotContain(anyQualifier.kotlin)
+      assertThat(annotations).contains(Binds::class)
+    }
+  }
+
+  @Test fun `the Dagger multibinding method has no qualifier when disabled`() {
+    compile(
+      """
+      package com.squareup.test
+      
+      import com.squareup.anvil.annotations.ContributesMultibinding
+      import javax.inject.Qualifier
+      $import
+      
+      @Qualifier
+      annotation class AnyQualifier
+
+      interface ParentInterface
+      
+      @ContributesMultibinding(Any::class, ignoreQualifier = true)
+      @AnyQualifier
+      interface ContributingInterface : ParentInterface
+      
+      $annotation(Any::class)
+      interface ComponentInterface
+      """
+    ) {
+      val bindingMethod = componentInterfaceAnvilModule.declaredMethods.single()
+      val annotations = bindingMethod.annotations.map { it.annotationClass }
+
+      assertThat(annotations).doesNotContain(anyQualifier.kotlin)
+      assertThat(annotations).containsAtLeast(Binds::class, IntoSet::class)
+    }
+  }
 }

--- a/compiler/src/test/java/com/squareup/anvil/compiler/codegen/ContributesMultibindingGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/codegen/ContributesMultibindingGeneratorTest.kt
@@ -1,0 +1,187 @@
+package com.squareup.anvil.compiler.codegen
+
+import com.google.common.truth.Truth.assertThat
+import com.squareup.anvil.compiler.compile
+import com.squareup.anvil.compiler.contributingInterface
+import com.squareup.anvil.compiler.hintMultibinding
+import com.squareup.anvil.compiler.hintMultibindingScope
+import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.COMPILATION_ERROR
+import org.junit.Test
+
+class ContributesMultibindingGeneratorTest {
+
+  @Test fun `there is a hint for a contributed multibinding for interfaces`() {
+    compile(
+      """
+      package com.squareup.test
+
+      import com.squareup.anvil.annotations.ContributesMultibinding
+
+      interface ParentInterface
+
+      @ContributesMultibinding(Any::class, ParentInterface::class)
+      interface ContributingInterface : ParentInterface
+      """
+    ) {
+      assertThat(contributingInterface.hintMultibinding?.java).isEqualTo(contributingInterface)
+      assertThat(contributingInterface.hintMultibindingScope).isEqualTo(Any::class)
+    }
+  }
+
+  @Test fun `there is a hint for a contributed multibinding for classes`() {
+    compile(
+      """
+      package com.squareup.test
+
+      import com.squareup.anvil.annotations.ContributesMultibinding
+
+      interface ParentInterface
+
+      @ContributesMultibinding(Any::class, ParentInterface::class)
+      class ContributingInterface : ParentInterface
+      """
+    ) {
+      assertThat(contributingInterface.hintMultibinding?.java).isEqualTo(contributingInterface)
+      assertThat(contributingInterface.hintMultibindingScope).isEqualTo(Any::class)
+    }
+  }
+
+  @Test fun `there is a hint for a contributed multibinding for an object`() {
+    compile(
+      """
+      package com.squareup.test
+
+      import com.squareup.anvil.annotations.ContributesMultibinding
+
+      interface ParentInterface
+
+      @ContributesMultibinding(Any::class, ParentInterface::class)
+      object ContributingInterface : ParentInterface
+      """
+    ) {
+      assertThat(contributingInterface.hintMultibinding?.java).isEqualTo(contributingInterface)
+      assertThat(contributingInterface.hintMultibindingScope).isEqualTo(Any::class)
+    }
+  }
+
+  @Test fun `the order of the scope can be changed with named parameters`() {
+    compile(
+      """
+      package com.squareup.test
+
+      import com.squareup.anvil.annotations.ContributesMultibinding
+
+      interface ParentInterface
+
+      @ContributesMultibinding(boundType = ParentInterface::class, scope = Int::class)
+      class ContributingInterface : ParentInterface
+      """
+    ) {
+      assertThat(contributingInterface.hintMultibindingScope).isEqualTo(Int::class)
+    }
+  }
+
+  @Test fun `there is a hint for a contributed multibinding for inner interfaces`() {
+    compile(
+      """
+      package com.squareup.test
+
+      import com.squareup.anvil.annotations.ContributesMultibinding
+
+      interface ParentInterface
+
+      class Abc {
+        @ContributesMultibinding(Any::class, ParentInterface::class)
+        interface ContributingInterface : ParentInterface
+      }
+      """
+    ) {
+      val contributingInterface =
+        classLoader.loadClass("com.squareup.test.Abc\$ContributingInterface")
+      assertThat(contributingInterface.hintMultibinding?.java).isEqualTo(contributingInterface)
+      assertThat(contributingInterface.hintMultibindingScope).isEqualTo(Any::class)
+    }
+  }
+
+  @Test fun `there is a hint for a contributed multibinding for inner classes`() {
+    compile(
+      """
+      package com.squareup.test
+
+      import com.squareup.anvil.annotations.ContributesMultibinding
+
+      interface ParentInterface
+      
+      class Abc {
+        @ContributesMultibinding(Any::class, ParentInterface::class)
+        class ContributingClass : ParentInterface
+      }
+      """
+    ) {
+      val contributingClass =
+        classLoader.loadClass("com.squareup.test.Abc\$ContributingClass")
+      assertThat(contributingClass.hintMultibinding?.java).isEqualTo(contributingClass)
+      assertThat(contributingClass.hintMultibindingScope).isEqualTo(Any::class)
+    }
+  }
+
+  @Test fun `contributed multibinding class must be public`() {
+    val visibilities = setOf(
+      "internal",
+      "private",
+      "protected"
+    )
+
+    visibilities.forEach { visibility ->
+      compile(
+        """
+        package com.squareup.test
+
+        import com.squareup.anvil.annotations.ContributesMultibinding
+
+        interface ParentInterface
+
+        @ContributesMultibinding(Any::class, ParentInterface::class)
+        $visibility class ContributingInterface : ParentInterface
+        """
+      ) {
+        assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+        // Position to the class.
+        assertThat(messages).contains("Source.kt: (8, ")
+        assertThat(messages).contains(
+          "com.squareup.test.ContributingInterface is binding a type, but the class is not " +
+            "public. Only public types are supported."
+        )
+      }
+    }
+  }
+
+  @Test fun `contributed multibindings aren't allowed to have more than one qualifier`() {
+    compile(
+      """
+      package com.squareup.test
+
+      import com.squareup.anvil.annotations.ContributesMultibinding
+      import javax.inject.Qualifier
+      
+      @Qualifier
+      annotation class AnyQualifier1
+      
+      @Qualifier
+      annotation class AnyQualifier2
+
+      interface ParentInterface
+
+      @ContributesMultibinding(Any::class)
+      @AnyQualifier1 
+      @AnyQualifier2
+      interface ContributingInterface : ParentInterface
+      """
+    ) {
+      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+      assertThat(messages).contains(
+        "Classes annotated with @ContributesMultibinding may not use more than one @Qualifier."
+      )
+    }
+  }
+}

--- a/integration-tests/library/src/main/java/com/squareup/anvil/test/Bindings.kt
+++ b/integration-tests/library/src/main/java/com/squareup/anvil/test/Bindings.kt
@@ -1,6 +1,7 @@
 package com.squareup.anvil.test
 
 import com.squareup.anvil.annotations.ContributesBinding
+import com.squareup.anvil.annotations.ContributesMultibinding
 import javax.inject.Inject
 import javax.inject.Named
 
@@ -12,8 +13,20 @@ public interface MiddleType : ParentType
   scope = AppScope::class,
   boundType = ParentType::class
 )
+@ContributesMultibinding(
+  scope = AppScope::class,
+  boundType = ParentType::class
+)
 public class AppBinding @Inject constructor() : MiddleType
 
 @ContributesBinding(SubScope::class)
+@ContributesMultibinding(SubScope::class, ignoreQualifier = true)
 @Named("middle")
-public object SubcomponentBinding : MiddleType
+public object SubcomponentBinding1 : MiddleType
+
+@ContributesMultibinding(SubScope::class)
+@Named("middle")
+public object SubcomponentBinding2 : MiddleType
+
+@ContributesMultibinding(SubScope::class)
+public object SubcomponentBinding3 : MiddleType

--- a/integration-tests/tests/src/test/java/com/squareup/anvil/test/MergeComponentTest.kt
+++ b/integration-tests/tests/src/test/java/com/squareup/anvil/test/MergeComponentTest.kt
@@ -37,7 +37,17 @@ internal class MergeComponentTest {
 
     assertThat(appComponent.parentType()).isInstanceOf(AppBinding::class.java)
     assertThat(subComponent.parentType()).isInstanceOf(AppBinding::class.java)
-    assertThat(subComponent.middleType()).isInstanceOf(SubcomponentBinding::class.java)
+    assertThat(subComponent.middleType()).isInstanceOf(SubcomponentBinding1::class.java)
+  }
+
+  @Test fun `contributed multibindings bind types for each scope`() {
+    val appComponent = DaggerMergeComponentTest_AppComponent.create()
+    val subComponent = appComponent.subComponent()
+
+    assertThat(appComponent.parentTypes()).hasSize(1)
+    assertThat(subComponent.middleTypes())
+      .containsExactly(SubcomponentBinding1, SubcomponentBinding3)
+    assertThat(subComponent.middleTypesNamed()).containsExactly(SubcomponentBinding2)
   }
 
   @MergeComponent(AppScope::class)
@@ -48,11 +58,15 @@ internal class MergeComponentTest {
     fun parentType(): ParentType
     fun function(): (String) -> Int
     fun charSequence(): CharSequence
+    fun parentTypes(): Set<ParentType>
   }
 
   @MergeSubcomponent(SubScope::class)
   interface SubComponent {
     @Named("middle") fun middleType(): MiddleType
     fun parentType(): ParentType
+
+    fun middleTypes(): Set<MiddleType>
+    @Named("middle") fun middleTypesNamed(): Set<MiddleType>
   }
 }

--- a/integration-tests/tests/src/test/java/com/squareup/anvil/test/MergeModulesTest.kt
+++ b/integration-tests/tests/src/test/java/com/squareup/anvil/test/MergeModulesTest.kt
@@ -33,7 +33,13 @@ internal class MergeModulesTest {
 
     assertThat(appComponent.parentType()).isInstanceOf(AppBinding::class.java)
     assertThat(subComponent.parentType()).isInstanceOf(AppBinding::class.java)
-    assertThat(subComponent.middleType()).isInstanceOf(SubcomponentBinding::class.java)
+    assertThat(subComponent.middleType()).isInstanceOf(SubcomponentBinding1::class.java)
+  }
+
+  @Test fun `contributed multibindings contain the right elements`() {
+    val subComponent = DaggerMergeModulesTest_AppComponent.create().subComponent()
+    assertThat(subComponent.middleTypes())
+      .containsExactly(SubcomponentBinding1, SubcomponentBinding3)
   }
 
   @MergeModules(AppScope::class)
@@ -53,5 +59,6 @@ internal class MergeModulesTest {
   interface SubComponent {
     @Named("middle") fun middleType(): MiddleType
     fun parentType(): ParentType
+    fun middleTypes(): Set<MiddleType>
   }
 }


### PR DESCRIPTION
This will partially resolve #152. This PR adds support for generating multibindings into sets. Generating multibindings for maps will be a separate PR #219. 

This PR is quite large and broken down into smaller commits. There are plenty of tests, which "contributeTo" (Do you see what I did here, yes, I'm very funny) to the size of the PR. In single commits you my find a TODO that is resolved in a later commit or a follow-up PR in #217 or #218. 

From the consumer side contributing multibindings is very similar to bindings and both annotations can be used in conjunction. Qualifiers are supported as well.
```kotlin
@ContributesBinding(SubScope::class)
@ContributesMultibinding(SubScope::class, ignoreQualifier = true)
@Named("middle")
object SomeType : Parent
```