### PR TITLE
Attempt to canonicalize string representation of Annotations across JDKs

### DIFF
--- a/compiler/src/test/java/com/squareup/anvil/compiler/TestUtils.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/TestUtils.kt
@@ -201,7 +201,7 @@ internal fun Class<*>.membersInjector(): Class<*> {
   )
 }
 
-private fun Class<*>.packageName(): String = `package`.name.let {
+private fun Class<*>.packageName(): String = (`package`?.name ?: "").let {
   if (it.isBlank()) "" else "$it."
 }
 
@@ -258,3 +258,11 @@ internal fun Any.invokeGet(vararg args: Any?): Any {
 @Suppress("UNCHECKED_CAST")
 internal fun <T> Annotation.getValue(): T =
   this::class.java.declaredMethods.single { it.name == "value" }.invoke(this) as T
+
+// Standardizes the string representation of an Annotation, accounting for differences
+// in JDK implementations.
+internal fun Annotation.toCanonicalString(): String {
+  return toString()
+    .replace("""(=int)(?!.class)\b""".toRegex(), "=int.class")
+    .replace("""(=class java.lang.String)\b""".toRegex(), "=java.lang.String.class")
+}

--- a/compiler/src/test/java/com/squareup/anvil/compiler/codegen/BindingModuleQualifierTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/codegen/BindingModuleQualifierTest.kt
@@ -10,6 +10,7 @@ import com.squareup.anvil.compiler.componentInterfaceAnvilModule
 import com.squareup.anvil.compiler.contributingInterface
 import com.squareup.anvil.compiler.isAbstract
 import com.squareup.anvil.compiler.parentInterface
+import com.squareup.anvil.compiler.toCanonicalString
 import dagger.Binds
 import dagger.Provides
 import dagger.multibindings.IntoSet
@@ -245,7 +246,7 @@ class BindingModuleQualifierTest(
           .containsExactly(Binds::class, anyQualifier.kotlin)
 
         val qualifierAnnotation = annotations.single { it.annotationClass == anyQualifier.kotlin }
-        assertThat(qualifierAnnotation.toString())
+        assertThat(qualifierAnnotation.toCanonicalString())
           .isEqualTo("@com.squareup.test.AnyQualifier(abc=int.class)")
       }
     }
@@ -335,7 +336,7 @@ class BindingModuleQualifierTest(
           .containsExactly(Binds::class, anyQualifier.kotlin)
 
         val qualifierAnnotation = annotations.single { it.annotationClass == anyQualifier.kotlin }
-        assertThat(qualifierAnnotation.toString())
+        assertThat(qualifierAnnotation.toCanonicalString())
           .isEqualTo("@com.squareup.test.AnyQualifier(abc=java.lang.String.class, def=1)")
       }
     }


### PR DESCRIPTION
Some unit tests fail under OpenJDK 1.8, due to non-standard string representation of Annotations. Canonicalize them to the representation given by JDK 11.