### PR TITLE
Remove bintray and jcenter repositories

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,13 +5,6 @@ buildscript {
     google()
     gradlePluginPortal()
     mavenCentral()
-    jcenter()
-    maven {
-      url "https://dl.bintray.com/kotlin/kotlin-eap"
-    }
-    maven {
-      url "http://dl.bintray.com/kotlin/kotlin-dev"
-    }
   }
 
   dependencies {
@@ -33,13 +26,6 @@ allprojects {
   repositories {
     google()
     mavenCentral()
-    jcenter()
-    maven {
-      url "https://dl.bintray.com/kotlin/kotlin-eap"
-    }
-    maven {
-      url "http://dl.bintray.com/kotlin/kotlin-dev"
-    }
   }
 }
 

--- a/gradle-plugin/build.gradle
+++ b/gradle-plugin/build.gradle
@@ -7,13 +7,6 @@ buildscript {
     google()
     gradlePluginPortal()
     mavenCentral()
-    jcenter()
-    maven {
-      url "https://dl.bintray.com/kotlin/kotlin-eap"
-    }
-    maven {
-      url "http://dl.bintray.com/kotlin/kotlin-dev"
-    }
   }
 
   dependencies {
@@ -27,13 +20,6 @@ buildscript {
 repositories {
   google()
   mavenCentral()
-  jcenter()
-  maven {
-    url "https://dl.bintray.com/kotlin/kotlin-eap"
-  }
-  maven {
-    url "http://dl.bintray.com/kotlin/kotlin-dev"
-  }
 }
 
 apply from: rootProject.file('copy_properties.gradle')


### PR DESCRIPTION
This should avoid any issue with the [upcoming sunset](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/) of them.