### PR TITLE
[Draft] FqName resolution for generated code

### DIFF
--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/AnvilModuleDescriptor.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/AnvilModuleDescriptor.kt
@@ -1,0 +1,44 @@
+package com.squareup.anvil.compiler.codegen
+
+import com.squareup.anvil.compiler.safePackageString
+import org.jetbrains.kotlin.descriptors.ModuleDescriptor
+import org.jetbrains.kotlin.descriptors.findTypeAliasAcrossModuleDependencies
+import org.jetbrains.kotlin.descriptors.resolveClassByFqName
+import org.jetbrains.kotlin.incremental.components.NoLookupLocation.FROM_BACKEND
+import org.jetbrains.kotlin.name.ClassId
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.name.Name
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
+
+internal class AnvilModuleDescriptor(
+  private val delegate: ModuleDescriptor,
+  generatedKtFiles: List<KtFile>
+) : ModuleDescriptor by delegate {
+
+  private val generatedKtFiles: MutableList<KtFile> = generatedKtFiles.toMutableList()
+
+  fun addFiles(newFiles: Collection<KtFile>) {
+    generatedKtFiles.addAll(newFiles)
+  }
+
+  fun resolveFqNameOrNull(
+    packageName: FqName,
+    className: String
+  ): FqName? {
+
+    val maybeClassFqName = FqName("${packageName.safePackageString()}$className")
+
+    resolveClassByFqName(maybeClassFqName, FROM_BACKEND)
+      ?.let { return it.fqNameSafe }
+
+    findTypeAliasAcrossModuleDependencies(ClassId(packageName, Name.identifier(className)))
+      ?.let { return it.fqNameSafe }
+
+    return generatedKtFiles
+      .asSequence()
+      .flatMap { it.classesAndInnerClasses() }
+      .firstOrNull { it.fqName == maybeClassFqName }
+      ?.fqName
+  }
+}

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/CodeGenerationExtension.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/CodeGenerationExtension.kt
@@ -18,10 +18,13 @@ import java.io.File
 
 internal class CodeGenerationExtension(
   private val codeGenDir: File,
-  private val codeGenerators: List<CodeGenerator>
+  codeGenerators: List<CodeGenerator>
 ) : AnalysisHandlerExtension {
 
   private var didRecompile = false
+
+  private val codeGenerators = codeGenerators
+    .sortedBy { it is PrivateCodeGenerator }
 
   override fun doAnalysis(
     project: Project,
@@ -57,7 +60,6 @@ internal class CodeGenerationExtension(
 
     fun generateCode(files: Collection<KtFile>): Collection<GeneratedFile> =
       codeGenerators
-        .sortedBy { it is PrivateCodeGenerator }
         .flatMap { codeGenerator ->
           codeGenerator.generateCode(codeGenDir, anvilModule, files).also { new ->
             anvilModule.addFiles(new.parse(psiManager))

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/KotlinPoet.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/KotlinPoet.kt
@@ -89,7 +89,7 @@ internal fun FqName.asClassName(module: ModuleDescriptor): ClassName {
     val packageSegments = segments.subList(0, index)
     val classSegments = segments.subList(index, segments.size)
 
-    val classifier = module.findClassOrTypeAlias(
+    val classifier = module.resolveFqNameOrNull(
       packageName = FqName.fromSegments(packageSegments),
       className = classSegments.joinToString(separator = ".")
     )

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/PsiUtils.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/PsiUtils.kt
@@ -401,7 +401,8 @@ internal fun ModuleDescriptor.resolveFqNameOrNull(
 
   if (this !is AnvilModuleDescriptor) {
     throw AnvilCompilationException(
-      "Expected ${AnvilModuleDescriptor::class.qualifiedName} receiver but got ${this::class.qualifiedName}."
+      "Expected ${AnvilModuleDescriptor::class.qualifiedName} as a receiver " +
+        "but got ${this::class.qualifiedName}."
     )
   }
 


### PR DESCRIPTION
Fixes #283 

There are a few design choices I made here without strong opinions.

- Instead of a decorator, would it be better if `AnvilModuleDescriptor` was just a standalone context-like object with properties for files and the module?  That object would be passed around instead of the `ModuleDescriptor`.
- Instead of explicitly adding files as they're created, it could just take the `codeGenDir` and `PsiManager` as constructor arguments and then re-parse the files itself (and cache them) as needed.  That's less performant, but even for a monolithic module with a lot of generated code it's probably negligible?
- Instead of using normal `ModuleDescriptor` types everywhere with a type check in `ModuleDescriptor.resolveFqNameOrNull`, would it be better to use the custom type everywhere?  It would mean exposing the type in `compiler-api` and the diff is a whole lot bigger.

I'm not yet sure how to go about introducing an extra code generator for tests, but tests are on their way.