### PR TITLE
Generate multibinding methods for contributed map multibindings. 

### DIFF
--- a/annotations/src/main/java/com/squareup/anvil/annotations/ContributesMultibinding.kt
+++ b/annotations/src/main/java/com/squareup/anvil/annotations/ContributesMultibinding.kt
@@ -50,6 +50,27 @@ import kotlin.reflect.KClass
  * abstract fun bindMainListener(listener: MainListener): Listener
  * ```
  *
+ * To generate a Map multibindings method you need to annotate the class with the map key. Anvil
+ * will use the map key as hint to generate a binding method for a map instead of a set:
+ * ```
+ * @MapKey
+ * annotation class BindingKey(val value: String)
+ *
+ * @ContributesMultibinding(AppScope::class)
+ * @BindingKey("abc")
+ * class MainListener @Inject constructor() : Listener
+ *
+ * // Will generate this binding method.
+ * @Binds @IntoMap @BindingKey("abc")
+ * abstract fun bindMainListener(listener: MainListener): Listener
+ * ```
+ * Note that map keys must allow classes as target. Dagger's built-in keys like `@StringKey` and
+ * `@ClassKey` only allow methods as target and therefore cannot be used with this annotation. It's
+ * recommended to create your own map key annotation class like in the snippet above. Furthermore,
+ * Dagger allows using map keys that are not known at compile time. Anvil doesn't support them
+ * either and it's recommended to contribute a normal Dagger module to the graph instead of using
+ * [ContributesMultibinding].
+ *
  * Contributed multibindings can replace other contributed modules and contributed multibindings
  * with the [replaces] parameter. This is especially helpful for different multibindings in
  * tests.

--- a/compiler/src/main/java/com/squareup/anvil/compiler/Utils.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/Utils.kt
@@ -8,9 +8,9 @@ import com.squareup.anvil.annotations.MergeSubcomponent
 import com.squareup.anvil.annotations.compat.MergeInterfaces
 import com.squareup.anvil.annotations.compat.MergeModules
 import com.squareup.anvil.compiler.codegen.requireFqName
-import dagger.Binds
 import dagger.Component
 import dagger.Lazy
+import dagger.MapKey
 import dagger.Module
 import dagger.Provides
 import dagger.Subcomponent
@@ -61,11 +61,11 @@ internal val contributesMultibindingFqName =
 internal val daggerComponentFqName = FqName(Component::class.java.canonicalName)
 internal val daggerSubcomponentFqName = FqName(Subcomponent::class.java.canonicalName)
 internal val daggerModuleFqName = FqName(Module::class.java.canonicalName)
-internal val daggerBindsFqName = FqName(Binds::class.java.canonicalName)
 internal val daggerProvidesFqName = FqName(Provides::class.java.canonicalName)
 internal val daggerLazyFqName = FqName(Lazy::class.java.canonicalName)
 internal val injectFqName = FqName(Inject::class.java.canonicalName)
 internal val qualifierFqName = FqName(Qualifier::class.java.canonicalName)
+internal val mapKeyFqName = FqName(MapKey::class.java.canonicalName)
 internal val assistedFqName = FqName(Assisted::class.java.canonicalName)
 internal val assistedFactoryFqName = FqName(AssistedFactory::class.java.canonicalName)
 internal val assistedInjectFqName = FqName(AssistedInject::class.java.canonicalName)
@@ -240,6 +240,10 @@ internal fun List<KotlinType>.getAllSuperTypes(): Sequence<FqName> =
 
 internal fun AnnotationDescriptor.isQualifier(): Boolean {
   return annotationClass?.annotations?.hasAnnotation(qualifierFqName) ?: false
+}
+
+internal fun AnnotationDescriptor.isMapKey(): Boolean {
+  return annotationClass?.annotations?.hasAnnotation(mapKeyFqName) ?: false
 }
 
 internal fun AnnotationDescriptor.requireClass(): ClassDescriptor {

--- a/compiler/src/test/java/com/squareup/anvil/compiler/TestUtils.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/TestUtils.kt
@@ -133,6 +133,10 @@ internal val Result.injectClass: Class<*>
 internal val Result.anyQualifier: Class<*>
   get() = classLoader.loadClass("com.squareup.test.AnyQualifier")
 
+@Suppress("UNCHECKED_CAST")
+internal val Result.bindingKey: Class<out Annotation>
+  get() = classLoader.loadClass("com.squareup.test.BindingKey") as Class<out Annotation>
+
 internal val Class<*>.hintContributes: KClass<*>?
   get() = getHint(HINT_CONTRIBUTES_PACKAGE_PREFIX)
 
@@ -246,3 +250,7 @@ internal fun Any.invokeGet(vararg args: Any?): Any {
   val method = this::class.java.declaredMethods.single { it.name == "get" }
   return method.invoke(this, *args)
 }
+
+@Suppress("UNCHECKED_CAST")
+internal fun <T> Annotation.getValue(): T =
+  this::class.java.declaredMethods.single { it.name == "value" }.invoke(this) as T

--- a/compiler/src/test/java/com/squareup/anvil/compiler/codegen/BindingModuleMultibindingMapTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/codegen/BindingModuleMultibindingMapTest.kt
@@ -1,0 +1,295 @@
+package com.squareup.anvil.compiler.codegen
+
+import com.google.common.truth.Truth.assertThat
+import com.squareup.anvil.annotations.MergeComponent
+import com.squareup.anvil.annotations.MergeSubcomponent
+import com.squareup.anvil.annotations.compat.MergeModules
+import com.squareup.anvil.compiler.AnyDaggerComponent
+import com.squareup.anvil.compiler.anyDaggerComponent
+import com.squareup.anvil.compiler.bindingKey
+import com.squareup.anvil.compiler.compile
+import com.squareup.anvil.compiler.componentInterface
+import com.squareup.anvil.compiler.componentInterfaceAnvilModule
+import com.squareup.anvil.compiler.contributingInterface
+import com.squareup.anvil.compiler.daggerModule
+import com.squareup.anvil.compiler.getValue
+import com.squareup.anvil.compiler.isAbstract
+import com.squareup.anvil.compiler.parentInterface
+import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.COMPILATION_ERROR
+import dagger.Binds
+import dagger.Provides
+import dagger.multibindings.IntoMap
+import dagger.multibindings.IntoSet
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import org.junit.runners.Parameterized.Parameters
+import kotlin.reflect.KClass
+
+@RunWith(Parameterized::class)
+class BindingModuleMultibindingMapTest(
+  private val annotationClass: KClass<*>
+) {
+
+  private val annotation = "@${annotationClass.simpleName}"
+  private val import = "import ${annotationClass.java.canonicalName}"
+
+  companion object {
+    @Parameters(name = "{0}")
+    @JvmStatic fun annotationClasses(): Collection<Any> {
+      return listOf(MergeComponent::class, MergeSubcomponent::class, MergeModules::class)
+    }
+  }
+
+  @Test fun `the Dagger multibinding method is generated for non-objects`() {
+    compile(
+      """
+      package com.squareup.test
+
+      import com.squareup.anvil.annotations.ContributesMultibinding
+      import dagger.MapKey
+      $import
+      
+      @MapKey
+      annotation class BindingKey(val value: String)
+
+      interface ParentInterface
+
+      interface Middle : ParentInterface
+
+      @ContributesMultibinding(Any::class, ParentInterface::class)
+      @BindingKey("abc")
+      interface ContributingInterface : Middle
+
+      $annotation(Any::class)
+      interface ComponentInterface
+      """
+    ) {
+      val modules = if (annotationClass == MergeModules::class) {
+        componentInterface.daggerModule.includes.toList()
+      } else {
+        componentInterface.anyDaggerComponent.modules
+      }
+
+      val methods = modules.single().java.declaredMethods
+      assertThat(methods).hasLength(1)
+
+      with(methods[0]) {
+        assertThat(returnType).isEqualTo(parentInterface)
+        assertThat(parameterTypes.toList()).containsExactly(contributingInterface)
+        assertThat(isAbstract).isTrue()
+        assertThat(isAnnotationPresent(Binds::class.java)).isTrue()
+        assertThat(isAnnotationPresent(IntoMap::class.java)).isTrue()
+        assertThat(isAnnotationPresent(IntoSet::class.java)).isFalse()
+        assertThat(isAnnotationPresent(bindingKey)).isTrue()
+        assertThat(getAnnotation(bindingKey).getValue<String>()).isEqualTo("abc")
+      }
+    }
+  }
+
+  @Test fun `the Dagger provider method is generated for objects`() {
+    compile(
+      """
+      package com.squareup.test
+
+      import com.squareup.anvil.annotations.ContributesMultibinding
+      import dagger.MapKey
+      $import
+      
+      @MapKey
+      annotation class BindingKey(val value: String)
+
+      interface ParentInterface
+
+      @ContributesMultibinding(Any::class)
+      @BindingKey("abc")
+      object ContributingInterface : ParentInterface
+
+      $annotation(Any::class)
+      interface ComponentInterface
+      """
+    ) {
+      val modules = if (annotationClass == MergeModules::class) {
+        componentInterface.daggerModule.includes.toList()
+      } else {
+        componentInterface.anyDaggerComponent.modules
+      }
+      assertThat(modules).containsExactly(componentInterfaceAnvilModule.kotlin)
+
+      val methods = modules.single().java.declaredMethods
+      assertThat(methods).hasLength(1)
+
+      with(methods[0]) {
+        assertThat(returnType).isEqualTo(parentInterface)
+        assertThat(parameterTypes.toList()).isEmpty()
+        assertThat(isAbstract).isFalse()
+        assertThat(isAnnotationPresent(Provides::class.java)).isTrue()
+        assertThat(isAnnotationPresent(IntoMap::class.java)).isTrue()
+        assertThat(isAnnotationPresent(bindingKey)).isTrue()
+        assertThat(getAnnotation(bindingKey).getValue<String>()).isEqualTo("abc")
+
+        val moduleInstance = modules.first().java.declaredFields
+          .first { it.name == "INSTANCE" }
+          .get(null)
+
+        assertThat(invoke(moduleInstance)::class.java.canonicalName)
+          .isEqualTo("com.squareup.test.ContributingInterface")
+      }
+    }
+  }
+
+  @Test fun `an enum map key is supported`() {
+    compile(
+      """
+      package com.squareup.test
+
+      import com.squareup.anvil.annotations.ContributesMultibinding
+      import dagger.MapKey
+      $import
+      
+      enum class EnumClass { ABC }
+      
+      @MapKey
+      annotation class BindingKey(val value: EnumClass)
+
+      interface ParentInterface
+
+      @ContributesMultibinding(Any::class)
+      @BindingKey(EnumClass.ABC)
+      interface ContributingInterface : ParentInterface
+
+      $annotation(Any::class)
+      interface ComponentInterface
+      """
+    ) {
+      val modules = if (annotationClass == MergeModules::class) {
+        componentInterface.daggerModule.includes.toList()
+      } else {
+        componentInterface.anyDaggerComponent.modules
+      }
+
+      val methods = modules.single().java.declaredMethods
+      assertThat(methods).hasLength(1)
+
+      assertThat(methods[0].getAnnotation(bindingKey).getValue<Any>().toString()).isEqualTo("ABC")
+    }
+  }
+
+  @Test fun `a class map key is supported`() {
+    compile(
+      """
+      package com.squareup.test
+
+      import com.squareup.anvil.annotations.ContributesMultibinding
+      import dagger.MapKey
+      import kotlin.reflect.KClass
+      $import
+      
+      @MapKey
+      annotation class BindingKey(val value: KClass<*>)
+
+      interface ParentInterface
+
+      @ContributesMultibinding(Any::class)
+      @BindingKey(Unit::class)
+      interface ContributingInterface : ParentInterface
+
+      $annotation(Any::class)
+      interface ComponentInterface
+      """
+    ) {
+      val modules = if (annotationClass == MergeModules::class) {
+        componentInterface.daggerModule.includes.toList()
+      } else {
+        componentInterface.anyDaggerComponent.modules
+      }
+
+      val methods = modules.single().java.declaredMethods
+      assertThat(methods).hasLength(1)
+
+      assertThat(methods[0].getAnnotation(bindingKey).getValue<KClass<*>>())
+        .isEqualTo(Unit::class.java)
+    }
+  }
+
+  @Test fun `a complex map key is supported`() {
+    compile(
+      """
+      package com.squareup.test
+
+      import com.squareup.anvil.annotations.ContributesMultibinding
+      import dagger.MapKey
+      import kotlin.reflect.KClass
+      $import
+      
+      @MapKey(unwrapValue = false)
+      annotation class BindingKey(
+        val name: String,
+        val implementingClass: KClass<*>,
+        val thresholds: IntArray
+      )
+
+      interface ParentInterface
+
+      @ContributesMultibinding(Any::class)
+      @BindingKey("abc", Unit::class, [1, 2, 3])
+      interface ContributingInterface : ParentInterface
+
+      $annotation(Any::class)
+      interface ComponentInterface
+      """
+    ) {
+      val modules = if (annotationClass == MergeModules::class) {
+        componentInterface.daggerModule.includes.toList()
+      } else {
+        componentInterface.anyDaggerComponent.modules
+      }
+
+      val annotation = modules.single().java.declaredMethods.single().getAnnotation(bindingKey)
+      val methods = annotation::class.java.declaredMethods
+
+      assertThat(methods.single { it.name == "name" }.invoke(annotation)).isEqualTo("abc")
+      assertThat(methods.single { it.name == "implementingClass" }.invoke(annotation))
+        .isEqualTo(Unit::class.java)
+      assertThat(methods.single { it.name == "thresholds" }.invoke(annotation) as IntArray)
+        .asList().containsExactly(1, 2, 3).inOrder()
+    }
+  }
+
+  @Test fun `contributed multibindings aren't allowed to have more than one map key`() {
+    compile(
+      """
+      package com.squareup.test
+
+      import com.squareup.anvil.annotations.ContributesMultibinding
+      import dagger.MapKey
+      import kotlin.reflect.KClass
+      $import
+      
+      @MapKey
+      annotation class BindingKey1(val value: KClass<*>)
+      
+      @MapKey
+      annotation class BindingKey2(val value: KClass<*>)
+
+      interface ParentInterface
+
+      @ContributesMultibinding(Any::class)
+      @BindingKey1(Unit::class)
+      @BindingKey2(Unit::class)
+      interface ContributingInterface : ParentInterface
+
+      $annotation(Any::class)
+      interface ComponentInterface
+      """
+    ) {
+      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+      assertThat(messages).contains(
+        "Classes annotated with @ContributesMultibinding may not use more than one @MapKey."
+      )
+    }
+  }
+
+  private val Class<*>.anyDaggerComponent: AnyDaggerComponent
+    get() = anyDaggerComponent(annotationClass)
+}

