### PR TITLE
Introduce a variant filter

### DIFF
--- a/gradle-plugin/src/main/java/com/squareup/anvil/plugin/AnvilExtension.kt
+++ b/gradle-plugin/src/main/java/com/squareup/anvil/plugin/AnvilExtension.kt
@@ -1,5 +1,6 @@
 package com.squareup.anvil.plugin
 
+import org.gradle.api.Action
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
 import javax.inject.Inject
@@ -42,6 +43,17 @@ public abstract class AnvilExtension @Inject constructor(objects: ObjectFactory)
    */
   public val disableComponentMerging: Property<Boolean> = objects.property(Boolean::class.java)
     .convention(false)
+
+  @Suppress("PropertyName")
+  internal var _variantFilter: Action<VariantFilter>? = null
+
+  /**
+   * Configures each variant of this project. For Android projects these are the respective
+   * Android variants, for JVM projects these are usually the main and test variant.
+   */
+  public fun variantFilter(action: Action<VariantFilter>) {
+    _variantFilter = action
+  }
 
   /*
    * The below properties are legacy former properties. We do a bit of Kotlin sugar to preserve

--- a/gradle-plugin/src/main/java/com/squareup/anvil/plugin/VariantFilter.kt
+++ b/gradle-plugin/src/main/java/com/squareup/anvil/plugin/VariantFilter.kt
@@ -1,0 +1,28 @@
+package com.squareup.anvil.plugin
+
+import com.android.build.gradle.api.BaseVariant
+import org.gradle.api.Named
+
+public interface VariantFilter : Named {
+
+  /**
+   * Indicate whether or not to ignore Anvil for this particular variant. Default is false.
+   */
+  public var ignore: Boolean
+}
+
+internal class CommonFilter(
+  private val name: String
+) : VariantFilter {
+  override fun getName(): String = name
+  override var ignore: Boolean = false
+}
+
+public class JvmVariantFilter internal constructor(
+  commonFilter: CommonFilter
+) : VariantFilter by commonFilter
+
+public class AndroidVariantFilter internal constructor(
+  commonFilter: CommonFilter,
+  public val androidVariant: BaseVariant
+) : VariantFilter by commonFilter

--- a/gradle-plugin/src/main/java/com/squareup/anvil/plugin/VariantFilter.kt
+++ b/gradle-plugin/src/main/java/com/squareup/anvil/plugin/VariantFilter.kt
@@ -9,13 +9,56 @@ public interface VariantFilter : Named {
    * Indicate whether or not to ignore Anvil for this particular variant. Default is false.
    */
   public var ignore: Boolean
+
+  /**
+   * Indicate whether Dagger factory generation for this variant should be enabled. The default
+   * value comes from the [AnvilExtension]. See [AnvilExtension.generateDaggerFactories] for more
+   * details.
+   */
+  public var generateDaggerFactories: Boolean
+
+  /**
+   * Indicate whether only Dagger factories for this variant should be generated. The default
+   * value comes from the [AnvilExtension]. See [AnvilExtension.generateDaggerFactoriesOnly] for
+   * more details.
+   */
+  public var generateDaggerFactoriesOnly: Boolean
+
+  /**
+   * Indicate whether component merging for this variant should be disabled. The default
+   * value comes from the [AnvilExtension]. See [AnvilExtension.disableComponentMerging] for more
+   * details.
+   */
+  public var disableComponentMerging: Boolean
 }
 
 internal class CommonFilter(
-  private val name: String
+  private val name: String,
+  private val extension: AnvilExtension
 ) : VariantFilter {
   override fun getName(): String = name
   override var ignore: Boolean = false
+
+  private var generateDaggerFactoriesOverride: Boolean? = null
+  override var generateDaggerFactories: Boolean
+    get() = generateDaggerFactoriesOverride ?: extension.generateDaggerFactories.get()
+    set(value) {
+      generateDaggerFactoriesOverride = value
+    }
+
+  private var generateDaggerFactoriesOnlyOverride: Boolean? = null
+  override var generateDaggerFactoriesOnly: Boolean
+    get() = generateDaggerFactoriesOnlyOverride ?: extension.generateDaggerFactoriesOnly.get()
+    set(value) {
+      generateDaggerFactoriesOnlyOverride = value
+    }
+
+  private var disableComponentMergingOverride: Boolean? = null
+  override var disableComponentMerging: Boolean
+    get() = disableComponentMergingOverride ?: extension.disableComponentMerging.get()
+    set(value) {
+      disableComponentMergingOverride = value
+    }
 }
 
 public class JvmVariantFilter internal constructor(

--- a/integration-tests/mpp/android-module/build.gradle
+++ b/integration-tests/mpp/android-module/build.gradle
@@ -1,3 +1,6 @@
+import com.android.build.gradle.api.UnitTestVariant
+import com.squareup.anvil.plugin.AndroidVariantFilter
+
 plugins {
   id 'org.jetbrains.kotlin.multiplatform'
   id 'com.android.library'
@@ -47,6 +50,15 @@ kotlin {
         implementation deps.junit
         implementation deps.truth
       }
+    }
+  }
+}
+
+anvil {
+  variantFilter { filter ->
+    if (filter instanceof AndroidVariantFilter &&
+        filter.androidVariant instanceof UnitTestVariant) {
+      ignore = true
     }
   }
 }

--- a/integration-tests/tests/build.gradle
+++ b/integration-tests/tests/build.gradle
@@ -6,6 +6,12 @@ kotlin {
   explicitApi()
 }
 
+anvil {
+  variantFilter {
+    ignore = name == 'main'
+  }
+}
+
 dependencies {
   testImplementation project(':integration-tests:library')
   testImplementation testFixtures(project(":compiler-utils"))


### PR DESCRIPTION
Introduce a new `VariantFilter` for the Gradle extension. This API allows you to enable and disable Anvil for specific variants. 

Allow to override `generateDaggerFactories`, `generateDaggerFactoriesOnly` and `disableComponentMerging` through the variant filter.

This resolves #100.
