### PR TITLE
Fix logic for directly imported members and implicitly imported members

### DIFF
--- a/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/KotlinPoetUtils.kt
+++ b/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/KotlinPoetUtils.kt
@@ -435,13 +435,10 @@ private fun KtExpression.codeBlock(module: ModuleDescriptor): CodeBlock {
           ?.let { memberRef ->
             CodeBlock.of("%M", memberRef)
           }
-          // Everything else isn't supported.
-          ?: run {
-            throw AnvilCompilationException(
-              "Couldn't resolve FqName $ref for Psi element: $text",
-              element = this
-            )
-          }
+          // If we reach here, it's a top-level constant defined in the same package but a different
+          // file. In this case, we can just do the same in our generated code because we're in the
+          // same package and can play by the same rules.
+          ?: CodeBlock.of("%L", ref)
       }
     }
     is KtCollectionLiteralExpression -> CodeBlock.of(

--- a/compiler/src/test/java/com/squareup/anvil/compiler/dagger/MembersInjectorGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/dagger/MembersInjectorGeneratorTest.kt
@@ -500,6 +500,11 @@ public final class InjectClass_Factory implements Factory<InjectClass> {
       """
       package com.squareup.test
       
+      const val CONST_SAME_PACKAGE = "samePackageConst"
+      """,
+      """
+      package com.squareup.test
+      
       import com.squareup.test2.CONST_IMPORTED
       import com.squareup.test2.Constants
       import com.squareup.test2.Constants.CONST_NESTED_BUT_IMPORTED_DIRECTLY
@@ -527,6 +532,7 @@ public final class InjectClass_Factory implements Factory<InjectClass> {
         @Named(Constants.CONST_NESTED) @Inject lateinit var string6: String
         @Named(CONST_NESTED_BUT_IMPORTED_DIRECTLY) @Inject lateinit var string7: String
         @Named(NestedClassWithCompanion.CONST_NESTED_IN_COMPANION) @Inject lateinit var string8: String
+        @Named(CONST_SAME_PACKAGE) @Inject lateinit var string9: String
         
         companion object {
           const val NESTED_CONSTANT = "def2"
@@ -586,6 +592,12 @@ public final class InjectClass_Factory implements Factory<InjectClass> {
         .single { it.annotationClass.simpleName == "IntQualifier" }
 
       assertThat(intAnnotation.getValue<Int>()).isEqualTo(3)
+
+      val string9 = membersInjector.staticInjectMethod("string9")
+        .annotations
+        .single { it.annotationClass.simpleName == "Named" }
+
+      assertThat(string9.getValue<String>()).isEqualTo("samePackageConst")
     }
   }
 


### PR DESCRIPTION
Two birds with one stone! Added two previously-failing test cases for this too. This shooooould cover all our bases for annotations without needing to worry about going down to the descriptor level.