### PR TITLE
If the bound type is specified, then multiple super types are allowed.

### DIFF
--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesBindingGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesBindingGenerator.kt
@@ -43,7 +43,7 @@ internal class ContributesBindingGenerator : CodeGenerator {
       .onEach { clazz ->
         clazz.checkClassIsPublic()
         clazz.checkNotMoreThanOneQualifier(module, contributesBindingFqName)
-        clazz.checkSingleSuperType(contributesBindingFqName)
+        clazz.checkSingleSuperType(module, contributesBindingFqName)
         clazz.checkClassExtendsBoundType(module, contributesBindingFqName)
       }
       .map { clazz ->
@@ -120,8 +120,13 @@ internal fun KtClassOrObject.checkClassIsPublic() {
 }
 
 internal fun KtClassOrObject.checkSingleSuperType(
+  module: ModuleDescriptor,
   annotationFqName: FqName
 ) {
+  // If the bound type exists, then you're allowed to have multiple super types. Without the bound
+  // type there must be exactly one super type.
+  if (boundType(annotationFqName, module) != null) return
+
   val superTypes = superTypeListEntries
   if (superTypes.size != 1) {
     throw AnvilCompilationException(

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesMultibindingGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesMultibindingGenerator.kt
@@ -37,7 +37,7 @@ internal class ContributesMultibindingGenerator : CodeGenerator {
         clazz.checkClassIsPublic()
         clazz.checkNotMoreThanOneQualifier(module, contributesMultibindingFqName)
         clazz.checkNotMoreThanOneMapKey(module)
-        clazz.checkSingleSuperType(contributesMultibindingFqName)
+        clazz.checkSingleSuperType(module, contributesMultibindingFqName)
         clazz.checkClassExtendsBoundType(module, contributesMultibindingFqName)
       }
       .map { clazz ->

--- a/compiler/src/test/java/com/squareup/anvil/compiler/codegen/ContributesBindingGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/codegen/ContributesBindingGeneratorTest.kt
@@ -253,6 +253,24 @@ class ContributesBindingGeneratorTest {
     }
   }
 
+  @Test fun `the bound type is not implied when explicitly defined`() {
+    compile(
+      """
+      package com.squareup.test
+
+      import com.squareup.anvil.annotations.ContributesBinding
+
+      interface ParentInterface
+
+      @ContributesBinding(Int::class, ParentInterface::class)
+      interface ContributingInterface : ParentInterface, CharSequence
+      """
+    ) {
+      assertThat(contributingInterface.hintBinding?.java).isEqualTo(contributingInterface)
+      assertThat(contributingInterface.hintBindingScope).isEqualTo(Int::class)
+    }
+  }
+
   @Test fun `the contributed binding class must extend the bound type`() {
     compile(
       """

--- a/compiler/src/test/java/com/squareup/anvil/compiler/codegen/ContributesMultibindingGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/codegen/ContributesMultibindingGeneratorTest.kt
@@ -254,6 +254,28 @@ class ContributesMultibindingGeneratorTest {
     }
   }
 
+  @Test fun `the bound type is not implied when explicitly defined`() {
+    compile(
+      """
+      package com.squareup.test
+
+      import com.squareup.anvil.annotations.ContributesMultibinding
+
+      interface ParentInterface
+
+      @ContributesMultibinding(
+        scope = Int::class, 
+        ignoreQualifier = true, 
+        boundType = ParentInterface::class
+      )
+      interface ContributingInterface : ParentInterface, CharSequence
+      """
+    ) {
+      assertThat(contributingInterface.hintMultibinding?.java).isEqualTo(contributingInterface)
+      assertThat(contributingInterface.hintMultibindingScope).isEqualTo(Int::class)
+    }
+  }
+
   @Test fun `the contributed multibinding class must extend the bound type`() {
     compile(
       """


### PR DESCRIPTION
That's a regression I noticed while testing the new version in our codebase.