### PR TITLE
Support different priorities for contributed bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * `@ContributesBinding` supports qualifiers now, see the README and documentation for examples.  
 * Upgrade Dagger to `2.32`. Generating factories for assisted injection is no longer compatible with older Dagger versions due to the behavior change in Dagger itself. Make sure to use Dagger version `2.32` or newer in your project, too.
+* `@ContributesBinding` has a priority field now for cases where you don't have access to replaced bindings at compile time, see #161.  
 * Use the mangled function name to generate the factory for a provider method.
 
 ## 2.1.0 (2021-02-05)

--- a/annotations/src/main/java/com/squareup/anvil/annotations/ContributesBinding.kt
+++ b/annotations/src/main/java/com/squareup/anvil/annotations/ContributesBinding.kt
@@ -1,5 +1,6 @@
 package com.squareup.anvil.annotations
 
+import com.squareup.anvil.annotations.ContributesBinding.Priority.NORMAL
 import kotlin.annotation.AnnotationRetention.RUNTIME
 import kotlin.annotation.AnnotationTarget.CLASS
 import kotlin.reflect.KClass
@@ -72,6 +73,10 @@ import kotlin.reflect.KClass
  * )
  * class FakeAuthenticator @Inject constructor() : Authenticator
  * ```
+ * If you don't have access to the class of another contributed binding that you want to replace,
+ * then you can change the [priority] of the bindings to avoid duplicate bindings. The contributed
+ * binding with the higher priority will be used.
+ *
  * [ContributesBinding] supports Kotlin objects, e.g.
  * ```
  * @ContributesBinding(AppScope::class)
@@ -99,10 +104,35 @@ public annotation class ContributesBinding(
    */
   val replaces: Array<KClass<*>> = [],
   /**
+   * The priority of this contributed binding. The priority should be changed only if you don't
+   * have access to the contributed binding class that you want to replace at compile time. If
+   * you have access and can reference the other class, then it's highly suggested to
+   * use [replaces] instead.
+   *
+   * In case of a duplicate binding for multiple contributed bindings the binding with the highest
+   * priority will be used and replace other contributed bindings for the same type with a lower
+   * priority. If duplicate contributed bindings use the same priority, then there will be an
+   * error for duplicate bindings.
+   *
+   * Note that [replaces] takes precedence. If you explicitly replace a binding it won't be
+   * considered no matter what its priority is.
+   *
+   * All contributed bindings have a [NORMAL] priority by default.
+   */
+  val priority: Priority = NORMAL,
+  /**
    * Whether the qualifier for this class should be included in the generated binding method. This
    * parameter is only necessary to use when [ContributesBinding] and [ContributesMultibinding]
    * are used together for the same class. If not, simply remove the qualifier from the class
    * and don't use this parameter.
    */
   val ignoreQualifier: Boolean = false
-)
+) {
+  /**
+   * The priority of a contributed binding.
+   */
+  @Suppress("unused")
+  public enum class Priority {
+    NORMAL, HIGH, HIGHEST
+  }
+}

--- a/compiler/src/main/java/com/squareup/anvil/compiler/Utils.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/Utils.kt
@@ -1,6 +1,7 @@
 package com.squareup.anvil.compiler
 
 import com.squareup.anvil.annotations.ContributesBinding
+import com.squareup.anvil.annotations.ContributesBinding.Priority.NORMAL
 import com.squareup.anvil.annotations.ContributesMultibinding
 import com.squareup.anvil.annotations.ContributesTo
 import com.squareup.anvil.annotations.MergeComponent
@@ -35,6 +36,7 @@ import org.jetbrains.kotlin.resolve.DescriptorUtils
 import org.jetbrains.kotlin.resolve.constants.ArrayValue
 import org.jetbrains.kotlin.resolve.constants.BooleanValue
 import org.jetbrains.kotlin.resolve.constants.ConstantValue
+import org.jetbrains.kotlin.resolve.constants.EnumValue
 import org.jetbrains.kotlin.resolve.constants.KClassValue
 import org.jetbrains.kotlin.resolve.constants.KClassValue.Value.NormalClass
 import org.jetbrains.kotlin.resolve.descriptorUtil.annotationClass
