### PR TITLE
Enable experimental Anvil APIs in all tests by default.

### DIFF
--- a/compiler-utils/src/testFixtures/java/com/squareup/anvil/compiler/internal/testing/TestUtils.kt
+++ b/compiler-utils/src/testFixtures/java/com/squareup/anvil/compiler/internal/testing/TestUtils.kt
@@ -185,6 +185,7 @@ public fun compileAnvil(
   useIR: Boolean = true,
   messageOutputStream: OutputStream = System.out,
   workingDir: File? = null,
+  enableExperimentalAnvilApis: Boolean = true,
   block: Result.() -> Unit = { }
 ): Result {
   return AnvilCompilation()
@@ -199,6 +200,12 @@ public fun compileAnvil(
       kotlinCompilation.apply {
         this.allWarningsAsErrors = allWarningsAsErrors
         this.messageOutputStream = messageOutputStream
+        if (enableExperimentalAnvilApis) {
+          this.kotlincArguments += listOf(
+            "-Xopt-in=kotlin.RequiresOptIn",
+            "-Xopt-in=com.squareup.anvil.annotations.ExperimentalAnvilApi"
+          )
+        }
         if (workingDir != null) {
           this.workingDir = workingDir
         }

--- a/compiler/src/test/java/com/squareup/anvil/compiler/InterfaceMergerTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/InterfaceMergerTest.kt
@@ -5,7 +5,6 @@ import com.squareup.anvil.annotations.MergeComponent
 import com.squareup.anvil.annotations.MergeSubcomponent
 import com.squareup.anvil.annotations.compat.MergeInterfaces
 import com.squareup.anvil.compiler.internal.testing.extends
-import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.COMPILATION_ERROR
 import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.INTERNAL_ERROR
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -141,7 +140,7 @@ class InterfaceMergerTest(
       abstract class MergingClass
       """
     ) {
-      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+      assertThat(exitCode).isError()
       // Position to the class.
       assertThat(messages).contains("Source0.kt: (6, 16)")
     }
@@ -194,7 +193,7 @@ class InterfaceMergerTest(
       interface ComponentInterface
       """
     ) {
-      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+      assertThat(exitCode).isError()
       // Position to the class. Unfortunately, a different error is reported that the class is
       // missing an @Module annotation.
       assertThat(messages).contains("Source0.kt: (7, 7)")
@@ -222,7 +221,7 @@ class InterfaceMergerTest(
       interface ComponentInterface
       """
     ) {
-      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+      assertThat(exitCode).isError()
       // Position to the class. Unfortunately, a different error is reported that the class is
       // missing an @Module annotation.
       assertThat(messages).contains("Source0.kt: (13, 11)")
@@ -311,7 +310,7 @@ class InterfaceMergerTest(
       interface ComponentInterface
       """
     ) {
-      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+      assertThat(exitCode).isError()
       // Position to the class.
       assertThat(messages).contains("Source0.kt: (18, 11)")
       assertThat(messages).contains(
@@ -348,7 +347,7 @@ class InterfaceMergerTest(
       interface ComponentInterface : ContributingInterface, OtherInterface
       """
     ) {
-      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+      assertThat(exitCode).isError()
       // Position to the class.
       assertThat(messages).contains(
         "ComponentInterface excludes types that it implements or extends. These types cannot " +
@@ -442,7 +441,7 @@ class InterfaceMergerTest(
         interface ComponentInterface
         """
       ) {
-        assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+        assertThat(exitCode).isError()
         // Position to the class.
         assertThat(messages).contains("Source0.kt: (7, ")
       }

--- a/compiler/src/test/java/com/squareup/anvil/compiler/MergeModulesTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/MergeModulesTest.kt
@@ -3,7 +3,6 @@ package com.squareup.anvil.compiler
 import com.google.common.truth.Truth.assertThat
 import com.squareup.anvil.compiler.internal.testing.daggerModule
 import com.squareup.anvil.compiler.internal.testing.withoutAnvilModule
-import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.COMPILATION_ERROR
 import org.junit.Test
 
 class MergeModulesTest {
@@ -85,7 +84,7 @@ class MergeModulesTest {
       class DaggerModule1
       """
     ) {
-      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+      assertThat(exitCode).isError()
       // Position to the class.
       assertThat(messages).contains("Source0.kt: (7, 7)")
     }
@@ -154,7 +153,7 @@ class MergeModulesTest {
       class DaggerModule1
       """
     ) {
-      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+      assertThat(exitCode).isError()
       // Position to the class.
       assertThat(messages).contains("Source0.kt: (7, 16)")
     }
@@ -277,7 +276,7 @@ class MergeModulesTest {
       class DaggerModule1
       """
     ) {
-      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+      assertThat(exitCode).isError()
       // Position to the class.
       assertThat(messages).contains("Source0.kt: (17, 16)")
       assertThat(messages).contains(
@@ -313,7 +312,7 @@ class MergeModulesTest {
       class DaggerModule1
       """
     ) {
-      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+      assertThat(exitCode).isError()
       // Position to the class.
       assertThat(messages).contains("Source0.kt: (17, 16)")
       assertThat(messages).contains(
@@ -409,7 +408,7 @@ class MergeModulesTest {
       class DaggerModule1
       """
     ) {
-      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+      assertThat(exitCode).isError()
       // Position to the class.
       assertThat(messages).contains("Source0.kt: (17, 11)")
       assertThat(messages).contains(
@@ -445,7 +444,7 @@ class MergeModulesTest {
       class DaggerModule1
       """
     ) {
-      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+      assertThat(exitCode).isError()
       // Position to the class.
       assertThat(messages).contains("Source0.kt: (17, 11)")
       assertThat(messages).contains(
@@ -477,7 +476,7 @@ class MergeModulesTest {
       class DaggerModule1
       """
     ) {
-      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+      assertThat(exitCode).isError()
       // Position to the class.
       assertThat(messages).contains("Source0.kt: (13, 16)")
     }
@@ -506,7 +505,7 @@ class MergeModulesTest {
       class DaggerModule1
       """
     ) {
-      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+      assertThat(exitCode).isError()
       // Position to the class.
       assertThat(messages).contains("Source0.kt: (15, 16)")
       assertThat(messages).contains(
@@ -601,7 +600,7 @@ class MergeModulesTest {
       class DaggerModule1
       """
     ) {
-      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+      assertThat(exitCode).isError()
       // Position to the class.
       assertThat(messages).contains("Source0.kt: (16, 7)")
       assertThat(messages).contains(
@@ -686,7 +685,7 @@ class MergeModulesTest {
       interface ComponentInterface
       """
     ) {
-      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+      assertThat(exitCode).isError()
       // Position to the class.
       assertThat(messages).contains("Source0.kt: (17, 11)")
       assertThat(messages).contains(
@@ -719,7 +718,7 @@ class MergeModulesTest {
       interface ComponentInterface
       """
     ) {
-      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+      assertThat(exitCode).isError()
       // Position to the class.
       assertThat(messages).contains("Source0.kt: (17, 11)")
       assertThat(messages).contains(
@@ -783,7 +782,7 @@ class MergeModulesTest {
         class DaggerModule1
         """
       ) {
-        assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+        assertThat(exitCode).isError()
         // Position to the class.
         assertThat(messages).contains("Source0.kt: (8, ")
       }
@@ -880,7 +879,7 @@ class MergeModulesTest {
       interface ComponentInterface
       """
     ) {
-      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+      assertThat(exitCode).isError()
       assertThat(messages).contains("Source0.kt: (19, 11)")
     }
   }

--- a/compiler/src/test/java/com/squareup/anvil/compiler/ModuleMergerTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/ModuleMergerTest.kt
@@ -8,7 +8,6 @@ import com.squareup.anvil.compiler.internal.testing.anyDaggerComponent
 import com.squareup.anvil.compiler.internal.testing.daggerComponent
 import com.squareup.anvil.compiler.internal.testing.daggerSubcomponent
 import com.squareup.anvil.compiler.internal.testing.withoutAnvilModule
-import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.COMPILATION_ERROR
 import dagger.Component
 import dagger.Subcomponent
 import org.junit.Test
@@ -121,7 +120,7 @@ class ModuleMergerTest(
       interface ComponentInterface
       """
     ) {
-      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+      assertThat(exitCode).isError()
       // Position to the class.
       assertThat(messages).contains("Source0.kt: (7, 11)")
     }
@@ -212,7 +211,7 @@ class ModuleMergerTest(
       interface ComponentInterface
       """
     ) {
-      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+      assertThat(exitCode).isError()
       // Position to the class.
       assertThat(messages).contains("Source0.kt: (7, 16)")
     }
@@ -335,7 +334,7 @@ class ModuleMergerTest(
       interface ComponentInterface
       """
     ) {
-      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+      assertThat(exitCode).isError()
       // Position to the class.
       assertThat(messages).contains("Source0.kt: (17, 16)")
       assertThat(messages).contains(
@@ -371,7 +370,7 @@ class ModuleMergerTest(
       interface ComponentInterface
       """
     ) {
-      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+      assertThat(exitCode).isError()
       // Position to the class.
       assertThat(messages).contains("Source0.kt: (17, 16)")
       assertThat(messages).contains(
@@ -467,7 +466,7 @@ class ModuleMergerTest(
       interface ComponentInterface
       """
     ) {
-      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+      assertThat(exitCode).isError()
       // Position to the class.
       assertThat(messages).contains("Source0.kt: (17, 11)")
       assertThat(messages).contains(
@@ -503,7 +502,7 @@ class ModuleMergerTest(
       interface ComponentInterface
       """
     ) {
-      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+      assertThat(exitCode).isError()
       // Position to the class.
       assertThat(messages).contains("Source0.kt: (17, 11)")
       assertThat(messages).contains(
@@ -535,7 +534,7 @@ class ModuleMergerTest(
       interface ComponentInterface
       """
     ) {
-      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+      assertThat(exitCode).isError()
       // Position to the class.
       assertThat(messages).contains("Source0.kt: (13, 16)")
     }
@@ -564,7 +563,7 @@ class ModuleMergerTest(
       interface ComponentInterface
       """
     ) {
-      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+      assertThat(exitCode).isError()
       // Position to the class.
       assertThat(messages).contains("Source0.kt: (15, 16)")
       assertThat(messages).contains(
@@ -664,7 +663,7 @@ class ModuleMergerTest(
       interface ComponentInterface
       """
     ) {
-      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+      assertThat(exitCode).isError()
       // Position to the class.
       assertThat(messages).contains("Source0.kt: (20, 11)")
       assertThat(messages).contains(
@@ -814,7 +813,7 @@ class ModuleMergerTest(
       interface ComponentInterface
       """
     ) {
-      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+      assertThat(exitCode).isError()
       // Position to the class.
       assertThat(messages).contains("Source0.kt: (17, 11)")
       assertThat(messages).contains(
@@ -847,7 +846,7 @@ class ModuleMergerTest(
       interface ComponentInterface
       """
     ) {
-      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+      assertThat(exitCode).isError()
       // Position to the class.
       assertThat(messages).contains("Source0.kt: (17, 11)")
       assertThat(messages).contains(
@@ -944,7 +943,7 @@ class ModuleMergerTest(
         interface ComponentInterface
         """
       ) {
-        assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+        assertThat(exitCode).isError()
         // Position to the class.
         assertThat(messages).contains("Source0.kt: (8, ")
       }
@@ -990,7 +989,7 @@ class ModuleMergerTest(
       }
       """
     ) {
-      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+      assertThat(exitCode).isError()
       assertThat(messages).contains("File being compiled: (10,18)")
     }
   }
@@ -1066,7 +1065,7 @@ class ModuleMergerTest(
       interface ComponentInterface
       """
     ) {
-      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+      assertThat(exitCode).isError()
       assertThat(messages).contains("Source0.kt: (19, 11)")
     }
   }
@@ -1082,7 +1081,7 @@ class ModuleMergerTest(
       interface ComponentInterface
       """
     ) {
-      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+      assertThat(exitCode).isError()
       assertThat(messages).contains(
         "Couldn't find scope for ${annotationClass.java.canonicalName}"
       )

--- a/compiler/src/test/java/com/squareup/anvil/compiler/TestUtils.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/TestUtils.kt
@@ -1,11 +1,15 @@
 package com.squareup.anvil.compiler
 
+import com.google.common.truth.ComparableSubject
 import com.google.common.truth.Truth.assertThat
 import com.squareup.anvil.annotations.MergeComponent
 import com.squareup.anvil.compiler.internal.capitalize
 import com.squareup.anvil.compiler.internal.testing.compileAnvil
 import com.squareup.anvil.compiler.internal.testing.generatedClassesString
 import com.squareup.anvil.compiler.internal.testing.packageName
+import com.tschuchort.compiletesting.KotlinCompilation.ExitCode
+import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.COMPILATION_ERROR
+import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.INTERNAL_ERROR
 import com.tschuchort.compiletesting.KotlinCompilation.Result
 import org.junit.Assume
 import kotlin.reflect.KClass
@@ -130,4 +134,8 @@ private fun Class<*>.contributedProperties(packagePrefix: String): List<KClass<*
 
 internal fun assumeMergeComponent(annotationClass: KClass<*>) {
   Assume.assumeTrue(annotationClass == MergeComponent::class)
+}
+
+internal fun ComparableSubject<ExitCode>.isError() {
+  isIn(setOf(COMPILATION_ERROR, INTERNAL_ERROR))
 }

--- a/compiler/src/test/java/com/squareup/anvil/compiler/codegen/BindingModuleGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/codegen/BindingModuleGeneratorTest.kt
@@ -13,10 +13,10 @@ import com.squareup.anvil.compiler.internal.testing.AnyDaggerComponent
 import com.squareup.anvil.compiler.internal.testing.anyDaggerComponent
 import com.squareup.anvil.compiler.internal.testing.daggerModule
 import com.squareup.anvil.compiler.internal.testing.isAbstract
+import com.squareup.anvil.compiler.isError
 import com.squareup.anvil.compiler.parentInterface
 import com.squareup.anvil.compiler.secondContributingInterface
 import com.squareup.anvil.compiler.subcomponentInterface
-import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.COMPILATION_ERROR
 import dagger.Binds
 import dagger.Provides
 import org.junit.Test
@@ -382,7 +382,7 @@ class BindingModuleGeneratorTest(
       interface ComponentInterface
       """
     ) {
-      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+      assertThat(exitCode).isError()
 
       assertThat(messages).contains("Source0.kt: (6, 11)")
       assertThat(messages).contains(
@@ -413,7 +413,7 @@ class BindingModuleGeneratorTest(
       interface ComponentInterface
       """
     ) {
-      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+      assertThat(exitCode).isError()
 
       assertThat(messages).contains("Source0.kt: (6, 11)")
       assertThat(messages).contains(

--- a/compiler/src/test/java/com/squareup/anvil/compiler/codegen/BindingModuleMultibindingMapTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/codegen/BindingModuleMultibindingMapTest.kt
@@ -14,8 +14,8 @@ import com.squareup.anvil.compiler.internal.testing.anyDaggerComponent
 import com.squareup.anvil.compiler.internal.testing.daggerModule
 import com.squareup.anvil.compiler.internal.testing.getValue
 import com.squareup.anvil.compiler.internal.testing.isAbstract
+import com.squareup.anvil.compiler.isError
 import com.squareup.anvil.compiler.parentInterface
-import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.COMPILATION_ERROR
 import dagger.Binds
 import dagger.Provides
 import dagger.multibindings.IntoMap
@@ -283,7 +283,7 @@ class BindingModuleMultibindingMapTest(
       interface ComponentInterface
       """
     ) {
-      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+      assertThat(exitCode).isError()
       assertThat(messages).contains(
         "Classes annotated with @ContributesMultibinding may not use more than one @MapKey."
       )

--- a/compiler/src/test/java/com/squareup/anvil/compiler/codegen/BindingModuleMultibindingSetTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/codegen/BindingModuleMultibindingSetTest.kt
@@ -12,9 +12,9 @@ import com.squareup.anvil.compiler.internal.testing.AnyDaggerComponent
 import com.squareup.anvil.compiler.internal.testing.anyDaggerComponent
 import com.squareup.anvil.compiler.internal.testing.daggerModule
 import com.squareup.anvil.compiler.internal.testing.isAbstract
+import com.squareup.anvil.compiler.isError
 import com.squareup.anvil.compiler.parentInterface
 import com.squareup.anvil.compiler.secondContributingInterface
-import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.COMPILATION_ERROR
 import dagger.Binds
 import dagger.Provides
 import dagger.multibindings.IntoSet
@@ -265,7 +265,7 @@ class BindingModuleMultibindingSetTest(
       interface ComponentInterface
       """
     ) {
-      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+      assertThat(exitCode).isError()
 
       assertThat(messages).contains("Source0.kt: (6, 11)")
       assertThat(messages).contains(

--- a/compiler/src/test/java/com/squareup/anvil/compiler/codegen/BindingModulePriorityTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/codegen/BindingModulePriorityTest.kt
@@ -8,9 +8,9 @@ import com.squareup.anvil.compiler.anvilModule
 import com.squareup.anvil.compiler.compile
 import com.squareup.anvil.compiler.componentInterface
 import com.squareup.anvil.compiler.contributingInterface
+import com.squareup.anvil.compiler.isError
 import com.squareup.anvil.compiler.parentInterface
 import com.squareup.anvil.compiler.secondContributingInterface
-import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.COMPILATION_ERROR
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
@@ -120,7 +120,7 @@ class BindingModulePriorityTest(
       interface ComponentInterface
       """
     ) {
-      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+      assertThat(exitCode).isError()
 
       assertThat(messages).contains(
         "There are multiple contributed bindings with the same bound type. The bound type is " +
@@ -250,7 +250,7 @@ class BindingModulePriorityTest(
       interface ComponentInterface
       """
     ) {
-      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+      assertThat(exitCode).isError()
 
       assertThat(messages).contains(
         "There are multiple contributed bindings with the same bound type. The bound type is " +
@@ -285,7 +285,7 @@ class BindingModulePriorityTest(
       interface ComponentInterface
       """
     ) {
-      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+      assertThat(exitCode).isError()
 
       assertThat(messages).contains(
         "There are multiple contributed bindings with the same bound type. The bound type is " +

--- a/compiler/src/test/java/com/squareup/anvil/compiler/codegen/ContributesBindingGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/codegen/ContributesBindingGeneratorTest.kt
@@ -5,7 +5,7 @@ import com.squareup.anvil.compiler.compile
 import com.squareup.anvil.compiler.contributingInterface
 import com.squareup.anvil.compiler.hintBinding
 import com.squareup.anvil.compiler.hintBindingScope
-import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.COMPILATION_ERROR
+import com.squareup.anvil.compiler.isError
 import org.junit.Test
 
 class ContributesBindingGeneratorTest {
@@ -145,7 +145,7 @@ class ContributesBindingGeneratorTest {
         $visibility class ContributingInterface : ParentInterface
         """
       ) {
-        assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+        assertThat(exitCode).isError()
         // Position to the class.
         assertThat(messages).contains("Source0.kt: (8, ")
         assertThat(messages).contains(
@@ -177,7 +177,7 @@ class ContributesBindingGeneratorTest {
       interface ContributingInterface : ParentInterface
       """
     ) {
-      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+      assertThat(exitCode).isError()
       assertThat(messages).contains(
         "Classes annotated with @ContributesBinding may not use more than one @Qualifier."
       )
@@ -197,7 +197,7 @@ class ContributesBindingGeneratorTest {
       interface ContributingInterface : ParentInterface, CharSequence
       """
     ) {
-      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+      assertThat(exitCode).isError()
       assertThat(messages).contains(
         "com.squareup.test.ContributingInterface contributes a binding, but does not specify " +
           "the bound type. This is only allowed with exactly one direct super type. If there " +
@@ -222,7 +222,7 @@ class ContributesBindingGeneratorTest {
       interface ContributingInterface : Abc(), ParentInterface
       """
     ) {
-      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+      assertThat(exitCode).isError()
       assertThat(messages).contains(
         "com.squareup.test.ContributingInterface contributes a binding, but does not specify " +
           "the bound type. This is only allowed with exactly one direct super type. If there " +
@@ -243,7 +243,7 @@ class ContributesBindingGeneratorTest {
       object ContributingInterface
       """
     ) {
-      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+      assertThat(exitCode).isError()
       assertThat(messages).contains(
         "com.squareup.test.ContributingInterface contributes a binding, but does not specify " +
           "the bound type. This is only allowed with exactly one direct super type. If there " +
@@ -284,7 +284,7 @@ class ContributesBindingGeneratorTest {
       interface ContributingInterface : CharSequence
       """
     ) {
-      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+      assertThat(exitCode).isError()
       assertThat(messages).contains(
         "com.squareup.test.ContributingInterface contributes a binding for " +
           "com.squareup.test.ParentInterface, but doesn't extend this type."

--- a/compiler/src/test/java/com/squareup/anvil/compiler/codegen/ContributesMultibindingGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/codegen/ContributesMultibindingGeneratorTest.kt
@@ -5,7 +5,7 @@ import com.squareup.anvil.compiler.compile
 import com.squareup.anvil.compiler.contributingInterface
 import com.squareup.anvil.compiler.hintMultibinding
 import com.squareup.anvil.compiler.hintMultibindingScope
-import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.COMPILATION_ERROR
+import com.squareup.anvil.compiler.isError
 import org.junit.Test
 
 class ContributesMultibindingGeneratorTest {
@@ -145,7 +145,7 @@ class ContributesMultibindingGeneratorTest {
         $visibility class ContributingInterface : ParentInterface
         """
       ) {
-        assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+        assertThat(exitCode).isError()
         // Position to the class.
         assertThat(messages).contains("Source0.kt: (8, ")
         assertThat(messages).contains(
@@ -178,7 +178,7 @@ class ContributesMultibindingGeneratorTest {
       interface ContributingInterface : ParentInterface
       """
     ) {
-      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+      assertThat(exitCode).isError()
       assertThat(messages).contains(
         "Classes annotated with @ContributesMultibinding may not use more than one @Qualifier."
       )
@@ -198,7 +198,7 @@ class ContributesMultibindingGeneratorTest {
       interface ContributingInterface : ParentInterface, CharSequence
       """
     ) {
-      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+      assertThat(exitCode).isError()
       assertThat(messages).contains(
         "com.squareup.test.ContributingInterface contributes a binding, but does not specify " +
           "the bound type. This is only allowed with exactly one direct super type. If there " +
@@ -223,7 +223,7 @@ class ContributesMultibindingGeneratorTest {
       interface ContributingInterface : Abc(), ParentInterface
       """
     ) {
-      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+      assertThat(exitCode).isError()
       assertThat(messages).contains(
         "com.squareup.test.ContributingInterface contributes a binding, but does not specify " +
           "the bound type. This is only allowed with exactly one direct super type. If there " +
@@ -244,7 +244,7 @@ class ContributesMultibindingGeneratorTest {
       object ContributingInterface
       """
     ) {
-      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+      assertThat(exitCode).isError()
       assertThat(messages).contains(
         "com.squareup.test.ContributingInterface contributes a binding, but does not specify " +
           "the bound type. This is only allowed with exactly one direct super type. If there " +
@@ -289,7 +289,7 @@ class ContributesMultibindingGeneratorTest {
       interface ContributingInterface : CharSequence
       """
     ) {
-      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+      assertThat(exitCode).isError()
       assertThat(messages).contains(
         "com.squareup.test.ContributingInterface contributes a binding for " +
           "com.squareup.test.ParentInterface, but doesn't extend this type."

--- a/compiler/src/test/java/com/squareup/anvil/compiler/codegen/ContributesToGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/codegen/ContributesToGeneratorTest.kt
@@ -9,7 +9,7 @@ import com.squareup.anvil.compiler.hintContributes
 import com.squareup.anvil.compiler.hintContributesScope
 import com.squareup.anvil.compiler.innerInterface
 import com.squareup.anvil.compiler.innerModule
-import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.COMPILATION_ERROR
+import com.squareup.anvil.compiler.isError
 import org.junit.Test
 
 class ContributesToGeneratorTest {
@@ -162,7 +162,7 @@ class ContributesToGeneratorTest {
       abstract class DaggerModule1
       """
     ) {
-      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+      assertThat(exitCode).isError()
       // Position to the class.
       assertThat(messages).contains("Source0.kt: (6, 16)")
     }
@@ -187,7 +187,7 @@ class ContributesToGeneratorTest {
         $visibility abstract class DaggerModule1
         """
       ) {
-        assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+        assertThat(exitCode).isError()
         // Position to the class.
         assertThat(messages).contains("Source0.kt: (7, ")
       }
@@ -212,7 +212,7 @@ class ContributesToGeneratorTest {
         $visibility interface ContributingInterface
         """
       ) {
-        assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+        assertThat(exitCode).isError()
         // Position to the class.
         assertThat(messages).contains("Source0.kt: (6, ")
       }

--- a/compiler/src/test/java/com/squareup/anvil/compiler/dagger/AnvilAnnotationDetectorCheckTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/dagger/AnvilAnnotationDetectorCheckTest.kt
@@ -4,7 +4,7 @@ import com.google.common.truth.Truth.assertThat
 import com.squareup.anvil.compiler.USE_IR
 import com.squareup.anvil.compiler.WARNINGS_AS_ERRORS
 import com.squareup.anvil.compiler.internal.testing.compileAnvil
-import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.COMPILATION_ERROR
+import com.squareup.anvil.compiler.isError
 import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.OK
 import com.tschuchort.compiletesting.KotlinCompilation.Result
 import org.junit.Test
@@ -115,7 +115,7 @@ class AnvilAnnotationDetectorCheckTest {
   }
 
   private fun Result.assertError() {
-    assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+    assertThat(exitCode).isError()
     assertThat(messages).contains("Source0.kt: (5, 1")
     assertThat(messages).contains(
       "This Gradle module is configured to ONLY generate Dagger factories with the " +

--- a/compiler/src/test/java/com/squareup/anvil/compiler/dagger/AnvilMergeAnnotationDetectorCheckTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/dagger/AnvilMergeAnnotationDetectorCheckTest.kt
@@ -4,7 +4,7 @@ import com.google.common.truth.Truth.assertThat
 import com.squareup.anvil.compiler.USE_IR
 import com.squareup.anvil.compiler.WARNINGS_AS_ERRORS
 import com.squareup.anvil.compiler.internal.testing.compileAnvil
-import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.COMPILATION_ERROR
+import com.squareup.anvil.compiler.isError
 import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.OK
 import com.tschuchort.compiletesting.KotlinCompilation.Result
 import org.junit.Test
@@ -103,7 +103,7 @@ class AnvilMergeAnnotationDetectorCheckTest {
   }
 
   private fun Result.assertError() {
-    assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+    assertThat(exitCode).isError()
     assertThat(messages).contains("Source0.kt: (5, 1")
     assertThat(messages).contains(
       "This Gradle module is configured to ONLY generate code with the " +

--- a/compiler/src/test/java/com/squareup/anvil/compiler/dagger/AssistedFactoryGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/dagger/AssistedFactoryGeneratorTest.kt
@@ -14,7 +14,7 @@ import com.squareup.anvil.compiler.internal.testing.implClass
 import com.squareup.anvil.compiler.internal.testing.isStatic
 import com.squareup.anvil.compiler.internal.testing.moduleFactoryClass
 import com.squareup.anvil.compiler.internal.testing.use
-import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.COMPILATION_ERROR
+import com.squareup.anvil.compiler.isError
 import com.tschuchort.compiletesting.KotlinCompilation.Result
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -896,7 +896,7 @@ public final class AssistedServiceFactory_Impl implements AssistedServiceFactory
       }
       """
     ) {
-      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+      assertThat(exitCode).isError()
       assertThat(messages).contains(
         "Invalid return type: com.squareup.test.AssistedService. An assisted factory's " +
           "abstract method must return a type with an @AssistedInject-annotated constructor."
@@ -922,7 +922,7 @@ public final class AssistedServiceFactory_Impl implements AssistedServiceFactory
       }
       """
     ) {
-      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+      assertThat(exitCode).isError()
       assertThat(messages).contains("Invalid return type:")
       assertThat(messages).contains(
         "An assisted factory's abstract method must return a type with an " +
@@ -951,7 +951,7 @@ public final class AssistedServiceFactory_Impl implements AssistedServiceFactory
       }
       """
     ) {
-      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+      assertThat(exitCode).isError()
       assertThat(messages).contains(
         "The parameters in the factory method must match the @Assisted parameters " +
           "in com.squareup.test.AssistedService."
@@ -979,7 +979,7 @@ public final class AssistedServiceFactory_Impl implements AssistedServiceFactory
       }
       """
     ) {
-      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+      assertThat(exitCode).isError()
       assertThat(messages).contains(
         "The parameters in the factory method must match the @Assisted parameters " +
           "in com.squareup.test.AssistedService."
@@ -1302,7 +1302,7 @@ public final class AssistedServiceFactory_Impl implements AssistedServiceFactory
       }
       """
     ) {
-      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+      assertThat(exitCode).isError()
       assertThat(messages).contains(
         "@AssistedFactory method has duplicate @Assisted types: " +
           "@Assisted(\"one\") com.squareup.test.Type"
@@ -1331,7 +1331,7 @@ public final class AssistedServiceFactory_Impl implements AssistedServiceFactory
       }
       """
     ) {
-      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+      assertThat(exitCode).isError()
       assertThat(messages).contains(
         "The @AssistedFactory-annotated type should contain a single abstract, non-default " +
           "method but found multiple"
@@ -1363,7 +1363,7 @@ public final class AssistedServiceFactory_Impl implements AssistedServiceFactory
       }
       """
     ) {
-      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+      assertThat(exitCode).isError()
       assertThat(messages).contains(
         "The @AssistedFactory-annotated type should contain a single abstract, non-default " +
           "method but found multiple"
@@ -1392,7 +1392,7 @@ public final class AssistedServiceFactory_Impl implements AssistedServiceFactory
       }
       """
     ) {
-      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+      assertThat(exitCode).isError()
       assertThat(messages).contains(
         "The @AssistedFactory-annotated type should contain a single abstract, non-default " +
           "method but found multiple"
@@ -1418,7 +1418,7 @@ public final class AssistedServiceFactory_Impl implements AssistedServiceFactory
       interface AssistedServiceFactory
       """
     ) {
-      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+      assertThat(exitCode).isError()
       assertThat(messages).contains(
         "The @AssistedFactory-annotated type is missing an abstract, non-default method " +
           "whose return type matches the assisted injection type."
@@ -1446,7 +1446,7 @@ public final class AssistedServiceFactory_Impl implements AssistedServiceFactory
       }
       """
     ) {
-      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+      assertThat(exitCode).isError()
       assertThat(messages).contains(
         "The @AssistedFactory-annotated type is missing an abstract, non-default method " +
           "whose return type matches the assisted injection type."

--- a/compiler/src/test/java/com/squareup/anvil/compiler/dagger/AssistedInjectGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/dagger/AssistedInjectGeneratorTest.kt
@@ -8,8 +8,7 @@ import com.squareup.anvil.compiler.internal.testing.compileAnvil
 import com.squareup.anvil.compiler.internal.testing.factoryClass
 import com.squareup.anvil.compiler.internal.testing.invokeGet
 import com.squareup.anvil.compiler.internal.testing.isStatic
-import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.COMPILATION_ERROR
-import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.INTERNAL_ERROR
+import com.squareup.anvil.compiler.isError
 import com.tschuchort.compiletesting.KotlinCompilation.Result
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -215,7 +214,7 @@ public final class AssistedService_Factory {
       )
       """
     ) {
-      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+      assertThat(exitCode).isError()
       assertThat(messages).contains(
         "@AssistedInject constructor has duplicate @Assisted type: " +
           "@Assisted com.squareup.test.SomeType"
@@ -239,7 +238,7 @@ public final class AssistedService_Factory {
       )
       """
     ) {
-      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+      assertThat(exitCode).isError()
       assertThat(messages).contains(
         "@AssistedInject constructor has duplicate @Assisted type: " +
           "@Assisted(\"one\") com.squareup.test.SomeType"
@@ -597,8 +596,7 @@ public final class AssistedService_Factory {
       }
       """
     ) {
-      // For some reason with Dagger this test throws an internal error.
-      assertThat(exitCode).isIn(listOf(COMPILATION_ERROR, INTERNAL_ERROR))
+      assertThat(exitCode).isError()
       assertThat(messages).contains("Types may only contain one injected constructor")
     }
   }
@@ -620,7 +618,7 @@ public final class AssistedService_Factory {
       }
       """
     ) {
-      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+      assertThat(exitCode).isError()
       assertThat(messages).contains("Types may only contain one injected constructor")
     }
   }

--- a/compiler/src/test/java/com/squareup/anvil/compiler/dagger/ComponentDetectorCheckTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/dagger/ComponentDetectorCheckTest.kt
@@ -4,7 +4,7 @@ import com.google.common.truth.Truth.assertThat
 import com.squareup.anvil.compiler.USE_IR
 import com.squareup.anvil.compiler.WARNINGS_AS_ERRORS
 import com.squareup.anvil.compiler.internal.testing.compileAnvil
-import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.COMPILATION_ERROR
+import com.squareup.anvil.compiler.isError
 import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.OK
 import com.tschuchort.compiletesting.KotlinCompilation.Result
 import org.junit.Test
@@ -22,7 +22,7 @@ class ComponentDetectorCheckTest {
       interface ComponentInterface
       """
     ) {
-      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+      assertThat(exitCode).isError()
       // Position to the class.
       assertThat(messages).contains("Source0.kt: (5, 1")
       assertThat(messages).contains(
@@ -62,7 +62,7 @@ class ComponentDetectorCheckTest {
         }
         """
     ) {
-      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+      assertThat(exitCode).isError()
       // Position to the class.
       assertThat(messages).contains("Source0.kt: (6, 3")
       assertThat(messages).contains(

--- a/compiler/src/test/java/com/squareup/anvil/compiler/dagger/InjectConstructorFactoryGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/dagger/InjectConstructorFactoryGeneratorTest.kt
@@ -8,7 +8,7 @@ import com.squareup.anvil.compiler.internal.testing.createInstance
 import com.squareup.anvil.compiler.internal.testing.factoryClass
 import com.squareup.anvil.compiler.internal.testing.getPropertyValue
 import com.squareup.anvil.compiler.internal.testing.isStatic
-import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.COMPILATION_ERROR
+import com.squareup.anvil.compiler.isError
 import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.OK
 import com.tschuchort.compiletesting.KotlinCompilation.Result
 import dagger.Lazy
@@ -2265,7 +2265,7 @@ public class InjectClass_Factory<T : List<String>>(
       }
       """
     ) {
-      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+      assertThat(exitCode).isError()
       assertThat(messages).contains("Types may only contain one injected constructor")
     }
   }

--- a/compiler/src/test/java/com/squareup/anvil/compiler/dagger/ProvidesMethodFactoryGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/dagger/ProvidesMethodFactoryGeneratorTest.kt
@@ -14,8 +14,7 @@ import com.squareup.anvil.compiler.internal.testing.compileAnvil
 import com.squareup.anvil.compiler.internal.testing.createInstance
 import com.squareup.anvil.compiler.internal.testing.isStatic
 import com.squareup.anvil.compiler.internal.testing.moduleFactoryClass
-import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.COMPILATION_ERROR
-import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.INTERNAL_ERROR
+import com.squareup.anvil.compiler.isError
 import com.tschuchort.compiletesting.KotlinCompilation.Result
 import dagger.Lazy
 import dagger.internal.Factory
@@ -2423,7 +2422,7 @@ public final class DaggerComponentInterface implements ComponentInterface {
       }
       """
     ) {
-      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+      assertThat(exitCode).isError()
       assertThat(messages).contains(
         "Cannot have more than one binding method with the same name in a single module"
       )
@@ -2524,7 +2523,7 @@ public final class DaggerComponentInterface implements ComponentInterface {
     ) {
       assumeFalse(useDagger)
 
-      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+      assertThat(exitCode).isError()
       assertThat(messages).contains("Source0.kt: (5, 3)")
       assertThat(messages).contains(
         "Dagger provider methods must specify the return type explicitly when using Anvil. " +
@@ -3100,7 +3099,7 @@ public final class DaggerModule1_GetStringFactory implements Factory<String> {
       }
       """
     ) {
-      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
+      assertThat(exitCode).isError()
       assertThat(messages).contains("@Provides methods cannot be abstract")
     }
   }
@@ -3119,8 +3118,7 @@ public final class DaggerModule1_GetStringFactory implements Factory<String> {
       }
       """
     ) {
-      // For some reason with Dagger this test throws an internal error.
-      assertThat(exitCode).isIn(setOf(COMPILATION_ERROR, INTERNAL_ERROR))
+      assertThat(exitCode).isError()
       assertThat(messages).contains("@Provides methods cannot be abstract")
     }
   }


### PR DESCRIPTION
For some reason, this changed the exit code for tests from a compilation error to an internal error when Dagger (KAPT) is enabled in a test. I think it's related to how the compile testing library works internally with KAPT.