### PR TITLE
Add rawTypeFilter to KotlinType.asTypeName()

### DIFF
--- a/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/KotlinPoetUtils.kt
+++ b/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/KotlinPoetUtils.kt
@@ -185,7 +185,7 @@ public fun KtTypeReference.requireTypeName(
 
 @ExperimentalAnvilApi
 public fun KotlinType.asTypeName(): TypeName {
-  return asTypeName { true }!!
+  return asTypeNameOrNull { true }!!
 }
 
 /**
@@ -194,7 +194,9 @@ public fun KotlinType.asTypeName(): TypeName {
  *                      resolve type arguments.
  */
 @ExperimentalAnvilApi
-public fun KotlinType.asTypeName(rawTypeFilter: (ClassName) -> Boolean = { true }): TypeName? {
+public fun KotlinType.asTypeNameOrNull(
+  rawTypeFilter: (ClassName) -> Boolean = { true }
+): TypeName? {
   if (isTypeParameter()) return TypeVariableName(toString())
 
   val className = classDescriptorForType().asClassName()

--- a/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/KotlinPoetUtils.kt
+++ b/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/KotlinPoetUtils.kt
@@ -185,9 +185,22 @@ public fun KtTypeReference.requireTypeName(
 
 @ExperimentalAnvilApi
 public fun KotlinType.asTypeName(): TypeName {
+  return asTypeName { true }!!
+}
+
+/**
+ * @param rawTypeFilter an optional raw type filter to allow for
+ *                      short-circuiting this before attempting to
+ *                      resolve type arguments.
+ */
+@ExperimentalAnvilApi
+public fun KotlinType.asTypeName(rawTypeFilter: (ClassName) -> Boolean = { true }): TypeName? {
   if (isTypeParameter()) return TypeVariableName(toString())
 
   val className = classDescriptorForType().asClassName()
+  if (!rawTypeFilter(className)) {
+    return null
+  }
   if (arguments.isEmpty()) return className.copy(nullable = isMarkedNullable)
 
   val argumentTypeNames = arguments.map { typeProjection ->


### PR DESCRIPTION
This optimization allows for short-circuiting the type resolution if the desired raw type isn't applicable