### PR TITLE
support member injection for superclasses

### DIFF
--- a/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/AnvilModuleDescriptor.kt
+++ b/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/AnvilModuleDescriptor.kt
@@ -12,6 +12,7 @@ import org.jetbrains.kotlin.psi.KtFile
 public interface AnvilModuleDescriptor : ModuleDescriptor {
   public fun resolveClassIdOrNull(classId: ClassId): FqName?
   public fun getClassesAndInnerClasses(ktFile: KtFile): List<KtClassOrObject>
+  public fun getKtClassOrObjectOrNull(fqName: FqName): KtClassOrObject?
 }
 
 @Suppress("NOTHING_TO_INLINE")
@@ -22,6 +23,11 @@ private inline fun ModuleDescriptor.asAnvilModuleDescriptor(): AnvilModuleDescri
 public fun ModuleDescriptor.resolveFqNameOrNull(
   fqName: FqName
 ): FqName? = asAnvilModuleDescriptor().resolveClassIdOrNull(fqName.classIdBestGuess())
+
+@ExperimentalAnvilApi
+public fun ModuleDescriptor.getKtClassOrObjectOrNull(
+  fqName: FqName
+): KtClassOrObject? = asAnvilModuleDescriptor().getKtClassOrObjectOrNull(fqName)
 
 @ExperimentalAnvilApi
 public fun ModuleDescriptor.canResolveFqName(

--- a/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/PsiUtils.kt
+++ b/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/PsiUtils.kt
@@ -20,6 +20,7 @@ import org.jetbrains.kotlin.psi.KtClassBody
 import org.jetbrains.kotlin.psi.KtClassLiteralExpression
 import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
+import org.jetbrains.kotlin.psi.KtEnumEntry
 import org.jetbrains.kotlin.psi.KtFunction
 import org.jetbrains.kotlin.psi.KtFunctionType
 import org.jetbrains.kotlin.psi.KtNameReferenceExpression
@@ -183,6 +184,36 @@ public inline fun <reified T> KtAnnotationEntry.findAnnotationArgument(
     ?.let { valueArgument ->
       valueArgument.children.firstOrNull() as? T
     }
+}
+
+/**
+ * This will return all super classes which are parsed as PSI, which means anything defined in this
+ * module. This will include generated code, assuming it has already been generated. It **will not**
+ * include any classes from other modules or external dependencies.
+ *
+ * The first element in the returned list represents the direct superclass to the receiver. The last
+ * element represents the class which is furthest up-stream.
+ *
+ * If you have a class hierarchy which extends into dependencies, and you need to reference those
+ * super classes, you'll need to take the last class in this list and resolve its `ClassDescriptor`,
+ * then resolve its super-classes that way. Note that this will only work if the last class in the
+ * list is not generated, so that it's parsed and part of the plain ModuleDescriptor.
+ */
+@ExperimentalAnvilApi
+public fun KtClassOrObject.allPsiSuperClasses(
+  module: ModuleDescriptor
+): List<KtClassOrObject> {
+
+  if (this is KtEnumEntry) return emptyList()
+
+  val superOrNull = superTypeListEntries
+    .asSequence()
+    .mapNotNull { it.typeReference?.fqNameOrNull(module) }
+    .mapNotNull { module.getKtClassOrObjectOrNull(it) }
+    .firstOrNull { !it.isInterface() }
+    ?: return emptyList()
+
+  return listOf(superOrNull) + superOrNull.allPsiSuperClasses(module)
 }
 
 @ExperimentalAnvilApi
@@ -498,11 +529,16 @@ public fun KtUserType.findExtendsBound(): List<FqName> {
 
 @ExperimentalAnvilApi
 public fun KtClassOrObject.requireClassDescriptor(module: ModuleDescriptor): ClassDescriptor {
-  return module.resolveClassByFqName(requireFqName(), KotlinLookupLocation(this))
+  return classDescriptorOrNull(module)
     ?: throw AnvilCompilationException(
       "Couldn't resolve class for ${requireFqName()}.",
       element = this
     )
+}
+
+@ExperimentalAnvilApi
+public fun KtClassOrObject.classDescriptorOrNull(module: ModuleDescriptor): ClassDescriptor? {
+  return module.resolveClassByFqName(requireFqName(), KotlinLookupLocation(this))
 }
 
 @ExperimentalAnvilApi

--- a/compiler-utils/src/testFixtures/java/com/squareup/anvil/compiler/internal/testing/TestUtils.kt
+++ b/compiler-utils/src/testFixtures/java/com/squareup/anvil/compiler/internal/testing/TestUtils.kt
@@ -183,7 +183,7 @@ public fun Any.invokeGet(vararg args: Any?): Any {
 
 @ExperimentalAnvilApi
 public fun Any.getPropertyValue(name: String): Any {
-  return this::class.java.getDeclaredField(name).use { it.get(this) }
+  return this::class.java.fields.first { it.name == name }.use { it.get(this) }
 }
 
 @Suppress("UNCHECKED_CAST")

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/DescriptorUtils.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/DescriptorUtils.kt
@@ -1,0 +1,180 @@
+package com.squareup.anvil.compiler.codegen
+
+import com.squareup.anvil.compiler.assistedFqName
+import com.squareup.anvil.compiler.daggerLazyFqName
+import com.squareup.anvil.compiler.injectFqName
+import com.squareup.anvil.compiler.internal.argumentType
+import com.squareup.anvil.compiler.internal.asClassName
+import com.squareup.anvil.compiler.internal.asTypeName
+import com.squareup.anvil.compiler.internal.capitalize
+import com.squareup.anvil.compiler.internal.classDescriptorForType
+import com.squareup.anvil.compiler.internal.isQualifier
+import com.squareup.anvil.compiler.internal.requireClassDescriptor
+import com.squareup.anvil.compiler.internal.toAnnotationSpec
+import com.squareup.anvil.compiler.internal.withJvmSuppressWildcardsIfNeeded
+import com.squareup.anvil.compiler.providerFqName
+import com.squareup.kotlinpoet.ClassName
+import org.jetbrains.kotlin.descriptors.CallableMemberDescriptor
+import org.jetbrains.kotlin.descriptors.ClassDescriptor
+import org.jetbrains.kotlin.descriptors.ModuleDescriptor
+import org.jetbrains.kotlin.descriptors.PropertyDescriptor
+import org.jetbrains.kotlin.descriptors.containingPackage
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameOrNull
+import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
+import org.jetbrains.kotlin.resolve.descriptorUtil.getAllSuperClassifiers
+import org.jetbrains.kotlin.resolve.scopes.DescriptorKindFilter
+import org.jetbrains.kotlin.resolve.scopes.MemberScope
+import org.jetbrains.kotlin.types.KotlinType
+import org.jetbrains.kotlin.types.isNullable
+import org.jetbrains.kotlin.utils.addToStdlib.safeAs
+
+internal fun ClassDescriptor.superClassMemberInjectedParameters(
+  module: ModuleDescriptor
+): List<MemberInjectParameter> = superClassMemberInjectedDescriptors(module)
+  .mapToMemberInjectParameters(module, asClassName())
+
+fun ClassDescriptor.superClassMemberInjectedDescriptors(
+  module: ModuleDescriptor
+): List<CallableMemberDescriptor> {
+
+  return getAllSuperClassifiers()
+    // no point in parsing android/androidx classes for injected params, so skip them
+    .filter { it.containingPackage()?.asString()?.startsWith("android") == false }
+    // the sequence of supers actually starts with itself, so for instance `class Impl : Base()`
+    // returns [ Impl, Base, kotlin.Any ]
+    // drop the first element since this function is supposed to return properties from supers.
+    .drop(1)
+    // look for any @Inject-annotated members.
+    // Downstream properties are parsed before the properties they override.
+    // If a property has already been added from a downstream sub-class, then ignore it.
+    .fold(mutableListOf<CallableMemberDescriptor>()) { acc, classifierDescriptor ->
+
+      classifierDescriptor.fqNameSafe
+        .requireClassDescriptor(module)
+        .unsubstitutedMemberScope
+        .memberInjectedPropertyDescriptors()
+        .forEach { property ->
+          if (acc.none { existing -> existing.name == property.name }) {
+            acc.add(property)
+          }
+        }
+      acc
+    }
+    .toList()
+}
+
+fun MemberScope.memberInjectedPropertyDescriptors(): List<PropertyDescriptor> {
+
+  return getContributedDescriptors(DescriptorKindFilter.VARIABLES)
+    .filterIsInstance<PropertyDescriptor>()
+    .filter { it.hasAnnotation(injectFqName) }
+}
+
+fun PropertyDescriptor.hasAnnotation(annotationFqName: FqName): Boolean {
+
+  // `@Inject lateinit var` is really `@field:Inject lateinit var`, which needs `backingField`
+  return backingField?.annotations?.hasAnnotation(annotationFqName) == true ||
+    setter?.annotations?.hasAnnotation(annotationFqName) == true ||
+    annotations.hasAnnotation(annotationFqName)
+}
+
+fun PropertyDescriptor.isSetterInjected(): Boolean {
+  return setter?.annotations?.hasAnnotation(injectFqName) == true
+}
+
+fun KotlinType.fqNameOrNull(): FqName? = classDescriptorForType()
+  .fqNameOrNull()
+
+internal fun List<CallableMemberDescriptor>.mapToMemberInjectParameters(
+  module: ModuleDescriptor,
+  containingClassName: ClassName
+): List<MemberInjectParameter> {
+
+  return map { descriptor ->
+
+    val type = descriptor.safeAs<PropertyDescriptor>()?.type
+      ?: descriptor.valueParameters.first().type
+
+    val typeFqName = type.fqNameOrNull()
+
+    val isWrappedInProvider = typeFqName == providerFqName
+    val isWrappedInLazy = typeFqName == daggerLazyFqName
+
+    var isLazyWrappedInProvider = false
+
+    val typeName = when {
+      type.isNullable() -> type.asTypeName()
+        .copy(nullable = true)
+
+      isWrappedInLazy || isWrappedInProvider -> {
+        val singleTypeParamType = type.arguments
+          .singleOrNull()
+          ?.type
+
+        if (isWrappedInProvider && singleTypeParamType?.fqNameOrNull() == daggerLazyFqName) {
+
+          // This is a super rare case when someone injects Provider<Lazy<Type>> that requires
+          // special care.
+          isLazyWrappedInProvider = true
+          singleTypeParamType.asTypeName()
+        } else {
+          type.argumentType().asTypeName()
+        }
+      }
+
+      else -> type.asTypeName()
+    }.withJvmSuppressWildcardsIfNeeded(descriptor)
+
+    val assistedAnnotation = descriptor.annotations
+      .findAnnotation(assistedFqName)
+
+    val assistedIdentifier = assistedAnnotation
+      ?.allValueArguments
+      ?.values
+      ?.firstOrNull()
+      ?.value as? String
+      ?: ""
+
+    val memberInjectorClassName = containingClassName.simpleNames
+      .joinToString("_") + "_MembersInjector"
+
+    val memberInjectorClass = ClassName(
+      containingClassName.packageName, memberInjectorClassName
+    )
+
+    val originalName = descriptor.name.asString()
+
+    val isSetterInjected = descriptor.safeAs<PropertyDescriptor>()
+      ?.isSetterInjected() == true
+
+    // setter delegates require a "set" prefix for their inject function
+    val accessName = if (isSetterInjected) {
+      "set${originalName.capitalize()}"
+    } else {
+      originalName
+    }
+
+    val qualifierAnnotations = descriptor.annotations
+      .filter { it.isQualifier() }
+      .map { it.toAnnotationSpec(module) }
+
+    MemberInjectParameter(
+      name = originalName,
+      typeName = typeName,
+      providerTypeName = typeName.wrapInProvider(),
+      lazyTypeName = typeName.wrapInLazy(),
+      isWrappedInProvider = isWrappedInProvider,
+      isWrappedInLazy = isWrappedInLazy,
+      isLazyWrappedInProvider = isLazyWrappedInProvider,
+      isAssisted = assistedAnnotation != null,
+      assistedIdentifier = assistedIdentifier,
+      memberInjectorClassName = memberInjectorClass,
+      originalName = originalName,
+      isSetterInjected = isSetterInjected,
+      accessName = accessName,
+      qualifierAnnotationSpecs = qualifierAnnotations,
+      injectedFieldSignature = descriptor.fqNameSafe
+    )
+  }
+}

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/Parameter.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/Parameter.kt
@@ -1,0 +1,74 @@
+package com.squareup.anvil.compiler.codegen
+
+import com.squareup.anvil.compiler.codegen.Parameter.AssistedParameterKey
+import com.squareup.kotlinpoet.AnnotationSpec
+import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.ParameterizedTypeName
+import com.squareup.kotlinpoet.TypeName
+import org.jetbrains.kotlin.name.FqName
+
+sealed interface Parameter {
+  val name: String
+  val typeName: TypeName
+  val providerTypeName: ParameterizedTypeName
+  val lazyTypeName: ParameterizedTypeName
+  val isWrappedInProvider: Boolean
+  val isWrappedInLazy: Boolean
+  val isLazyWrappedInProvider: Boolean
+  val isAssisted: Boolean
+  val assistedIdentifier: String
+  val assistedParameterKey: AssistedParameterKey
+
+  // @Assisted parameters are equal, if the type and the identifier match. This subclass makes
+  // diffing the parameters easier.
+  data class AssistedParameterKey(
+    private val typeName: TypeName,
+    private val assistedIdentifier: String
+  )
+
+  val originalTypeName: TypeName
+    get() = when {
+      isLazyWrappedInProvider -> lazyTypeName.wrapInProvider()
+      isWrappedInProvider -> providerTypeName
+      isWrappedInLazy -> lazyTypeName
+      else -> typeName
+    }
+}
+
+internal data class ConstructorParameter(
+  override val name: String,
+  override val typeName: TypeName,
+  override val providerTypeName: ParameterizedTypeName,
+  override val lazyTypeName: ParameterizedTypeName,
+  override val isWrappedInProvider: Boolean,
+  override val isWrappedInLazy: Boolean,
+  override val isLazyWrappedInProvider: Boolean,
+  override val isAssisted: Boolean,
+  override val assistedIdentifier: String,
+  override val assistedParameterKey: AssistedParameterKey = AssistedParameterKey(
+    typeName,
+    assistedIdentifier
+  )
+) : Parameter
+
+internal data class MemberInjectParameter(
+  override val name: String,
+  override val typeName: TypeName,
+  override val providerTypeName: ParameterizedTypeName,
+  override val lazyTypeName: ParameterizedTypeName,
+  override val isWrappedInProvider: Boolean,
+  override val isWrappedInLazy: Boolean,
+  override val isLazyWrappedInProvider: Boolean,
+  override val isAssisted: Boolean,
+  override val assistedIdentifier: String,
+  val memberInjectorClassName: ClassName,
+  val originalName: String,
+  val isSetterInjected: Boolean,
+  val accessName: String,
+  val qualifierAnnotationSpecs: List<AnnotationSpec>,
+  val injectedFieldSignature: FqName,
+  override val assistedParameterKey: AssistedParameterKey = AssistedParameterKey(
+    typeName,
+    assistedIdentifier
+  )
+) : Parameter

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/RealAnvilModuleDescriptor.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/RealAnvilModuleDescriptor.kt
@@ -49,6 +49,11 @@ class RealAnvilModuleDescriptor(
       ?.fqName
   }
 
+  override fun getKtClassOrObjectOrNull(fqName: FqName): KtClassOrObject? {
+    return allClasses
+      .firstOrNull { it.fqName == fqName }
+  }
+
   private val KtFile.identifier: String
     get() = packageFqName.asString() + name
 }

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/ProvidesMethodFactoryGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/ProvidesMethodFactoryGenerator.kt
@@ -8,7 +8,7 @@ import com.squareup.anvil.compiler.api.GeneratedFile
 import com.squareup.anvil.compiler.api.createGeneratedFile
 import com.squareup.anvil.compiler.codegen.PrivateCodeGenerator
 import com.squareup.anvil.compiler.codegen.asArgumentList
-import com.squareup.anvil.compiler.codegen.mapToParameter
+import com.squareup.anvil.compiler.codegen.mapToConstructorParameters
 import com.squareup.anvil.compiler.daggerModuleFqName
 import com.squareup.anvil.compiler.daggerProvidesFqName
 import com.squareup.anvil.compiler.internal.asClassName
@@ -143,7 +143,8 @@ internal class ProvidesMethodFactoryGenerator : PrivateCodeGenerator() {
 
     val callableName = declaration.nameAsSafeName.asString()
 
-    val parameters = declaration.valueParameters.mapToParameter(module)
+    val parameters = declaration.valueParameters
+      .mapToConstructorParameters(module)
 
     val returnType = declaration.requireTypeReference(module).requireTypeName(module)
       .withJvmSuppressWildcardsIfNeeded(declaration, module)


### PR DESCRIPTION
fixes #343

Basically, these changes use PSI to find superclasses by parsing the FqName from a `KtClassOrObject`'s supertype list, then using that to look up the super's `KtClassOrObject` from `RealAnvilModuleDescriptor`.  When this method no longer returns results, that means any additional super-types come from other modules/dependencies and it's safe to use descriptors.

This required forking a lot of the psi-based parsing for `Parameter` for use with Descriptor types.  

I also turned `Parameter` into an interface and created `MemberInjectParameter`, which is the same thing except for a few extra fields for member-injected specific stuff.  I don't love the names I chose, and there are a few options I'm on the fence about, like using interface delegation for MemberInjectedParameter and losing the data modifier.

**`Parameter` naming is changed to use original names**.  In order to support collecting all the parameters from different sources, I had to either pass around a `startIndex` parameter, or use original parameter names.  Continuing to use the index seems error-prone, and the Kotlin compiler should already be ensuring that the original parameter names are unique.  There may be an edge case I'm not considering, but all tests pass.

I believe this approach of doing a reverse lookup for the `KtClassOrObject` could also be used to solve the `AssistedFactory` generation issue (#326) without a major rewrite, but I haven't fully tested this yet.

TODO
- [x] Add superclass injection into MemberInjectors
- [x] Parse Qualifier annotations.