### PR TITLE
Use updated `temurin` distro on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
       - uses: gradle/wrapper-validation-action@v1
       - uses : actions/setup-java@v2
         with :
-          distribution : 'adopt'
+          distribution : 'temurin'
           java-version : '11'
           check-latest : true
 
@@ -79,7 +79,7 @@ jobs:
       - uses: gradle/wrapper-validation-action@v1
       - uses : actions/setup-java@v2
         with :
-          distribution : 'adopt'
+          distribution : 'temurin'
           java-version : '11'
           check-latest : true
 
@@ -108,7 +108,7 @@ jobs:
       - uses: gradle/wrapper-validation-action@v1
       - uses : actions/setup-java@v2
         with :
-          distribution : 'adopt'
+          distribution : 'temurin'
           java-version : '11'
           check-latest : true
 
@@ -124,7 +124,7 @@ jobs:
       - uses: gradle/wrapper-validation-action@v1
       - uses : actions/setup-java@v2
         with :
-          distribution : 'adopt'
+          distribution : 'temurin'
           java-version : '11'
           check-latest : true
 
@@ -147,7 +147,7 @@ jobs:
       - uses: gradle/wrapper-validation-action@v1
       - uses : actions/setup-java@v2
         with :
-          distribution : 'adopt'
+          distribution : 'temurin'
           java-version : '11'
           check-latest : true
 
@@ -175,7 +175,7 @@ jobs:
       - uses: gradle/wrapper-validation-action@v1
       - uses : actions/setup-java@v2
         with :
-          distribution : 'adopt'
+          distribution : 'temurin'
           java-version : '11'
           check-latest : true
 
@@ -203,7 +203,7 @@ jobs:
       - uses: gradle/wrapper-validation-action@v1
       - uses : actions/setup-java@v2
         with :
-          distribution : 'adopt'
+          distribution : 'temurin'
           java-version : '11'
           check-latest : true
 
@@ -228,7 +228,7 @@ jobs:
       - uses: gradle/wrapper-validation-action@v1
       - uses : actions/setup-java@v2
         with :
-          distribution : 'adopt'
+          distribution : 'temurin'
           java-version : '11'
           check-latest : true
 
@@ -262,7 +262,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses : actions/setup-java@v2
         with :
-          distribution : 'adopt'
+          distribution : 'temurin'
           java-version : '11'
           check-latest : true
 


### PR DESCRIPTION
This is the successor to the now-deprecated `adopt` distro since it was acquired by the Eclipse foundation