### PR TITLE
Bound type error message

### DIFF
--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/BindingModuleGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/BindingModuleGenerator.kt
@@ -380,20 +380,16 @@ internal class BindingModuleGenerator(
       fun KotlinType.describeTypeParameters(): String = arguments
         .ifEmpty { return "" }
         .joinToString(prefix = "<", postfix = ">") { typeArgument ->
-          typeArgument.type.classDescriptorForType().name.asString() +
-            typeArgument.type.describeTypeParameters()
+          typeArgument.type.toString() + typeArgument.type.describeTypeParameters()
         }
-
-      val boundType = type.typeConstructor
-        .supertypes
-        .first { it.classDescriptorForType() == boundTypeDescriptor }
 
       throw AnvilCompilationException(
         classDescriptor = boundTypeDescriptor,
-        message = "Binding ${boundTypeDescriptor.fqNameSafe} contains type parameters(s)" +
-          " ${boundType.describeTypeParameters()}." +
+        message = "Class ${type.fqNameSafe} binds ${boundTypeDescriptor.fqNameSafe}," +
+          " but the bound type contains type parameter(s)" +
+          " ${boundTypeDescriptor.defaultType.describeTypeParameters()}." +
           " Type parameters in bindings are not supported. This binding needs" +
-          " to be contributed to a dagger module manually"
+          " to be contributed in a Dagger module manually."
       )
     }
   }

--- a/compiler/src/test/java/com/squareup/anvil/compiler/codegen/BindingModuleMultibindingSetTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/codegen/BindingModuleMultibindingSetTest.kt
@@ -269,8 +269,9 @@ class BindingModuleMultibindingSetTest(
 
       assertThat(messages).contains("Source0.kt: (6, 11)")
       assertThat(messages).contains(
-        "Binding com.squareup.test.ParentInterface contains type parameters(s)" +
-          " <Map<String, List<Pair<String, Int>>>, SomeOtherType>"
+        "Class com.squareup.test.ContributingInterface binds com.squareup.test.ParentInterface, " +
+          "but the bound type contains type parameter(s) <T, S>. Type parameters in bindings " +
+          "are not supported. This binding needs to be contributed in a Dagger module manually."
       )
     }
   }


### PR DESCRIPTION
Fix the bound type error message when there are multiple inherited types and actually use the right type parameters.