### PR TITLE
Remove deprecated Kotlin build flag.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -33,10 +33,6 @@ kapt.use.worker.api=true
 # https://blog.jetbrains.com/kotlin/2019/04/kotlin-1-3-30-released/
 kapt.include.compile.classpath=false
 
-# Use parallel execution with Gradle's worker API
-# https://blog.jetbrains.com/kotlin/2019/01/kotlin-1-3-20-released/
-kotlin.parallel.tasks.in.project=true
-
 # Don't recompile Kotlin code if changes in Java don't have an effect.
 # https://blog.jetbrains.com/kotlin/2018/01/kotlin-1-2-20-is-out/
 kotlin.incremental.usePreciseJavaTracking=true


### PR DESCRIPTION
Deprecated since Kotlin 1.5.20.