--- a/integration-tests/library/src/main/java/com/squareup/anvil/test/MapBindings.kt
+++ b/integration-tests/library/src/main/java/com/squareup/anvil/test/MapBindings.kt
@@ -1,0 +1,22 @@
+package com.squareup.anvil.test
+
+import com.squareup.anvil.annotations.ContributesMultibinding
+import dagger.MapKey
+import javax.inject.Named
+
+@MapKey
+public annotation class BindingKey(val value: String)
+
+@ContributesMultibinding(AppScope::class, ignoreQualifier = true)
+@Named("abc")
+@BindingKey("1")
+public object MapBinding1 : ParentType
+
+@ContributesMultibinding(AppScope::class)
+@Named("abc")
+@BindingKey("2")
+public object MapBinding2 : ParentType
+
+@ContributesMultibinding(AppScope::class)
+@BindingKey("3")
+public object MapBinding3 : ParentType

--- a/integration-tests/tests/src/test/java/com/squareup/anvil/test/MergeComponentTest.kt
+++ b/integration-tests/tests/src/test/java/com/squareup/anvil/test/MergeComponentTest.kt
@@ -50,6 +50,13 @@ internal class MergeComponentTest {
     assertThat(subComponent.middleTypesNamed()).containsExactly(SubcomponentBinding2)
   }
 
+  @Test fun `contributed map multibindings are provided`() {
+    val appComponent = DaggerMergeComponentTest_AppComponent.create()
+
+    assertThat(appComponent.mapBindings()).containsExactly("1", MapBinding1, "3", MapBinding3)
+    assertThat(appComponent.mapBindingsNamed()).containsExactly("2", MapBinding2)
+  }
+
   @MergeComponent(AppScope::class)
   @Singleton
   @Suppress("unused")
@@ -59,6 +66,8 @@ internal class MergeComponentTest {
     fun function(): (String) -> Int
     fun charSequence(): CharSequence
     fun parentTypes(): Set<ParentType>
+    fun mapBindings(): Map<String, ParentType>
+    @Named("abc") fun mapBindingsNamed(): Map<String, ParentType>
   }
 
   @MergeSubcomponent(SubScope::class)


### PR DESCRIPTION
If a class is annotated with @ContributesMultibinding and a map key annotation, then Anvil will generate a map multibinding method.

This PR completes #152.