### PR TITLE
Add more tests to verify that exclusions and replacements don't result in duplicate bindings

### DIFF
--- a/compiler/src/test/java/com/squareup/anvil/compiler/codegen/BindingModulePriorityTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/codegen/BindingModulePriorityTest.kt
@@ -131,6 +131,64 @@ class BindingModulePriorityTest(
     }
   }
 
+  @Test fun `bindings with the same priority can be replaced and aren't duplicate bindings`() {
+    compile(
+      """
+      package com.squareup.test
+      
+      import com.squareup.anvil.annotations.ContributesBinding
+      $import
+      
+      interface ParentInterface
+      
+      @ContributesBinding(Any::class)
+      interface ContributingInterface : ParentInterface
+      
+      @ContributesBinding(Any::class, replaces = [ContributingInterface::class])
+      interface SecondContributingInterface : ParentInterface
+      
+      $annotation(Any::class)
+      interface ComponentInterface
+      """
+    ) {
+      val bindingMethod = componentInterfaceAnvilModule.declaredMethods.single()
+
+      with(bindingMethod) {
+        assertThat(returnType).isEqualTo(parentInterface)
+        assertThat(parameterTypes.toList()).containsExactly(secondContributingInterface)
+      }
+    }
+  }
+
+  @Test fun `bindings with the same priority can be excluded and aren't duplicate bindings`() {
+    compile(
+      """
+      package com.squareup.test
+      
+      import com.squareup.anvil.annotations.ContributesBinding
+      $import
+      
+      interface ParentInterface
+      
+      @ContributesBinding(Any::class)
+      interface ContributingInterface : ParentInterface
+      
+      @ContributesBinding(Any::class)
+      interface SecondContributingInterface : ParentInterface
+      
+      $annotation(Any::class, exclude = [ContributingInterface::class])
+      interface ComponentInterface
+      """
+    ) {
+      val bindingMethod = componentInterfaceAnvilModule.declaredMethods.single()
+
+      with(bindingMethod) {
+        assertThat(returnType).isEqualTo(parentInterface)
+        assertThat(parameterTypes.toList()).containsExactly(secondContributingInterface)
+      }
+    }
+  }
+
   @Test fun `multiple multibindings with the same type are allowed`() {
     compile(
       """


### PR DESCRIPTION
I thought I detected a bug in Anvil while testing the release in our codebase, but it turns out that our project was configured wrong. I wanted to keep nonetheless for more confidence and to avoid regressions. 