### PR TITLE
support generic type resolution in assisted factories

### DIFF
--- a/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/AnvilModuleDescriptor.kt
+++ b/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/AnvilModuleDescriptor.kt
@@ -1,6 +1,7 @@
 package com.squareup.anvil.compiler.internal
 
 import com.squareup.anvil.annotations.ExperimentalAnvilApi
+import com.squareup.anvil.compiler.api.AnvilCompilationException
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.FqName
@@ -28,6 +29,12 @@ public fun ModuleDescriptor.resolveFqNameOrNull(
 public fun ModuleDescriptor.getKtClassOrObjectOrNull(
   fqName: FqName
 ): KtClassOrObject? = asAnvilModuleDescriptor().getKtClassOrObjectOrNull(fqName)
+
+@ExperimentalAnvilApi
+public fun ModuleDescriptor.requireKtClassOrObject(
+  fqName: FqName
+): KtClassOrObject = getKtClassOrObjectOrNull(fqName)
+  ?: throw AnvilCompilationException("Couldn't resolve KtClassOrObject for ${fqName.asString()}")
 
 @ExperimentalAnvilApi
 public fun ModuleDescriptor.canResolveFqName(

--- a/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/CompilerUtils.kt
+++ b/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/CompilerUtils.kt
@@ -21,6 +21,9 @@ import org.jetbrains.kotlin.resolve.constants.KClassValue
 import org.jetbrains.kotlin.resolve.constants.KClassValue.Value.NormalClass
 import org.jetbrains.kotlin.resolve.descriptorUtil.annotationClass
 import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
+import org.jetbrains.kotlin.resolve.descriptorUtil.getAllSuperClassifiers
+import org.jetbrains.kotlin.resolve.descriptorUtil.getSuperClassNotAny
+import org.jetbrains.kotlin.resolve.descriptorUtil.getSuperInterfaces
 import org.jetbrains.kotlin.resolve.descriptorUtil.module
 import org.jetbrains.kotlin.types.ErrorType
 import org.jetbrains.kotlin.types.KotlinType
@@ -62,6 +65,16 @@ public fun ClassDescriptor.annotation(
   "Couldn't find $annotationFqName with scope $scope for $fqNameSafe."
 }
 
+/**
+ * Returns only the super class (excluding [Any]) and implemented interfaces declared directly by
+ * this class. This is different from [getAllSuperClassifiers] in that the latter returns the entire
+ * hierarchy.
+ */
+public fun ClassDescriptor.directSuperClassAndInterfaces(): List<ClassDescriptor> {
+  return listOfNotNull(getSuperClassNotAny())
+    .plus(getSuperInterfaces())
+}
+
 @ExperimentalAnvilApi
 public fun ConstantValue<*>.toType(
   module: ModuleDescriptor,
@@ -76,8 +89,9 @@ public fun ConstantValue<*>.toType(
 public fun KotlinType.argumentType(): KotlinType = arguments.first().type
 
 @ExperimentalAnvilApi
-public fun KotlinType.classDescriptorForType(): ClassDescriptor =
-  DescriptorUtils.getClassDescriptorForType(this)
+public fun KotlinType.classDescriptorForType(): ClassDescriptor {
+  return DescriptorUtils.getClassDescriptorForType(this)
+}
 
 @ExperimentalAnvilApi
 public fun AnnotationDescriptor.getAnnotationValue(key: String): ConstantValue<*>? =


### PR DESCRIPTION
fixes #395

There are basically two moves to these changes.

First, I switched it so that the parsing looks to descriptors first before falling back upon PSI parsing.  Descriptors should be fine in almost every case, whereas PSI will not be enough on its own in cases like that of #395.  So, using descriptors should make troubleshooting slightly more consistent.

Second, I had to do a reverse lookup for type resolution of generics when using PSI.  If a generic function isn't overridden by a subclass/interface, then all PSI has to work on is `fun create(...): T`, and type resolution for `T` will fail.  Now, we look to the subclass which implements the generic interface and get the type of `T` from its declaration.