### PR TITLE
reproducing dexing issue

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -20,7 +20,7 @@ ext {
   ktlintVersion = "0.41.0"
 
   deps = [
-      android_gradle_plugin: "com.android.tools.build:gradle:4.1.0",
+      android_gradle_plugin: "com.android.tools.build:gradle:4.2.0",
       anvil_plugin: "com.squareup.anvil:gradle-plugin:${findProperty('VERSION_NAME')}",
       maven_publishing_plugin: "com.vanniktech:gradle-maven-publish-plugin:0.14.2",
       gradle_publishing_plugin: "com.gradle.publish:plugin-publish-plugin:0.12.0",

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Wed May 19 23:37:41 PDT 2021
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-bin.zip
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME

--- a/sample/app/build.gradle
+++ b/sample/app/build.gradle
@@ -21,6 +21,7 @@ android {
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_1_8
     targetCompatibility JavaVersion.VERSION_1_8
+    coreLibraryDesugaringEnabled = true
   }
 
   lintOptions {
@@ -43,7 +44,7 @@ dependencies {
   implementation deps.androidx.core
   implementation deps.androidx.material
   implementation deps.dagger2.dagger
-
+  coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:1.1.5")
   kapt deps.dagger2.compiler
 
   testImplementation deps.junit


### PR DESCRIPTION
@vRallev fyi

https://issuetracker.google.com/issues/188852556

```
./gradlew :sample:app build
```


```
javap -v ./build/tmp/kotlin-classes/debug/anvil/hint/merge/com/squareup/anvil/sample/Com_squareup_anvil_sample_RandomModuleKt.class

SourceFile: "com_squareup_anvil_sample_RandomModule.kt"
RuntimeVisibleAnnotations:
  0: #22(#23=[I#24,I#25,I#26],#27=[I#24,I#28,I#29],#30=I#26,#31=[s#32],#33=[s#5,s#6,s#34,s#9,s#10,s#14,s#35,s#16,s#36])
    kotlin.Metadata(
      mv=[1,4,2]
      bv=[1,0,3]
      k=2
      d1=["\u0000\u0016\n\u0000\n\u0002\u0018\u0002\n\u0002\u0018\u0002\n\u0002\b\u0003\n\u0002\u0018\u0002\n\u0002\b\u0002\"\u0017\u0010\u0000\u001a\b\u0012\u0004\u0012\u00020\u00020\u0001¢\u0006\b\n\u0000\u001a\u0004\b\u0003\u0010\u0004\"\u0017\u0010\u0005\u001a\b\u0012\u0004\u0012\u00020\u00060\u0001¢\u0006\b\n\u0000\u001a\u0004\b\u0007\u0010\u0004¨\u0006\b"]
      d2=["com_squareup_anvil_sample_RandomModule_reference","Lkotlin/reflect/KClass;","Lcom/squareup/anvil/sample/RandomModule;","getCom_squareup_anvil_sample_RandomModule_reference","()Lkotlin/reflect/KClass;","com_squareup_anvil_sample_RandomModule_scope","Lcom/squareup/scopes/AppScope;","getCom_squareup_anvil_sample_RandomModule_scope","app_debug"]
    )
```

The Dex version looks like:

```
~/Downloads/dex-tools-2.1-SNAPSHOT/d2j-dex2jar.sh /tmp/Com_squareup_anvil_sample_RandomModuleKt.dex 
unzip Com_squareup_anvil_sample_RandomModuleKt-dex2jar.jar 
javap -v anvil/hint/merge/com/squareup/anvil/sample/Com_squareup_anvil_sample_RandomModuleKt.class 
```

```
RuntimeVisibleAnnotations:
  0: #5(#6=[I#7,I#8,I#9],#10=[s#11],#12=[s#13,s#14,s#15,s#13,s#16,s#17,s#18,s#19,s#20,s#21],#22=I#23,#24=[I#7,I#25,I#23])
    kotlin.Metadata(
      bv=[1,0,3]
      d1=["\u0000\u0014\n\u0002\u0018\u0002\n\u0002\u0018\u0002\n\u0002\b\u0004\n\u0002\u0018\u0002\n\u0002\b\u0003\"\u001f\u0010\u0002\u001a\b\u0012\u0004\u0012\u00020\u00010\u00008\u0006@\u0006¢\u0006\f\n\u0004\b\u0002\u0010\u0003\u001a\u0004\b\u0004\u0010\u0005\"\u001f\u0010\u0007\u001a\b\u0012\u0004\u0012\u00020\u00060\u00008\u0006@\u0006¢\u0006\f\n\u0004\b\u0007\u0010\u0003\u001a\u0004\b\b\u0010\u0005¨\u0006\t"]
      d2=["Lkotlin/reflect/KClass;","Lcom/squareup/scopes/AppScope;","com_squareup_anvil_sample_RandomModule_scope","Lkotlin/reflect/KClass;","getCom_squareup_anvil_sample_RandomModule_scope","()Lkotlin/reflect/KClass;","Lcom/squareup/anvil/sample/RandomModule;","com_squareup_anvil_sample_RandomModule_reference","getCom_squareup_anvil_sample_RandomModule_reference","app_debug"]
      k=2
      mv=[1,4,2]
    )
```