### PR TITLE
Fix replaced modules and bindings by excluded modules

### DIFF
--- a/compiler/src/main/java/com/squareup/anvil/compiler/ModuleMerger.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/ModuleMerger.kt
@@ -156,6 +156,7 @@ internal class ModuleMerger(
 
     val replacedModules = modules
       .filter { (classDescriptor, _) ->
+        // Ignore replaced modules or bindings specified by excluded modules.
         classDescriptor.defaultType.asmType(codegen.typeMapper) !in excludedModules
       }
       .flatMap { (classDescriptor, contributeAnnotation) ->

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/BindingModuleGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/BindingModuleGenerator.kt
@@ -181,9 +181,7 @@ internal class BindingModuleGenerator(
       val bindingsReplacedInDaggerModules = contributedModuleClasses
         .asSequence()
         .filter { it.scope(contributesToFqName, module) == scope }
-        .filterNot {
-          it.fqName in excludedTypesForScope[scope].orEmpty().map { it.fqNameSafe }
-        }
+        .filter { it.fqName !in excludedTypesForScope[scope].orEmpty().map { it.fqNameSafe } }
         .flatMap { it.replaces(contributesToFqName, module) }
         .plus(
           classScanner
@@ -194,9 +192,7 @@ internal class BindingModuleGenerator(
               scope = scope
             )
             .filter { it.annotationOrNull(daggerModuleFqName) != null }
-            .filterNot {
-              it in excludedTypesForScope[scope].orEmpty()
-            }
+            .filter { it !in excludedTypesForScope[scope].orEmpty() }
             .flatMap {
               it.annotationOrNull(contributesToFqName, scope)
                 ?.replaces(module)

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/BindingModuleGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/BindingModuleGenerator.kt
@@ -173,6 +173,9 @@ internal class BindingModuleGenerator(
     module: ModuleDescriptor
   ): Collection<GeneratedFile> {
     return mergedScopes.flatMap { (scope, daggerModuleFiles) ->
+      // Precompute this list once per scope since it expensive.
+      val excludedNames = excludedTypesForScope[scope].orEmpty().map { it.fqNameSafe }
+
       // Contributed Dagger modules can replace other Dagger modules but also contributed bindings.
       // If a binding is replaced, then we must not generate the binding method.
       //
@@ -182,7 +185,7 @@ internal class BindingModuleGenerator(
         .asSequence()
         .filter { it.scope(contributesToFqName, module) == scope }
         // Ignore replaced bindings specified by excluded modules for this scope.
-        .filter { it.fqName !in excludedTypesForScope[scope].orEmpty().map { it.fqNameSafe } }
+        .filter { it.fqName !in excludedNames }
         .flatMap { it.replaces(contributesToFqName, module) }
         .plus(
           classScanner

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/BindingModuleGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/BindingModuleGenerator.kt
@@ -88,7 +88,6 @@ internal class BindingModuleGenerator(
   private val mergedScopes = mutableMapOf<FqName, MutableList<Pair<File, KtClassOrObject>>>()
     .withDefault { mutableListOf() }
 
-  // excludes DaggerModule1
   private val excludedTypesForScope = mutableMapOf<FqName, List<ClassDescriptor>>()
 
   private val contributedBindingClasses = mutableListOf<FqName>()

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/BindingModuleGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/BindingModuleGenerator.kt
@@ -181,6 +181,7 @@ internal class BindingModuleGenerator(
       val bindingsReplacedInDaggerModules = contributedModuleClasses
         .asSequence()
         .filter { it.scope(contributesToFqName, module) == scope }
+        // Ignore replaced bindings specified by excluded modules for this scope.
         .filter { it.fqName !in excludedTypesForScope[scope].orEmpty().map { it.fqNameSafe } }
         .flatMap { it.replaces(contributesToFqName, module) }
         .plus(
@@ -192,6 +193,7 @@ internal class BindingModuleGenerator(
               scope = scope
             )
             .filter { it.annotationOrNull(daggerModuleFqName) != null }
+            // Ignore replaced bindings specified by excluded modules for this scope.
             .filter { it !in excludedTypesForScope[scope].orEmpty() }
             .flatMap {
               it.annotationOrNull(contributesToFqName, scope)

--- a/compiler/src/test/java/com/squareup/anvil/compiler/ModuleMergerTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/ModuleMergerTest.kt
@@ -675,6 +675,36 @@ class ModuleMergerTest(
     }
   }
 
+  @Test fun `contributed modules cannot be replaced by excluded modules`() {
+    compile(
+      """
+      package com.squareup.test
+
+      import com.squareup.anvil.annotations.ContributesTo
+      $import
+
+      @ContributesTo(Any::class, replaces = [DaggerModule2::class])
+      @dagger.Module
+      abstract class DaggerModule1
+
+      @ContributesTo(Any::class)
+      @dagger.Module
+      abstract class DaggerModule2 
+
+      $annotation(
+          scope = Any::class,
+          exclude = [
+            DaggerModule1::class
+          ]
+      )
+      interface ComponentInterface
+      """
+    ) {
+      val component = componentInterface.anyDaggerComponent
+      assertThat(component.modules.withoutAnvilModule()).containsExactly(daggerModule2.kotlin)
+    }
+  }
+
   @Test fun `contributed bindings can be excluded`() {
     compile(
       """

--- a/compiler/src/test/java/com/squareup/anvil/compiler/codegen/BindingModuleGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/codegen/BindingModuleGeneratorTest.kt
@@ -392,6 +392,94 @@ class BindingModuleGeneratorTest(
     }
   }
 
+  @Test fun `the contributed binding is not replaced by excluded modules`() {
+    compile(
+      """
+      package com.squareup.test
+      
+      import com.squareup.anvil.annotations.ContributesBinding
+      import com.squareup.anvil.annotations.ContributesTo
+      $import
+
+      interface ParentInterface
+
+      @ContributesBinding(Any::class)
+      interface ContributingInterface : ParentInterface
+      
+      @ContributesTo(
+          Any::class,
+          replaces = [ContributingInterface::class]
+      )
+      @dagger.Module
+      abstract class DaggerModule1
+      
+      $annotation(Any::class, exclude = [DaggerModule1::class])
+      interface ComponentInterface
+      """
+    ) {
+      val modules = if (annotationClass == MergeModules::class) {
+        componentInterface.daggerModule.includes.toList()
+      } else {
+        componentInterface.anyDaggerComponent.modules
+      }
+      assertThat(modules).containsExactly(componentInterfaceAnvilModule.kotlin)
+
+      val methods = modules.first().java.declaredMethods
+      assertThat(methods).hasLength(1)
+
+      with(methods[0]) {
+        assertThat(returnType).isEqualTo(parentInterface)
+        assertThat(parameterTypes.toList()).containsExactly(contributingInterface)
+        assertThat(isAbstract).isTrue()
+        assertThat(isAnnotationPresent(Binds::class.java)).isTrue()
+      }
+    }
+  }
+
+  @Test fun `the contributed multibinding is not replaced by excluded modules`() {
+    compile(
+      """
+      package com.squareup.test
+      
+      import com.squareup.anvil.annotations.ContributesMultibinding
+      import com.squareup.anvil.annotations.ContributesTo
+      $import
+
+      interface ParentInterface
+
+      @ContributesMultibinding(Any::class)
+      interface ContributingInterface : ParentInterface
+      
+      @ContributesTo(
+          Any::class,
+          replaces = [ContributingInterface::class]
+      )
+      @dagger.Module
+      abstract class DaggerModule1
+      
+      $annotation(Any::class, exclude = [DaggerModule1::class])
+      interface ComponentInterface
+      """
+    ) {
+      val modules = if (annotationClass == MergeModules::class) {
+        componentInterface.daggerModule.includes.toList()
+      } else {
+        componentInterface.anyDaggerComponent.modules
+      }
+      assertThat(modules).containsExactly(componentInterfaceAnvilModule.kotlin)
+
+      val methods = modules.first().java.declaredMethods
+      assertThat(methods).hasLength(1)
+
+      with(methods[0]) {
+        assertThat(returnType).isEqualTo(parentInterface)
+        assertThat(parameterTypes.toList()).containsExactly(contributingInterface)
+        assertThat(isAbstract).isTrue()
+        assertThat(isAnnotationPresent(Binds::class.java)).isTrue()
+      }
+    }
+  }
+
   private val Class<*>.anyDaggerComponent: AnyDaggerComponent
     get() = anyDaggerComponent(annotationClass)
 }

--- a/compiler/src/test/java/com/squareup/anvil/compiler/codegen/BindingModuleGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/codegen/BindingModuleGeneratorTest.kt
@@ -436,50 +436,6 @@ class BindingModuleGeneratorTest(
     }
   }
 
-  @Test fun `the contributed multibinding is not replaced by excluded modules`() {
-    compile(
-      """
-      package com.squareup.test
-      
-      import com.squareup.anvil.annotations.ContributesMultibinding
-      import com.squareup.anvil.annotations.ContributesTo
-      $import
-
-      interface ParentInterface
-
-      @ContributesMultibinding(Any::class)
-      interface ContributingInterface : ParentInterface
-      
-      @ContributesTo(
-          Any::class,
-          replaces = [ContributingInterface::class]
-      )
-      @dagger.Module
-      abstract class DaggerModule1
-      
-      $annotation(Any::class, exclude = [DaggerModule1::class])
-      interface ComponentInterface
-      """
-    ) {
-      val modules = if (annotationClass == MergeModules::class) {
-        componentInterface.daggerModule.includes.toList()
-      } else {
-        componentInterface.anyDaggerComponent.modules
-      }
-      assertThat(modules).containsExactly(componentInterfaceAnvilModule.kotlin)
-
-      val methods = modules.first().java.declaredMethods
-      assertThat(methods).hasLength(1)
-
-      with(methods[0]) {
-        assertThat(returnType).isEqualTo(parentInterface)
-        assertThat(parameterTypes.toList()).containsExactly(contributingInterface)
-        assertThat(isAbstract).isTrue()
-        assertThat(isAnnotationPresent(Binds::class.java)).isTrue()
-      }
-    }
-  }
-
   private val Class<*>.anyDaggerComponent: AnyDaggerComponent
     get() = anyDaggerComponent(annotationClass)
 }

--- a/compiler/src/test/java/com/squareup/anvil/compiler/codegen/BindingModuleMultibindingSetTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/codegen/BindingModuleMultibindingSetTest.kt
@@ -345,6 +345,7 @@ class BindingModuleMultibindingSetTest(
         assertThat(parameterTypes.toList()).containsExactly(contributingInterface)
         assertThat(isAbstract).isTrue()
         assertThat(isAnnotationPresent(Binds::class.java)).isTrue()
+        assertThat(isAnnotationPresent(IntoSet::class.java)).isTrue()
       }
     }
   }

--- a/compiler/src/test/java/com/squareup/anvil/compiler/codegen/BindingModuleMultibindingSetTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/codegen/BindingModuleMultibindingSetTest.kt
@@ -305,6 +305,50 @@ class BindingModuleMultibindingSetTest(
     }
   }
 
+  @Test fun `the contributed multibinding is not replaced by excluded modules`() {
+    compile(
+      """
+      package com.squareup.test
+      
+      import com.squareup.anvil.annotations.ContributesMultibinding
+      import com.squareup.anvil.annotations.ContributesTo
+      $import
+
+      interface ParentInterface
+
+      @ContributesMultibinding(Any::class)
+      interface ContributingInterface : ParentInterface
+      
+      @ContributesTo(
+          Any::class,
+          replaces = [ContributingInterface::class]
+      )
+      @dagger.Module
+      abstract class DaggerModule1
+      
+      $annotation(Any::class, exclude = [DaggerModule1::class])
+      interface ComponentInterface
+      """
+    ) {
+      val modules = if (annotationClass == MergeModules::class) {
+        componentInterface.daggerModule.includes.toList()
+      } else {
+        componentInterface.anyDaggerComponent.modules
+      }
+      assertThat(modules).containsExactly(componentInterfaceAnvilModule.kotlin)
+
+      val methods = modules.first().java.declaredMethods
+      assertThat(methods).hasLength(1)
+
+      with(methods[0]) {
+        assertThat(returnType).isEqualTo(parentInterface)
+        assertThat(parameterTypes.toList()).containsExactly(contributingInterface)
+        assertThat(isAbstract).isTrue()
+        assertThat(isAnnotationPresent(Binds::class.java)).isTrue()
+      }
+    }
+  }
+
   private val Class<*>.anyDaggerComponent: AnyDaggerComponent
     get() = anyDaggerComponent(annotationClass)
 }


### PR DESCRIPTION
Fixes #301. Modules and bindings are no longer replaced if the replacement is declared by an excluded module.

Open to better ways of accomplishing this as I found the fq and psi class work a little tricky.