### PR TITLE
Add required dependency to README

### DIFF
--- a/compiler-api/README.md
+++ b/compiler-api/README.md
@@ -22,6 +22,7 @@ artifact:
 ```groovy
 dependencies {
   api "com.squareup.anvil:compiler-api:${latest_version}"
+  implementation "com.squareup.anvil:compiler-utils:${latest_version}"
 
   // Optional:
   compileOnly "com.google.auto.service:auto-service-annotations:1.0"


### PR DESCRIPTION
compiler-utils is required in order to pull in `com.squareup.anvil.compiler.internal.*`