### PR TITLE
Fix ordering of compileAnvil calls

### DIFF
--- a/compiler-utils/src/testFixtures/java/com/squareup/anvil/compiler/internal/testing/TestUtils.kt
+++ b/compiler-utils/src/testFixtures/java/com/squareup/anvil/compiler/internal/testing/TestUtils.kt
@@ -223,14 +223,6 @@ public fun compileAnvil(
   block: Result.() -> Unit = { }
 ): Result {
   return AnvilCompilation()
-    .configureAnvil(
-      enableDaggerAnnotationProcessor = enableDaggerAnnotationProcessor,
-      generateDaggerFactories = generateDaggerFactories,
-      generateDaggerFactoriesOnly = generateDaggerFactoriesOnly,
-      disableComponentMerging = disableComponentMerging,
-      enableExperimentalAnvilApis = enableExperimentalAnvilApis,
-    )
-    .useIR(useIR)
     .apply {
       kotlinCompilation.apply {
         this.allWarningsAsErrors = allWarningsAsErrors
@@ -244,6 +236,14 @@ public fun compileAnvil(
         addPreviousCompilationResult(previousCompilationResult)
       }
     }
+    .configureAnvil(
+      enableDaggerAnnotationProcessor = enableDaggerAnnotationProcessor,
+      generateDaggerFactories = generateDaggerFactories,
+      generateDaggerFactoriesOnly = generateDaggerFactoriesOnly,
+      disableComponentMerging = disableComponentMerging,
+      enableExperimentalAnvilApis = enableExperimentalAnvilApis,
+    )
+    .useIR(useIR)
     .compile(*sources)
     .also(block)
 }


### PR DESCRIPTION
Since `configureAnvil` manipulates the working dir, this should be set first