### PR TITLE
Improve check if FqName exists

### DIFF
--- a/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/AnvilModuleDescriptor.kt
+++ b/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/AnvilModuleDescriptor.kt
@@ -1,0 +1,31 @@
+package com.squareup.anvil.compiler.internal
+
+import com.squareup.anvil.annotations.ExperimentalAnvilApi
+import org.jetbrains.kotlin.descriptors.ModuleDescriptor
+import org.jetbrains.kotlin.name.ClassId
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.name.Name
+
+@ExperimentalAnvilApi
+public abstract class AnvilModuleDescriptor : ModuleDescriptor {
+  public abstract fun resolveClassIdOrNull(classId: ClassId): FqName?
+}
+
+public fun ModuleDescriptor.resolveFqNameOrNull(
+  fqName: FqName
+): FqName? = (this as AnvilModuleDescriptor).resolveClassIdOrNull(fqName.classIdBestGuess())
+
+public fun ModuleDescriptor.canResolveFqName(
+  fqName: FqName
+): Boolean = resolveFqNameOrNull(fqName) != null
+
+public fun ModuleDescriptor.resolveFqNameOrNull(
+  packageName: FqName,
+  className: String
+): FqName? = (this as AnvilModuleDescriptor)
+  .resolveClassIdOrNull(ClassId(packageName, Name.identifier(className)))
+
+public fun ModuleDescriptor.canResolveFqName(
+  packageName: FqName,
+  className: String
+): Boolean = resolveFqNameOrNull(packageName, className) != null

--- a/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/CompilerUtils.kt
+++ b/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/CompilerUtils.kt
@@ -168,6 +168,19 @@ public fun FqName.safePackageString(
   }
 
 @ExperimentalAnvilApi
+public fun FqName.classIdBestGuess(): ClassId {
+  val segments = pathSegments().map { it.asString() }
+  val classNameIndex = segments.indexOfFirst { it[0].isUpperCase() }
+  if (classNameIndex < 0) {
+    return ClassId.topLevel(this)
+  }
+
+  val packageFqName = FqName.fromSegments(segments.subList(0, classNameIndex))
+  val relativeClassName = FqName.fromSegments(segments.subList(classNameIndex, segments.size))
+  return ClassId(packageFqName, relativeClassName, false)
+}
+
+@ExperimentalAnvilApi
 public fun String.capitalize(): String = replaceFirstChar(Char::uppercaseChar)
 
 @ExperimentalAnvilApi

