### PR TITLE
Fix the check for kotlin annotations. 

### DIFF
--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/PsiUtils.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/PsiUtils.kt
@@ -77,14 +77,12 @@ internal fun KtAnnotated.findAnnotation(fqName: FqName): KtAnnotationEntry? {
 
   // Look first if it's a Kotlin annotation. These annotations are usually not imported and the
   // remaining checks would fail.
-  annotationEntries.firstOrNull { annotation ->
-    kotlinAnnotations
-      .any { kotlinAnnotationFqName ->
-        val text = annotation.text
-        text.startsWith("@${kotlinAnnotationFqName.shortName()}") ||
-          text.startsWith("@$kotlinAnnotationFqName")
-      }
-  }?.let { return it }
+  if (fqName in kotlinAnnotations) {
+    annotationEntries.firstOrNull { annotation ->
+      val text = annotation.text
+      text.startsWith("@${fqName.shortName()}") || text.startsWith("@$fqName")
+    }?.let { return it }
+  }
 
   // Check if the fully qualified name is used, e.g. `@dagger.Module`.
   val annotationEntry = annotationEntries.firstOrNull {

--- a/compiler/src/test/java/com/squareup/anvil/compiler/codegen/ContributesToGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/codegen/ContributesToGeneratorTest.kt
@@ -61,6 +61,28 @@ class ContributesToGeneratorTest {
     }
   }
 
+  @Test fun `a file can contain an internal class`() {
+    // There was a bug that triggered a failure. Make sure that it doesn't happen again.
+    // https://github.com/square/anvil/issues/232
+    compile(
+      """
+      package com.squareup.test
+
+      import com.squareup.anvil.annotations.ContributesTo
+
+      @ContributesTo(Any::class)
+      @dagger.Module
+      abstract class DaggerModule1
+      
+      @PublishedApi
+      internal class FailAnvil
+      """
+    ) {
+      assertThat(daggerModule1.hintContributes?.java).isEqualTo(daggerModule1)
+      assertThat(daggerModule1.hintContributesScope).isEqualTo(Any::class)
+    }
+  }
+
   @Test fun `there is a hint for contributed interfaces`() {
     compile(
       """


### PR DESCRIPTION
It actually didn't look for the specific annotation we meant, but rather all Kotlin annotations we care about.

Fixes #232