@@ -212,6 +214,11 @@ internal fun AnnotationDescriptor.boundType(
       "If there are multiple or none, then the bound type must be explicitly defined in " +
       "the @${annotationFqName.shortName()} annotation."
   )
+}
+
+internal fun AnnotationDescriptor.priority(): ContributesBinding.Priority {
+  val enumValue = getAnnotationValue("priority") as? EnumValue ?: return NORMAL
+  return ContributesBinding.Priority.valueOf(enumValue.enumEntryName.asString())
 }
 
 internal fun AnnotationDescriptor.ignoreQualifier(): Boolean {

--- a/compiler/src/test/java/com/squareup/anvil/compiler/codegen/BindingModulePriorityTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/codegen/BindingModulePriorityTest.kt
@@ -1,0 +1,158 @@
+package com.squareup.anvil.compiler.codegen
+
+import com.google.common.truth.Truth.assertThat
+import com.squareup.anvil.annotations.MergeComponent
+import com.squareup.anvil.annotations.MergeSubcomponent
+import com.squareup.anvil.annotations.compat.MergeModules
+import com.squareup.anvil.compiler.compile
+import com.squareup.anvil.compiler.componentInterfaceAnvilModule
+import com.squareup.anvil.compiler.contributingInterface
+import com.squareup.anvil.compiler.parentInterface
+import com.squareup.anvil.compiler.secondContributingInterface
+import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.COMPILATION_ERROR
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import org.junit.runners.Parameterized.Parameters
+import kotlin.reflect.KClass
+
+@RunWith(Parameterized::class)
+class BindingModulePriorityTest(
+  annotationClass: KClass<*>
+) {
+
+  private val annotation = "@${annotationClass.simpleName}"
+  private val import = "import ${annotationClass.java.canonicalName}"
+
+  companion object {
+    @Parameters(name = "{0}")
+    @JvmStatic fun annotationClasses(): Collection<Any> {
+      return listOf(MergeComponent::class, MergeSubcomponent::class, MergeModules::class)
+    }
+  }
+
+  @Test fun `the binding with the higher priority is used`() {
+    compile(
+      """
+      package com.squareup.test
+      
+      import com.squareup.anvil.annotations.ContributesBinding
+      import com.squareup.anvil.annotations.ContributesBinding.Priority.HIGH
+      import com.squareup.anvil.annotations.ContributesBinding.Priority.HIGHEST
+      $import
+      
+      interface ParentInterface
+      
+      @ContributesBinding(Any::class, priority = HIGHEST)
+      interface ContributingInterface : ParentInterface
+      
+      @ContributesBinding(Any::class, priority = HIGH)
+      interface ContributingInterface2 : ParentInterface
+      
+      @ContributesBinding(Any::class)
+      interface ContributingInterface3 : ParentInterface
+      
+      $annotation(Any::class)
+      interface ComponentInterface
+      """
+    ) {
+      val bindingMethod = componentInterfaceAnvilModule.declaredMethods.single()
+
+      with(bindingMethod) {
+        assertThat(returnType).isEqualTo(parentInterface)
+        assertThat(parameterTypes.toList()).containsExactly(contributingInterface)
+      }
+    }
+  }
+
+  @Test fun `the binding with the higher priority is used with one replaced binding`() {
+    compile(
+      """
+      package com.squareup.test
+      
+      import com.squareup.anvil.annotations.ContributesBinding
+      import com.squareup.anvil.annotations.ContributesBinding.Priority.HIGH
+      import com.squareup.anvil.annotations.ContributesBinding.Priority.HIGHEST
+      $import
+      
+      interface ParentInterface
+      
+      @ContributesBinding(Any::class, priority = HIGHEST)
+      interface ContributingInterface : ParentInterface
+      
+      @ContributesBinding(Any::class, priority = HIGH, replaces = [ContributingInterface::class])
+      interface SecondContributingInterface : ParentInterface
+      
+      @ContributesBinding(Any::class)
+      interface ContributingInterface3 : ParentInterface
+      
+      $annotation(Any::class)
+      interface ComponentInterface
+      """
+    ) {
+      val bindingMethod = componentInterfaceAnvilModule.declaredMethods.single()
+
+      with(bindingMethod) {
+        assertThat(returnType).isEqualTo(parentInterface)
+        assertThat(parameterTypes.toList()).containsExactly(secondContributingInterface)
+      }
+    }
+  }
+
+  @Test fun `bindings with the same priority throw an error`() {
+    compile(
+      """
+      package com.squareup.test
+      
+      import com.squareup.anvil.annotations.ContributesBinding
+      $import
+      
+      interface ParentInterface
+      
+      @ContributesBinding(Any::class)
+      interface ContributingInterface : ParentInterface
+      
+      @ContributesBinding(Any::class)
+      interface SecondContributingInterface : ParentInterface
+      
+      $annotation(Any::class)
+      interface ComponentInterface
+      """
+    ) {
+      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+
+      assertThat(messages).contains(
+        "There are multiple contributed bindings with the same bound type. The bound type is " +
+          "com.squareup.test.ParentInterface. The contributed binding classes are: ["
+      )
+      // Check the contributed bindings separately, we cannot rely on the order in the string.
+      assertThat(messages).contains("com.squareup.test.ContributingInterface")
+      assertThat(messages).contains("com.squareup.test.SecondContributingInterface")
+    }
+  }
+
+  @Test fun `multiple multibindings with the same type are allowed`() {
+    compile(
+      """
+      package com.squareup.test
+      
+      import com.squareup.anvil.annotations.ContributesMultibinding
+      $import
+      
+      interface ParentInterface
+      
+      @ContributesMultibinding(Any::class)
+      interface ContributingInterface : ParentInterface
+      
+      @ContributesMultibinding(Any::class)
+      interface SecondContributingInterface : ParentInterface
+      
+      $annotation(Any::class)
+      interface ComponentInterface
+      """
+    ) {
+      val bindingMethods = componentInterfaceAnvilModule.declaredMethods
+      assertThat(bindingMethods).hasLength(2)
+    }
+  }
+}

--- a/integration-tests/library/src/main/java/com/squareup/anvil/test/PriorityBindings.kt
+++ b/integration-tests/library/src/main/java/com/squareup/anvil/test/PriorityBindings.kt
@@ -1,0 +1,15 @@
+package com.squareup.anvil.test
+
+import com.squareup.anvil.annotations.ContributesBinding
+import com.squareup.anvil.annotations.ContributesBinding.Priority.HIGH
+
+public interface PriorityBinding
+
+@ContributesBinding(
+  scope = AppScope::class,
+  priority = HIGH
+)
+public object PriorityBindingHigh : PriorityBinding
+
+@ContributesBinding(AppScope::class)
+public object PriorityBindingNormal : PriorityBinding

--- a/integration-tests/tests/src/test/java/com/squareup/anvil/test/MergeComponentTest.kt
+++ b/integration-tests/tests/src/test/java/com/squareup/anvil/test/MergeComponentTest.kt
@@ -57,6 +57,11 @@ internal class MergeComponentTest {
     assertThat(appComponent.mapBindingsNamed()).containsExactly("2", MapBinding2)
   }
 
+  @Test fun `the binding with the highest priority is bound`() {
+    val appComponent = DaggerMergeComponentTest_AppComponent.create()
+    assertThat(appComponent.priorityBinding()).isEqualTo(PriorityBindingHigh)
+  }
+
   @MergeComponent(AppScope::class)
   @Singleton
   @Suppress("unused")
@@ -68,6 +73,7 @@ internal class MergeComponentTest {
     fun parentTypes(): Set<ParentType>
     fun mapBindings(): Map<String, ParentType>
     @Named("abc") fun mapBindingsNamed(): Map<String, ParentType>
+    fun priorityBinding(): PriorityBinding
   }
 
   @MergeSubcomponent(SubScope::class)


### PR DESCRIPTION
Add a priority field to @ContributesBinding to replace other contributed bindings. The priority should only be used, if you don't have access to the replaced class at compile time. Otherwise prefer the `replaces` field.

Fixes #161