--- a/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/KotlinPoetUtils.kt
+++ b/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/KotlinPoetUtils.kt
@@ -77,12 +77,12 @@ public fun FqName.asClassName(module: ModuleDescriptor): ClassName {
     val packageSegments = segments.subList(0, index)
     val classSegments = segments.subList(index, segments.size)
 
-    val classifier = module.findClassOrTypeAlias(
+    val validFqName = module.canResolveFqName(
       packageName = FqName.fromSegments(packageSegments),
       className = classSegments.joinToString(separator = ".")
     )
 
-    if (classifier != null) {
+    if (validFqName) {
       return ClassName(
         packageName = packageSegments.joinToString(separator = "."),
         simpleNames = classSegments

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesBindingGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesBindingGenerator.kt
@@ -113,7 +113,7 @@ internal fun KtClassOrObject.checkNotMoreThanOneQualifier(
   // annotations, then there can't be more than two qualifiers.
   if (annotationEntries.size <= 2) return
 
-  val qualifiers = requireClassDescriptor(module).annotations.filter { it.isQualifier() }
+  val qualifiers = annotationEntries.filter { it.isQualifier(module) }
 
   if (qualifiers.size > 1) {
     throw AnvilCompilationException(

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/PrivateCodeGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/PrivateCodeGenerator.kt
@@ -9,7 +9,8 @@ import java.io.File
 /**
  * Generates code that doesn't impact any other [CodeGenerator], meaning no other code generator
  * will process the generated code produced by this instance. A [PrivateCodeGenerator] is called
- * one last time after [flush] has been called to get a chance to evaluate written results.
+ * one last time after [FlushingCodeGenerator.flush] has been called to get a chance to evaluate
+ * written results.
  */
 internal abstract class PrivateCodeGenerator : CodeGenerator {
   final override fun generateCode(

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/RealAnvilModuleDescriptor.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/RealAnvilModuleDescriptor.kt
@@ -1,0 +1,42 @@
+package com.squareup.anvil.compiler.codegen
+
+import com.squareup.anvil.compiler.internal.AnvilModuleDescriptor
+import com.squareup.anvil.compiler.internal.classesAndInnerClasses
+import org.jetbrains.kotlin.descriptors.ModuleDescriptor
+import org.jetbrains.kotlin.descriptors.findTypeAliasAcrossModuleDependencies
+import org.jetbrains.kotlin.descriptors.resolveClassByFqName
+import org.jetbrains.kotlin.incremental.components.NoLookupLocation.FROM_BACKEND
+import org.jetbrains.kotlin.name.ClassId
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.psi.KtClassOrObject
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
+
+class RealAnvilModuleDescriptor(
+  delegate: ModuleDescriptor
+) : AnvilModuleDescriptor(), ModuleDescriptor by delegate {
+
+  private val classesMap = mutableMapOf<KtFile, List<KtClassOrObject>>()
+  private val allClasses: Sequence<KtClassOrObject>
+    get() = classesMap.values.asSequence().flatMap { it }
+
+  fun addFiles(files: Collection<KtFile>) {
+    files.forEach { ktFile ->
+      classesMap[ktFile] = ktFile.classesAndInnerClasses().toList()
+    }
+  }
+
+  override fun resolveClassIdOrNull(classId: ClassId): FqName? {
+    val fqName = classId.asSingleFqName()
+
+    resolveClassByFqName(fqName, FROM_BACKEND)
+      ?.let { return it.fqNameSafe }
+
+    findTypeAliasAcrossModuleDependencies(classId)
+      ?.let { return it.fqNameSafe }
+
+    return allClasses
+      .firstOrNull { it.fqName == fqName }
+      ?.fqName
+  }
+}

--- a/compiler/src/test/java/com/squareup/anvil/compiler/MergeModulesTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/MergeModulesTest.kt
@@ -148,7 +148,7 @@ class MergeModulesTest {
       import com.squareup.anvil.annotations.compat.MergeModules
 
       @ContributesTo(Any::class)
-      abstract class DaggerModule1
+      abstract class DaggerModule2
 
       @MergeModules(Any::class)
       class DaggerModule1

--- a/integration-tests/code-generator-tests/build.gradle
+++ b/integration-tests/code-generator-tests/build.gradle
@@ -2,6 +2,10 @@ apply plugin: 'org.jetbrains.kotlin.jvm'
 apply plugin: 'com.squareup.anvil'
 apply plugin: 'org.jetbrains.kotlin.kapt'
 
+anvil {
+  generateDaggerFactories = true
+}
+
 dependencies {
   anvil project(':integration-tests:code-generator')
 

--- a/integration-tests/code-generator-tests/src/test/java/com/squareup/anvil/test/GeneratedCodeTest.kt
+++ b/integration-tests/code-generator-tests/src/test/java/com/squareup/anvil/test/GeneratedCodeTest.kt
@@ -6,6 +6,7 @@ import com.sqareup.anvil.compiler.internal.testing.withoutAnvilModule
 import com.squareup.anvil.annotations.MergeComponent
 import dagger.Component
 import org.junit.Test
+import javax.inject.Inject
 
 class GeneratedCodeTest {
 
@@ -31,6 +32,19 @@ class GeneratedCodeTest {
       .containsExactly(contributedModule)
   }
 
+  @Test fun `the generated class can be injected`() {
+    // This is a reproducer for https://github.com/square/anvil/issues/283.
+    assertThat(DaggerGeneratedCodeTest_AppComponent.create().otherClass()).isNotNull()
+  }
+
   @MergeComponent(Unit::class)
-  interface AppComponent
+  interface AppComponent {
+    fun otherClass(): OtherClass
+  }
+
+  class OtherClass @Inject constructor(
+    // Keep the fully qualified name, otherwise the one specific error from
+    // https://github.com/square/anvil/issues/283 can't be reproduced.
+    val injectClass: generated.test.com.squareup.anvil.test.InjectClass
+  )
 }

--- a/integration-tests/code-generator/src/main/java/com/squareup/anvil/test/TestCodeGenerator.kt
+++ b/integration-tests/code-generator/src/main/java/com/squareup/anvil/test/TestCodeGenerator.kt
@@ -59,6 +59,15 @@ class TestCodeGenerator : CodeGenerator {
           interface ContributedModule 
         """.trimIndent()
 
+        @Language("kotlin")
+        val injectClass = """
+          package $generatedPackage
+          
+          import javax.inject.Inject
+    
+          class InjectClass @Inject constructor() 
+        """.trimIndent()
+
         sequenceOf(
           createGeneratedFile(
             codeGenDir = codeGenDir,
@@ -77,6 +86,12 @@ class TestCodeGenerator : CodeGenerator {
             packageName = generatedPackage,
             fileName = "ContributedModule",
             content = contributedModule
+          ),
+          createGeneratedFile(
+            codeGenDir = codeGenDir,
+            packageName = generatedPackage,
+            fileName = "InjectClass",
+            content = injectClass
           ),
         )
       }


### PR DESCRIPTION
Introduce a new API to check if a FqName can be resolved. In the implementation also check for the FqName in generated code, which is critical for some code generators.

Before we only resolved the class descriptor and based upon the result decided if the FqName is valid, which was never true for generated code.

Add an integration test for generating a class that is referenced in non-generated code.

Fixes #283, the solution is based on #282.

