### PR TITLE
Use the correct replacement classes. 

### DIFF
--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/BindingModuleGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/BindingModuleGenerator.kt
@@ -190,6 +190,12 @@ internal class BindingModuleGenerator(
               annotation = contributesToFqName,
               scope = scope
             )
+            .filter { it.annotationOrNull(daggerModuleFqName) != null }
+            .flatMap {
+              it.annotationOrNull(contributesToFqName, scope)
+                ?.replaces(module)
+                ?: emptyList()
+            }
             .map { it.fqNameSafe }
         )
         .toList()


### PR DESCRIPTION
This is a regression that was introduced while working on the new CodeGenerator API.