### PR TITLE
Account for member injection in assisted types

### DIFF
--- a/compiler-utils/src/testFixtures/java/com/squareup/anvil/compiler/internal/testing/ReflectionTestUtils.kt
+++ b/compiler-utils/src/testFixtures/java/com/squareup/anvil/compiler/internal/testing/ReflectionTestUtils.kt
@@ -3,7 +3,7 @@
 package com.squareup.anvil.compiler.internal.testing
 
 import com.squareup.anvil.annotations.ExperimentalAnvilApi
-import java.lang.reflect.Executable
+import java.lang.reflect.AccessibleObject
 import java.lang.reflect.Member
 import java.lang.reflect.Modifier
 
@@ -23,7 +23,7 @@ public fun <T : Any> Class<T>.createInstance(
 ): T = declaredConstructors.single().use { it.newInstance(*initargs) } as T
 
 @ExperimentalAnvilApi
-public inline fun <T, E : Executable> E.use(block: (E) -> T): T {
+public inline fun <T, E : AccessibleObject> E.use(block: (E) -> T): T {
   // Deprecated since Java 9, but many projects still use JDK 8 for compilation.
   @Suppress("DEPRECATION")
   val original = isAccessible

--- a/compiler-utils/src/testFixtures/java/com/squareup/anvil/compiler/internal/testing/TestUtils.kt
+++ b/compiler-utils/src/testFixtures/java/com/squareup/anvil/compiler/internal/testing/TestUtils.kt
@@ -180,6 +180,13 @@ public fun Any.invokeGet(vararg args: Any?): Any {
   return method.invoke(this, *args)
 }
 
+@ExperimentalAnvilApi
+public fun Any.getPropertyValue(name: String): Any {
+  val propField = this::class.java.getDeclaredField(name)
+    .apply { isAccessible = true }
+  return propField.get(this)
+}
+
 @Suppress("UNCHECKED_CAST")
 @ExperimentalAnvilApi
 public fun <T> Annotation.getValue(): T =

--- a/compiler-utils/src/testFixtures/java/com/squareup/anvil/compiler/internal/testing/TestUtils.kt
+++ b/compiler-utils/src/testFixtures/java/com/squareup/anvil/compiler/internal/testing/TestUtils.kt
@@ -182,9 +182,7 @@ public fun Any.invokeGet(vararg args: Any?): Any {
 
 @ExperimentalAnvilApi
 public fun Any.getPropertyValue(name: String): Any {
-  val propField = this::class.java.getDeclaredField(name)
-    .apply { isAccessible = true }
-  return propField.get(this)
+  return this::class.java.getDeclaredField(name).use { it.get(this) }
 }
 
 @Suppress("UNCHECKED_CAST")

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/InjectConstructorFactoryGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/InjectConstructorFactoryGenerator.kt
@@ -131,7 +131,13 @@ internal class InjectConstructorFactoryGenerator : PrivateCodeGenerator() {
               } else {
                 val instanceName = "instance"
                 addStatement("val $instanceName = newInstance($newInstanceArgumentList)")
-                addMemberInjection(packageName, clazz, memberInjectParameters, memberInjectProperties, instanceName)
+                addMemberInjection(
+                  packageName,
+                  clazz,
+                  memberInjectParameters,
+                  memberInjectProperties,
+                  instanceName
+                )
                 addStatement("return $instanceName")
               }
             }

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/InjectConstructorFactoryGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/InjectConstructorFactoryGenerator.kt
@@ -16,7 +16,6 @@ import com.squareup.anvil.compiler.internal.buildFile
 import com.squareup.anvil.compiler.internal.capitalize
 import com.squareup.anvil.compiler.internal.classesAndInnerClass
 import com.squareup.anvil.compiler.internal.generateClassName
-import com.squareup.anvil.compiler.internal.hasAnnotation
 import com.squareup.anvil.compiler.internal.safePackageString
 import com.squareup.anvil.compiler.internal.typeVariableNames
 import com.squareup.kotlinpoet.ClassName
@@ -31,12 +30,9 @@ import com.squareup.kotlinpoet.asClassName
 import com.squareup.kotlinpoet.jvm.jvmStatic
 import dagger.internal.Factory
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
-import org.jetbrains.kotlin.lexer.KtTokens
-import org.jetbrains.kotlin.psi.KtClassBody
 import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.psi.KtConstructor
 import org.jetbrains.kotlin.psi.KtFile
-import org.jetbrains.kotlin.psi.psiUtil.visibilityModifierTypeOrDefault
 import java.io.File
 
 @AutoService(CodeGenerator::class)
@@ -68,13 +64,7 @@ internal class InjectConstructorFactoryGenerator : PrivateCodeGenerator() {
     val packageName = clazz.containingKtFile.packageFqName.safePackageString()
     val className = "${clazz.generateClassName()}_Factory"
 
-    val memberInjectProperties = clazz.children
-      .asSequence()
-      .filterIsInstance<KtClassBody>()
-      .flatMap { it.properties.asSequence() }
-      .filterNot { it.visibilityModifierTypeOrDefault() == KtTokens.PRIVATE_KEYWORD }
-      .filter { it.hasAnnotation(injectFqName, module) }
-      .toList()
+    val memberInjectProperties = clazz.injectedMembers(module)
 
     val parameters = constructor.valueParameters
       .plus(memberInjectProperties)

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/MembersInjectionUtils.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/MembersInjectionUtils.kt
@@ -17,14 +17,16 @@ import org.jetbrains.kotlin.psi.psiUtil.visibilityModifierTypeOrDefault
 
 // TODO
 //  Include methods: https://github.com/square/anvil/issues/339
-//  Include property setters:https://github.com/square/anvil/issues/340
 //  Include superclass: https://github.com/square/anvil/issues/343
 internal fun KtClassOrObject.injectedMembers(module: ModuleDescriptor) = children
   .asSequence()
   .filterIsInstance<KtClassBody>()
   .flatMap { it.properties.asSequence() }
   .filterNot { it.visibilityModifierTypeOrDefault() == KtTokens.PRIVATE_KEYWORD }
-  .filter { it.hasAnnotation(injectFqName, module) }
+  .filter {
+    it.hasAnnotation(injectFqName, module) ||
+      it.setter?.hasAnnotation(injectFqName, module) == true
+  }
   .toList()
 
 internal fun FunSpec.Builder.addMemberInjection(

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/MembersInjectionUtils.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/MembersInjectionUtils.kt
@@ -1,0 +1,21 @@
+package com.squareup.anvil.compiler.codegen.dagger
+
+import com.squareup.anvil.compiler.injectFqName
+import com.squareup.anvil.compiler.internal.hasAnnotation
+import org.jetbrains.kotlin.descriptors.ModuleDescriptor
+import org.jetbrains.kotlin.lexer.KtTokens
+import org.jetbrains.kotlin.psi.KtClassBody
+import org.jetbrains.kotlin.psi.KtClassOrObject
+import org.jetbrains.kotlin.psi.psiUtil.visibilityModifierTypeOrDefault
+
+// TODO
+//  Include methods: https://github.com/square/anvil/issues/339
+//  Include property setters:https://github.com/square/anvil/issues/340
+//  Include superclass: https://github.com/square/anvil/issues/343
+internal fun KtClassOrObject.injectedMembers(module: ModuleDescriptor) = children
+  .asSequence()
+  .filterIsInstance<KtClassBody>()
+  .flatMap { it.properties.asSequence() }
+  .filterNot { it.visibilityModifierTypeOrDefault() == KtTokens.PRIVATE_KEYWORD }
+  .filter { it.hasAnnotation(injectFqName, module) }
+  .toList()

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/MembersInjectionUtils.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/MembersInjectionUtils.kt
@@ -1,11 +1,18 @@
 package com.squareup.anvil.compiler.codegen.dagger
 
+import com.squareup.anvil.compiler.codegen.Parameter
+import com.squareup.anvil.compiler.daggerDoubleCheckFqNameString
 import com.squareup.anvil.compiler.injectFqName
+import com.squareup.anvil.compiler.internal.capitalize
+import com.squareup.anvil.compiler.internal.generateClassName
 import com.squareup.anvil.compiler.internal.hasAnnotation
+import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.FunSpec
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.KtClassBody
 import org.jetbrains.kotlin.psi.KtClassOrObject
+import org.jetbrains.kotlin.psi.KtProperty
 import org.jetbrains.kotlin.psi.psiUtil.visibilityModifierTypeOrDefault
 
 // TODO
@@ -19,3 +26,29 @@ internal fun KtClassOrObject.injectedMembers(module: ModuleDescriptor) = childre
   .filterNot { it.visibilityModifierTypeOrDefault() == KtTokens.PRIVATE_KEYWORD }
   .filter { it.hasAnnotation(injectFqName, module) }
   .toList()
+
+internal fun FunSpec.Builder.addMemberInjection(
+  packageName: String,
+  clazz: KtClassOrObject,
+  memberInjectParameters: List<Parameter>,
+  memberInjectProperties: List<KtProperty>,
+  instanceName: String
+) {
+  val memberInjectorClassName = "${clazz.generateClassName()}_MembersInjector"
+  val memberInjectorClass = ClassName(packageName, memberInjectorClassName)
+
+  memberInjectParameters.forEachIndexed { index, parameter ->
+    val property = memberInjectProperties[index]
+    val propertyName = property.nameAsSafeName.asString()
+    val functionName = "inject${propertyName.capitalize()}"
+
+    val param = when {
+      parameter.isWrappedInProvider -> parameter.name
+      parameter.isWrappedInLazy ->
+        "$daggerDoubleCheckFqNameString.lazy(${parameter.name})"
+      else -> parameter.name + ".get()"
+    }
+
+    addStatement("%T.$functionName($instanceName, $param)", memberInjectorClass)
+  }
+}

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/MembersInjectionUtils.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/MembersInjectionUtils.kt
@@ -21,7 +21,7 @@ import org.jetbrains.kotlin.psi.psiUtil.visibilityModifierTypeOrDefault
 internal fun KtClassOrObject.injectedMembers(module: ModuleDescriptor) = children
   .asSequence()
   .filterIsInstance<KtClassBody>()
-  .flatMap { it.properties.asSequence() }
+  .flatMap { it.properties }
   .filterNot { it.visibilityModifierTypeOrDefault() == KtTokens.PRIVATE_KEYWORD }
   .filter {
     it.hasAnnotation(injectFqName, module) ||

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/MembersInjectionUtils.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/MembersInjectionUtils.kt
@@ -4,16 +4,25 @@ import com.squareup.anvil.compiler.codegen.Parameter
 import com.squareup.anvil.compiler.daggerDoubleCheckFqNameString
 import com.squareup.anvil.compiler.injectFqName
 import com.squareup.anvil.compiler.internal.capitalize
+import com.squareup.anvil.compiler.internal.findAnnotation
 import com.squareup.anvil.compiler.internal.generateClassName
 import com.squareup.anvil.compiler.internal.hasAnnotation
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FunSpec
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
+import org.jetbrains.kotlin.descriptors.annotations.AnnotationUseSiteTarget
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.KtClassBody
 import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.psi.KtProperty
 import org.jetbrains.kotlin.psi.psiUtil.visibilityModifierTypeOrDefault
+
+internal fun KtProperty.isSetterInjected(module: ModuleDescriptor): Boolean {
+  return setter?.hasAnnotation(injectFqName, module) == true ||
+    findAnnotation(injectFqName, module)
+    ?.useSiteTarget
+    ?.getAnnotationUseSiteTarget() == AnnotationUseSiteTarget.PROPERTY_SETTER
+}
 
 // TODO
 //  Include methods: https://github.com/square/anvil/issues/339
@@ -25,7 +34,7 @@ internal fun KtClassOrObject.injectedMembers(module: ModuleDescriptor) = childre
   .filterNot { it.visibilityModifierTypeOrDefault() == KtTokens.PRIVATE_KEYWORD }
   .filter {
     it.hasAnnotation(injectFqName, module) ||
-      it.setter?.hasAnnotation(injectFqName, module) == true
+      it.isSetterInjected(module)
   }
   .toList()
 

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/MembersInjectorGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/MembersInjectorGenerator.kt
@@ -8,13 +8,11 @@ import com.squareup.anvil.compiler.api.createGeneratedFile
 import com.squareup.anvil.compiler.codegen.PrivateCodeGenerator
 import com.squareup.anvil.compiler.codegen.mapToParameter
 import com.squareup.anvil.compiler.daggerDoubleCheckFqNameString
-import com.squareup.anvil.compiler.injectFqName
 import com.squareup.anvil.compiler.internal.asClassName
 import com.squareup.anvil.compiler.internal.buildFile
 import com.squareup.anvil.compiler.internal.capitalize
 import com.squareup.anvil.compiler.internal.classesAndInnerClass
 import com.squareup.anvil.compiler.internal.generateClassName
-import com.squareup.anvil.compiler.internal.hasAnnotation
 import com.squareup.anvil.compiler.internal.isGenericClass
 import com.squareup.anvil.compiler.internal.isQualifier
 import com.squareup.anvil.compiler.internal.requireClassDescriptor
@@ -37,12 +35,9 @@ import dagger.MembersInjector
 import dagger.internal.InjectedFieldSignature
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 import org.jetbrains.kotlin.descriptors.PropertyDescriptor
-import org.jetbrains.kotlin.lexer.KtTokens
-import org.jetbrains.kotlin.psi.KtClassBody
 import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtProperty
-import org.jetbrains.kotlin.psi.psiUtil.visibilityModifierTypeOrDefault
 import org.jetbrains.kotlin.resolve.scopes.DescriptorKindFilter
 import java.io.File
 
@@ -59,13 +54,7 @@ internal class MembersInjectorGenerator : PrivateCodeGenerator() {
     projectFiles
       .classesAndInnerClass(module)
       .forEach { clazz ->
-        val injectProperties = clazz.children
-          .asSequence()
-          .filterIsInstance<KtClassBody>()
-          .flatMap { it.properties.asSequence() }
-          .filterNot { it.visibilityModifierTypeOrDefault() == KtTokens.PRIVATE_KEYWORD }
-          .filter { it.hasAnnotation(injectFqName, module) }
-          .toList()
+        val injectProperties = clazz.injectedMembers(module)
           .ifEmpty { return@forEach }
 
         generateMembersInjectorClass(

--- a/compiler/src/test/java/com/squareup/anvil/compiler/TestUtils.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/TestUtils.kt
@@ -70,6 +70,9 @@ internal val Result.daggerModule4: Class<*>
 internal val Result.innerModule: Class<*>
   get() = classLoader.loadClass("com.squareup.test.ComponentInterface\$InnerModule")
 
+internal val Result.nestedInjectClass: Class<*>
+  get() = classLoader.loadClass("com.squareup.test.ParentClass\$NestedInjectClass")
+
 internal val Result.injectClass: Class<*>
   get() = classLoader.loadClass("com.squareup.test.InjectClass")
 

--- a/compiler/src/test/java/com/squareup/anvil/compiler/dagger/AssistedFactoryGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/dagger/AssistedFactoryGeneratorTest.kt
@@ -29,7 +29,7 @@ class AssistedFactoryGeneratorTest(
   companion object {
     @Parameters(name = "Use Dagger: {0}")
     @JvmStatic fun useDagger(): Collection<Any> {
-      return listOf(false)
+      return listOf(true, false)
     }
   }
 

--- a/compiler/src/test/java/com/squareup/anvil/compiler/dagger/MembersInjectorGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/dagger/MembersInjectorGeneratorTest.kt
@@ -40,15 +40,18 @@ class MembersInjectorGeneratorTest(
 package com.squareup.test;
 
 import dagger.MembersInjector;
+import dagger.internal.DaggerGenerated;
 import dagger.internal.InjectedFieldSignature;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 import javax.inject.Named;
 import javax.inject.Provider;
 import kotlin.Pair;
 import kotlin.jvm.functions.Function1;
 
+@DaggerGenerated
 @Generated(
     value = "dagger.internal.codegen.ComponentProcessor",
     comments = "https://dagger.dev"
@@ -70,24 +73,34 @@ public final class InjectClass_MembersInjector implements MembersInjector<Inject
 
   private final Provider<Set<Function1<List<String>, List<String>>>> setProvider;
 
+  private final Provider<Map<String, String>> p0Provider;
+
+  private final Provider<Map<String, Boolean>> p0Provider2;
+
   public InjectClass_MembersInjector(Provider<String> stringProvider,
       Provider<String> qualifiedStringProvider, Provider<CharSequence> charSequenceProvider,
-      Provider<List<String>> listProvider, Provider<Pair<Pair<String, Integer>,
-      ? extends Set<String>>> pairProvider, Provider<Set<Function1<List<String>, List<String>>>> setProvider) {
+      Provider<List<String>> listProvider,
+      Provider<Pair<Pair<String, Integer>, ? extends Set<String>>> pairProvider,
+      Provider<Set<Function1<List<String>, List<String>>>> setProvider,
+      Provider<Map<String, String>> p0Provider, Provider<Map<String, Boolean>> p0Provider2) {
     this.stringProvider = stringProvider;
     this.qualifiedStringProvider = qualifiedStringProvider;
     this.charSequenceProvider = charSequenceProvider;
     this.listProvider = listProvider;
     this.pairProvider = pairProvider;
     this.setProvider = setProvider;
+    this.p0Provider = p0Provider;
+    this.p0Provider2 = p0Provider2;
   }
 
   public static MembersInjector<InjectClass> create(Provider<String> stringProvider,
       Provider<String> qualifiedStringProvider, Provider<CharSequence> charSequenceProvider,
-      Provider<List<String>> listProvider, Provider<Pair<Pair<String, Integer>,
-      ? extends Set<String>>> pairProvider, Provider<Set<Function1<List<String>,
-      List<String>>>> setProvider) {
-    return new InjectClass_MembersInjector(stringProvider, qualifiedStringProvider, charSequenceProvider, listProvider, pairProvider, setProvider);}
+      Provider<List<String>> listProvider,
+      Provider<Pair<Pair<String, Integer>, ? extends Set<String>>> pairProvider,
+      Provider<Set<Function1<List<String>, List<String>>>> setProvider,
+      Provider<Map<String, String>> p0Provider, Provider<Map<String, Boolean>> p0Provider2) {
+    return new InjectClass_MembersInjector(stringProvider, qualifiedStringProvider, charSequenceProvider, listProvider, pairProvider, setProvider, p0Provider, p0Provider2);
+  }
 
   @Override
   public void injectMembers(InjectClass instance) {
@@ -97,6 +110,8 @@ public final class InjectClass_MembersInjector implements MembersInjector<Inject
     injectList(instance, listProvider.get());
     injectPair(instance, pairProvider.get());
     injectSet(instance, setProvider.get());
+    injectSetSetterAnnotated(instance, p0Provider.get());
+    injectSetSetterAnnotated2(instance, p0Provider2.get());
   }
 
   @InjectedFieldSignature("com.squareup.test.InjectClass.string")
@@ -104,8 +119,8 @@ public final class InjectClass_MembersInjector implements MembersInjector<Inject
     instance.string = string;
   }
 
-  @Named("qualified")
   @InjectedFieldSignature("com.squareup.test.InjectClass.qualifiedString")
+  @Named("qualified")
   public static void injectQualifiedString(InjectClass instance, String qualifiedString) {
     instance.qualifiedString = qualifiedString;
   }
@@ -131,8 +146,16 @@ public final class InjectClass_MembersInjector implements MembersInjector<Inject
       Set<Function1<List<String>, List<String>>> set) {
     instance.set = set;
   }
+
+  public static void injectSetSetterAnnotated(InjectClass instance, Map<String, String> p0) {
+    instance.setSetterAnnotated(p0);
+  }
+
+  public static void injectSetSetterAnnotated2(InjectClass instance, Map<String, Boolean> p0) {
+    instance.setSetterAnnotated2(p0);
+  }
 }
-     */
+*/
 
     compile(
       """

--- a/compiler/src/test/java/com/squareup/anvil/compiler/dagger/MembersInjectorGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/dagger/MembersInjectorGeneratorTest.kt
@@ -255,11 +255,9 @@ public final class InjectClass_MembersInjector implements MembersInjector<Inject
         .invoke(null, injectInstanceStatic, Pair(Pair("e", 1), setOf("f")))
       membersInjector.staticInjectMethod("set")
         .invoke(null, injectInstanceStatic, setOf { _: List<String> -> listOf("g") })
-      // From dagger, it will just see a plain old "set" method rather than a field
-      val name = if (useDagger) "setSetterAnnotated" else "setterAnnotated"
-      membersInjector.staticInjectMethod(name)
+      membersInjector.staticInjectMethod("setSetterAnnotated")
         .invoke(null, injectInstanceStatic, mapOf("Hello" to "World"))
-      membersInjector.staticInjectMethod("${name}2")
+      membersInjector.staticInjectMethod("setSetterAnnotated2")
         .invoke(null, injectInstanceStatic, mapOf("Hello" to false))
 
       assertThat(injectInstanceConstructor).isEqualTo(injectInstanceStatic)


### PR DESCRIPTION
Resolves #342 and also leaves some important consolidated logic toe-holds along the way for helping with #341, #340, #339, and #343