### PR TITLE
Fix DefinitelyNotNullTye

### DIFF
--- a/compiler-utils/src/testFixtures/java/com/squareup/anvil/compiler/internal/testing/TestUtils.kt
+++ b/compiler-utils/src/testFixtures/java/com/squareup/anvil/compiler/internal/testing/TestUtils.kt
@@ -223,14 +223,6 @@ public fun compileAnvil(
   block: Result.() -> Unit = { }
 ): Result {
   return AnvilCompilation()
-    .configureAnvil(
-      enableDaggerAnnotationProcessor = enableDaggerAnnotationProcessor,
-      generateDaggerFactories = generateDaggerFactories,
-      generateDaggerFactoriesOnly = generateDaggerFactoriesOnly,
-      disableComponentMerging = disableComponentMerging,
-      enableExperimentalAnvilApis = enableExperimentalAnvilApis,
-    )
-    .useIR(useIR)
     .apply {
       kotlinCompilation.apply {
         this.allWarningsAsErrors = allWarningsAsErrors
@@ -244,6 +236,14 @@ public fun compileAnvil(
         addPreviousCompilationResult(previousCompilationResult)
       }
     }
+    .configureAnvil(
+      enableDaggerAnnotationProcessor = enableDaggerAnnotationProcessor,
+      generateDaggerFactories = generateDaggerFactories,
+      generateDaggerFactoriesOnly = generateDaggerFactoriesOnly,
+      disableComponentMerging = disableComponentMerging,
+      enableExperimentalAnvilApis = enableExperimentalAnvilApis,
+    )
+    .useIR(useIR)
     .compile(*sources)
     .also(block)
 }


### PR DESCRIPTION
This is another special type that I _believe_ is used for cases where Kotlinc knows a given descriptor is not null due to some external indication like `@NonNull` or a JSR 305/jSpecify annotation. I'm unable to repro it in a test but I can repro it in our codebase (which has a setup that leads me to believe the JSR 305 case, where it trips up on a java base class from an upstream module sitting in a jsr305-dictated package).

I've at least been able to confirm that our code compiles with this fix and also found some prior art in kotlinc that suggests this is the right path to unwrapping [here](https://github.com/JetBrains/kotlin/blob/9ee0d6b60ac4f0ea0ccc5dd01146bab92fabcdf2/core/descriptors/src/org/jetbrains/kotlin/types/TypeUtils.java#L448-L458.