### PR TITLE
Support JDK 16+ in project

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,9 +53,17 @@ subprojects {
     }
   }
 
-  tasks.withType(JavaCompile).configureEach {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+  pluginManager.withPlugin("java") {
+    // Use JDK 11 but target Java 8 for maximum compatibility
+    java {
+      toolchain {
+        languageVersion.set(JavaLanguageVersion.of(11))
+      }
+    }
+
+    tasks.withType(JavaCompile).configureEach {
+      options.release.set(8)
+    }
   }
 
   //noinspection UnnecessaryQualifiedReference

--- a/compiler/build.gradle
+++ b/compiler/build.gradle
@@ -4,6 +4,21 @@ apply plugin: 'com.vanniktech.maven.publish'
 
 apply from: project.file('generate_build_properties.gradle')
 
+tasks.withType(Test.class).configureEach { Test testTask ->
+  testTask.jvmArgs(
+    "--add-opens=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
+    "--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
+    "--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED",
+    "--add-opens=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
+    "--add-opens=jdk.compiler/com.sun.tools.javac.jvm=ALL-UNNAMED",
+    "--add-opens=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
+    "--add-opens=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED",
+    "--add-opens=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED",
+    "--add-opens=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+    "--add-opens=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED"
+  )
+}
+
 dependencies {
   implementation project(':annotations')
   implementation project(':compiler-api')

--- a/gradle-plugin/build.gradle
+++ b/gradle-plugin/build.gradle
@@ -48,9 +48,15 @@ pluginBundle {
   tags = ['dagger2', 'dagger2-android', 'kotlin', 'kotlin-compiler-plugin']
 }
 
+// Use JDK 11 but target Java 8 for maximum compatibility
+java {
+  toolchain {
+    languageVersion.set(JavaLanguageVersion.of(11))
+  }
+}
+
 tasks.withType(JavaCompile).configureEach {
-  sourceCompatibility = JavaVersion.VERSION_1_8
-  targetCompatibility = JavaVersion.VERSION_1_8
+  options.release.set(8)
 }
 
 //noinspection UnnecessaryQualifiedReference

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,6 @@ POM_LICENCE_NAME=The Apache Software License, Version 2.0
 POM_LICENCE_URL=https://www.apache.org/licenses/LICENSE-2.0.txt
 POM_LICENCE_DIST=repo
 
-org.gradle.jvmargs=-Xmx2048m
 org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.configureondemand=false
@@ -25,9 +24,8 @@ android.enableJetifier=false
 # https://blog.jetbrains.com/kotlin/2019/04/kotlin-1-3-30-released/
 kapt.incremental.apt=true
 
-# Use Gradle's worker API for KAPT.
-# https://blog.jetbrains.com/kotlin/2019/04/kotlin-1-3-30-released/
-kapt.use.worker.api=true
+# Don't use Gradle's worker API for KAPT as KAPT doesn't work on JDK 16+ with it
+kapt.use.worker.api=false
 
 # Turn on compile avoidance for annotation processors
 # https://blog.jetbrains.com/kotlin/2019/04/kotlin-1-3-30-released/
@@ -36,6 +34,31 @@ kapt.include.compile.classpath=false
 # Don't recompile Kotlin code if changes in Java don't have an effect.
 # https://blog.jetbrains.com/kotlin/2018/01/kotlin-1-2-20-is-out/
 kotlin.incremental.usePreciseJavaTracking=true
+
+# Configure JVM args for both Gradle and Kotlin to make everything play well on JDK 16+
+org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8 \
+  --add-opens=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
+  --add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED \
+  --add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED \
+  --add-opens=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
+  --add-opens=jdk.compiler/com.sun.tools.javac.jvm=ALL-UNNAMED \
+  --add-opens=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED \
+  --add-opens=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
+  --add-opens=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED \
+  --add-opens=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
+  --add-opens=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+
+kotlin.daemon.jvmargs=-Dfile.encoding=UTF-8 \
+  --add-opens=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
+  --add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED \
+  --add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED \
+  --add-opens=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
+  --add-opens=jdk.compiler/com.sun.tools.javac.jvm=ALL-UNNAMED \
+  --add-opens=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED \
+  --add-opens=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
+  --add-opens=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED \
+  --add-opens=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
+  --add-opens=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
 
 # Disable unused features.
 android.defaults.buildfeatures.buildconfig=false


### PR DESCRIPTION
This requires opening a number of modules in order for kapt to work safely (both in build and in KCT unit tests). This also switches to using the more modern Gradle toolchains API to configure the Java toolchain