### PR TITLE
Fix crashes when classes don't use any package. 

### DIFF
--- a/compiler/src/main/java/com/squareup/anvil/compiler/ClassScanner.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/ClassScanner.kt
@@ -22,7 +22,7 @@ internal class ClassScanner {
     scope: FqName
   ): Sequence<ClassDescriptor> {
     val packageDescriptor = module.getPackage(FqName(packageName))
-    return generateSequence(packageDescriptor.subPackages()) { subPackages ->
+    return generateSequence(listOf(packageDescriptor)) { subPackages ->
       subPackages
         .flatMap { it.subPackages() }
         .ifEmpty { null }

--- a/compiler/src/main/java/com/squareup/anvil/compiler/ModuleMerger.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/ModuleMerger.kt
@@ -272,7 +272,8 @@ internal class ModuleMerger(
   }
 
   private fun createAnvilModuleName(classDescriptor: ClassDescriptor): FqName {
-    val name = "$MODULE_PACKAGE_PREFIX.${classDescriptor.findPackage().fqName}." +
+    val name = "$MODULE_PACKAGE_PREFIX." +
+      classDescriptor.findPackage().fqName.safePackageString() +
       classDescriptor.parentsWithSelf
         .filterIsInstance<ClassDescriptor>()
         .toList()

--- a/compiler/src/main/java/com/squareup/anvil/compiler/ModuleMergerIr.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/ModuleMergerIr.kt
@@ -18,8 +18,8 @@ import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
 import org.jetbrains.kotlin.ir.types.defaultType
 import org.jetbrains.kotlin.ir.types.impl.IrDynamicTypeImpl
 import org.jetbrains.kotlin.ir.util.defaultType
-import org.jetbrains.kotlin.ir.util.getPackageFragment
 import org.jetbrains.kotlin.ir.util.isInterface
+import org.jetbrains.kotlin.ir.util.packageFqName
 import org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.types.Variance.INVARIANT
@@ -274,10 +274,9 @@ internal class ModuleMergerIr(
   }
 
   private fun createAnvilModuleName(declaration: IrClass): FqName {
-    val packageFqName = declaration.getPackageFragment()?.fqName
-    val packageSection = if (packageFqName != null) "$packageFqName." else ""
+    val packageName = declaration.packageFqName?.safePackageString() ?: ""
 
-    val name = "$MODULE_PACKAGE_PREFIX.$packageSection" +
+    val name = "$MODULE_PACKAGE_PREFIX.$packageName" +
       declaration.parentsWithSelf
         .filterIsInstance<IrClass>()
         .toList()

--- a/compiler/src/main/java/com/squareup/anvil/compiler/Utils.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/Utils.kt
@@ -258,3 +258,21 @@ internal fun AnnotationDescriptor.requireClass(): ClassDescriptor {
     message = "Couldn't find the annotation class for $fqName",
   )
 }
+
+/**
+ * This function should only be used for package names. If the FqName is the root (no package at
+ * all), then this function returns an empty string whereas `toString()` would return "<root>". For
+ * a more convenient string concatenation the returned result can be prefixed and suffixed with an
+ * additional dot. The root package never will use a prefix or suffix.
+ */
+internal fun FqName.safePackageString(
+  dotPrefix: Boolean = false,
+  dotSuffix: Boolean = true
+): String =
+  if (isRoot) {
+    ""
+  } else {
+    val prefix = if (dotPrefix) "." else ""
+    val suffix = if (dotSuffix) "." else ""
+    "$prefix$this$suffix"
+  }

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/BindingModuleGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/BindingModuleGenerator.kt
@@ -31,6 +31,7 @@ import com.squareup.anvil.compiler.mergeModulesFqName
 import com.squareup.anvil.compiler.mergeSubcomponentFqName
 import com.squareup.anvil.compiler.priority
 import com.squareup.anvil.compiler.replaces
+import com.squareup.anvil.compiler.safePackageString
 import com.squareup.anvil.compiler.scope
 import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.FileSpec
@@ -440,8 +441,8 @@ internal class BindingModuleGenerator(
   private fun KtClassOrObject.generateClassName(): String =
     generateClassName(separator = "") + ANVIL_MODULE_SUFFIX
 
-  private fun generatePackageName(psiClass: KtClassOrObject): String =
-    "$MODULE_PACKAGE_PREFIX.${psiClass.containingKtFile.packageFqName}"
+  private fun generatePackageName(psiClass: KtClassOrObject): String = MODULE_PACKAGE_PREFIX +
+    psiClass.containingKtFile.packageFqName.safePackageString(dotPrefix = true)
 
   private fun daggerModuleContent(
     scope: String,

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesBindingGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesBindingGenerator.kt
@@ -9,6 +9,7 @@ import com.squareup.anvil.compiler.boundType
 import com.squareup.anvil.compiler.codegen.CodeGenerator.GeneratedFile
 import com.squareup.anvil.compiler.contributesBindingFqName
 import com.squareup.anvil.compiler.isQualifier
+import com.squareup.anvil.compiler.safePackageString
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.KModifier.PUBLIC
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
@@ -46,8 +47,8 @@ internal class ContributesBindingGenerator : CodeGenerator {
         clazz.checkClassExtendsBoundType(module, contributesBindingFqName)
       }
       .map { clazz ->
-        val generatedPackage =
-          "$HINT_BINDING_PACKAGE_PREFIX.${clazz.containingKtFile.packageFqName}"
+        val generatedPackage = HINT_BINDING_PACKAGE_PREFIX +
+          clazz.containingKtFile.packageFqName.safePackageString(dotPrefix = true)
         val className = clazz.asClassName()
         val classFqName = clazz.requireFqName().toString()
         val propertyName = classFqName.replace('.', '_')

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesMultibindingGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesMultibindingGenerator.kt
@@ -7,6 +7,7 @@ import com.squareup.anvil.compiler.SCOPE_SUFFIX
 import com.squareup.anvil.compiler.codegen.CodeGenerator.GeneratedFile
 import com.squareup.anvil.compiler.contributesMultibindingFqName
 import com.squareup.anvil.compiler.isMapKey
+import com.squareup.anvil.compiler.safePackageString
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.KModifier.PUBLIC
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
@@ -40,8 +41,8 @@ internal class ContributesMultibindingGenerator : CodeGenerator {
         clazz.checkClassExtendsBoundType(module, contributesMultibindingFqName)
       }
       .map { clazz ->
-        val generatedPackage =
-          "$HINT_MULTIBINDING_PACKAGE_PREFIX.${clazz.containingKtFile.packageFqName}"
+        val generatedPackage = HINT_MULTIBINDING_PACKAGE_PREFIX +
+          clazz.containingKtFile.packageFqName.safePackageString(dotPrefix = true)
         val className = clazz.asClassName()
         val classFqName = clazz.requireFqName().toString()
         val propertyName = classFqName.replace('.', '_')

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesToGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesToGenerator.kt
@@ -8,6 +8,7 @@ import com.squareup.anvil.compiler.SCOPE_SUFFIX
 import com.squareup.anvil.compiler.codegen.CodeGenerator.GeneratedFile
 import com.squareup.anvil.compiler.contributesToFqName
 import com.squareup.anvil.compiler.daggerModuleFqName
+import com.squareup.anvil.compiler.safePackageString
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.KModifier.PUBLIC
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
@@ -54,8 +55,8 @@ internal class ContributesToGenerator : CodeGenerator {
         }
       }
       .map { clazz ->
-        val generatedPackage =
-          "$HINT_CONTRIBUTES_PACKAGE_PREFIX.${clazz.containingKtFile.packageFqName}"
+        val generatedPackage = HINT_CONTRIBUTES_PACKAGE_PREFIX +
+          clazz.containingKtFile.packageFqName.safePackageString(dotPrefix = true)
         val className = clazz.asClassName()
         val classFqName = clazz.requireFqName().toString()
         val propertyName = classFqName.replace('.', '_')

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/KotlinPoet.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/KotlinPoet.kt
@@ -10,6 +10,7 @@ import com.squareup.anvil.compiler.daggerLazyFqName
 import com.squareup.anvil.compiler.jvmSuppressWildcardsFqName
 import com.squareup.anvil.compiler.providerFqName
 import com.squareup.anvil.compiler.requireClass
+import com.squareup.anvil.compiler.safePackageString
 import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FileSpec
@@ -56,7 +57,7 @@ import javax.inject.Provider
 
 internal fun KtClassOrObject.asClassName(): ClassName =
   ClassName(
-    packageName = containingKtFile.packageFqName.asString(),
+    packageName = containingKtFile.packageFqName.safePackageString(),
     simpleNames = parentsWithSelf
       .filterIsInstance<KtClassOrObject>()
       .map { it.nameAsSafeName.asString() }
@@ -66,7 +67,8 @@ internal fun KtClassOrObject.asClassName(): ClassName =
 
 internal fun ClassDescriptor.asClassName(): ClassName =
   ClassName(
-    packageName = parents.filterIsInstance<PackageFragmentDescriptor>().first().fqName.asString(),
+    packageName = parents.filterIsInstance<PackageFragmentDescriptor>().first()
+      .fqName.safePackageString(),
     simpleNames = parentsWithSelf.filterIsInstance<ClassDescriptor>()
       .map { it.name.asString() }
       .toList()

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/PsiUtils.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/PsiUtils.kt
@@ -7,6 +7,7 @@ import com.squareup.anvil.compiler.getAllSuperTypes
 import com.squareup.anvil.compiler.injectFqName
 import com.squareup.anvil.compiler.jvmSuppressWildcardsFqName
 import com.squareup.anvil.compiler.publishedApiFqName
+import com.squareup.anvil.compiler.safePackageString
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.descriptors.ClassDescriptor
 import org.jetbrains.kotlin.descriptors.ClassifierDescriptorWithTypeParameters
@@ -359,7 +360,7 @@ internal fun ModuleDescriptor.findClassOrTypeAlias(
   packageName: FqName,
   className: String
 ): ClassifierDescriptorWithTypeParameters? {
-  resolveClassByFqName(FqName("$packageName.$className"), FROM_BACKEND)
+  resolveClassByFqName(FqName("${packageName.safePackageString()}$className"), FROM_BACKEND)
     ?.let { return it }
 
   findTypeAliasAcrossModuleDependencies(ClassId(packageName, Name.identifier(className)))

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/AssistedFactoryGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/AssistedFactoryGenerator.kt
@@ -17,6 +17,7 @@ import com.squareup.anvil.compiler.codegen.fqNameOrNull
 import com.squareup.anvil.compiler.codegen.hasAnnotation
 import com.squareup.anvil.compiler.codegen.requireClassDescriptor
 import com.squareup.anvil.compiler.generateClassName
+import com.squareup.anvil.compiler.safePackageString
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.FunSpec
@@ -167,7 +168,7 @@ internal class AssistedFactoryGenerator : PrivateCodeGenerator() {
       )
     }
 
-    val packageName = clazz.containingKtFile.packageFqName.asString()
+    val packageName = clazz.containingKtFile.packageFqName.safePackageString()
     val className = "${clazz.generateClassName()}_Impl"
     val implClass = ClassName(packageName, className)
 

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/AssistedInjectGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/AssistedInjectGenerator.kt
@@ -14,6 +14,7 @@ import com.squareup.anvil.compiler.codegen.fqNameOrNull
 import com.squareup.anvil.compiler.codegen.injectConstructor
 import com.squareup.anvil.compiler.codegen.mapToParameter
 import com.squareup.anvil.compiler.generateClassName
+import com.squareup.anvil.compiler.safePackageString
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.FunSpec
@@ -63,7 +64,7 @@ internal class AssistedInjectGenerator : PrivateCodeGenerator() {
     clazz: KtClassOrObject,
     constructor: KtConstructor<*>
   ): GeneratedFile {
-    val packageName = clazz.containingKtFile.packageFqName.asString()
+    val packageName = clazz.containingKtFile.packageFqName.safePackageString()
     val className = "${clazz.generateClassName()}_Factory"
 
     val parameters = constructor.valueParameters.mapToParameter(module)

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/InjectConstructorFactoryGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/InjectConstructorFactoryGenerator.kt
@@ -12,6 +12,7 @@ import com.squareup.anvil.compiler.codegen.injectConstructor
 import com.squareup.anvil.compiler.codegen.mapToParameter
 import com.squareup.anvil.compiler.generateClassName
 import com.squareup.anvil.compiler.injectFqName
+import com.squareup.anvil.compiler.safePackageString
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.FunSpec
@@ -54,7 +55,7 @@ internal class InjectConstructorFactoryGenerator : PrivateCodeGenerator() {
     clazz: KtClassOrObject,
     constructor: KtConstructor<*>
   ): GeneratedFile {
-    val packageName = clazz.containingKtFile.packageFqName.asString()
+    val packageName = clazz.containingKtFile.packageFqName.safePackageString()
     val className = "${clazz.generateClassName()}_Factory"
 
     val parameters = constructor.valueParameters.mapToParameter(module)

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/MembersInjectorGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/MembersInjectorGenerator.kt
@@ -13,6 +13,7 @@ import com.squareup.anvil.compiler.codegen.requireFqName
 import com.squareup.anvil.compiler.daggerDoubleCheckFqNameString
 import com.squareup.anvil.compiler.generateClassName
 import com.squareup.anvil.compiler.injectFqName
+import com.squareup.anvil.compiler.safePackageString
 import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FileSpec
@@ -67,7 +68,7 @@ internal class MembersInjectorGenerator : PrivateCodeGenerator() {
     clazz: KtClassOrObject,
     injectProperties: List<KtProperty>
   ): GeneratedFile {
-    val packageName = clazz.containingKtFile.packageFqName.asString()
+    val packageName = clazz.containingKtFile.packageFqName.safePackageString()
     val className = "${clazz.generateClassName()}_MembersInjector"
     val classType = clazz.asClassName()
       .let {

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/ProvidesMethodFactoryGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/ProvidesMethodFactoryGenerator.kt
@@ -23,6 +23,7 @@ import com.squareup.anvil.compiler.daggerModuleFqName
 import com.squareup.anvil.compiler.daggerProvidesFqName
 import com.squareup.anvil.compiler.generateClassName
 import com.squareup.anvil.compiler.publishedApiFqName
+import com.squareup.anvil.compiler.safePackageString
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.FunSpec
@@ -118,7 +119,7 @@ internal class ProvidesMethodFactoryGenerator : PrivateCodeGenerator() {
       declaration.visibilityModifierTypeOrDefault() == INTERNAL_KEYWORD &&
       !declaration.hasAnnotation(publishedApiFqName)
 
-    val packageName = clazz.containingKtFile.packageFqName.asString()
+    val packageName = clazz.containingKtFile.packageFqName.safePackageString()
     val className = buildString {
       append(clazz.generateClassName())
       append('_')

--- a/compiler/src/test/java/com/squareup/anvil/compiler/InterfaceMergerTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/InterfaceMergerTest.kt
@@ -549,6 +549,25 @@ class InterfaceMergerTest(
     }
   }
 
+  @Test fun `interfaces are merged without a package`() {
+    compile(
+      """
+      import com.squareup.anvil.annotations.ContributesTo
+      $import
+      
+      @ContributesTo(Any::class)
+      interface ContributingInterface
+      
+      $annotation(Any::class)
+      interface ComponentInterface
+      """
+    ) {
+      val componentInterface = classLoader.loadClass("ComponentInterface")
+      val contributingInterface = classLoader.loadClass("ContributingInterface")
+      assertThat(componentInterface extends contributingInterface).isTrue()
+    }
+  }
+
   @Test fun `module interfaces are not merged`() {
     // They could cause errors while compiling code when adding our contributed super classes.
     compile(

--- a/compiler/src/test/java/com/squareup/anvil/compiler/MergeModulesTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/MergeModulesTest.kt
@@ -811,6 +811,25 @@ class MergeModulesTest {
     }
   }
 
+  @Test fun `modules are merged without a package`() {
+    compile(
+      """
+      import com.squareup.anvil.annotations.compat.MergeModules
+      import com.squareup.anvil.annotations.ContributesTo
+
+      @ContributesTo(Any::class)
+      @dagger.Module
+      abstract class DaggerModule2
+
+      @MergeModules(Any::class)
+      class DaggerModule1
+      """
+    ) {
+      assertThat(classLoader.loadClass("DaggerModule1").daggerModule.includes.withoutAnvilModule())
+        .containsExactly(classLoader.loadClass("DaggerModule2").kotlin)
+    }
+  }
+
   @Test fun `a module is not allowed to be included and excluded`() {
     compile(
       """

--- a/compiler/src/test/java/com/squareup/anvil/compiler/ModuleMergerTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/ModuleMergerTest.kt
@@ -952,6 +952,26 @@ class ModuleMergerTest(
     }
   }
 
+  @Test fun `modules are merged without a package`() {
+    compile(
+      """
+      import com.squareup.anvil.annotations.ContributesTo
+      $import
+      
+      @ContributesTo(Any::class)
+      @dagger.Module
+      abstract class DaggerModule1
+      
+      $annotation(Any::class)
+      interface ComponentInterface
+      """
+    ) {
+      val component = classLoader.loadClass("ComponentInterface").anyDaggerComponent
+      assertThat(component.modules.withoutAnvilModule())
+        .containsExactly(classLoader.loadClass("DaggerModule1").kotlin)
+    }
+  }
+
   @Test fun `a module is not allowed to be included and excluded`() {
     compile(
       """

--- a/compiler/src/test/java/com/squareup/anvil/compiler/codegen/BindingModuleGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/codegen/BindingModuleGeneratorTest.kt
@@ -340,6 +340,28 @@ class BindingModuleGeneratorTest(
     }
   }
 
+  @Test fun `a Dagger module is generated for a merged class and added to the component without a package`() { // ktlint-disable max-line-length
+    compile(
+      """
+      $import
+      
+      $annotation(Any::class)
+      interface ComponentInterface
+      """
+    ) {
+      val modules = if (annotationClass == MergeModules::class) {
+        classLoader.loadClass("ComponentInterface").daggerModule.includes.toList()
+      } else {
+        classLoader.loadClass("ComponentInterface").anyDaggerComponent.modules
+      }
+      assertThat(modules).containsExactly(
+        classLoader
+          .loadClass("$MODULE_PACKAGE_PREFIX.ComponentInterfaceAnvilModule")
+          .kotlin
+      )
+    }
+  }
+
   @Test fun `the contributed binding class must not have a generic type parameter`() {
     compile(
       """


### PR DESCRIPTION
The compiler APIs return "<root>" as fully qualified name for the root package, but we want to default to an empty string instead.

Fixes #227