### PR TITLE
Avoid duplicate generated subcomponents

### DIFF
--- a/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/CompilerUtils.kt
+++ b/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/CompilerUtils.kt
@@ -229,22 +229,15 @@ public fun String.decapitalize(): String = replaceFirstChar(Char::lowercaseChar)
 public fun FqName.generateClassName(
   separator: String = "_",
   suffix: String = ""
-): String = classIdBestGuess().generateClassName(separator = separator, suffix = suffix)
+): ClassId = classIdBestGuess().generateClassName(separator = separator, suffix = suffix)
 
 @ExperimentalAnvilApi
 public fun ClassId.generateClassName(
   separator: String = "_",
   suffix: String = ""
-): String {
-  val packageName = packageFqName
-    .takeIf { !it.isRoot }
-    ?.asString()
-    ?.let { "$it." }
-    ?: ""
-
+): ClassId {
   val className = relativeClassName.asString().replace(".", separator)
-
-  return "$packageName$className$suffix"
+  return ClassId(packageFqName, FqName(className + suffix), false)
 }
 
 @ExperimentalAnvilApi

--- a/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/PsiUtils.kt
+++ b/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/PsiUtils.kt
@@ -771,6 +771,10 @@ public fun FqName.classDescriptorOrNull(module: ModuleDescriptor): ClassDescript
 }
 
 @ExperimentalAnvilApi
+public fun ClassId.classDescriptorOrNull(module: ModuleDescriptor): ClassDescriptor? =
+  asSingleFqName().classDescriptorOrNull(module)
+
+@ExperimentalAnvilApi
 public fun KtAnnotationEntry.isQualifier(module: ModuleDescriptor): Boolean {
   return typeReference
     ?.requireFqName(module)

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesSubcomponentHandlerGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesSubcomponentHandlerGenerator.kt
@@ -36,7 +36,7 @@ import com.squareup.anvil.compiler.internal.scope
 import com.squareup.anvil.compiler.internal.toClassId
 import com.squareup.anvil.compiler.internal.toClassReference
 import com.squareup.anvil.compiler.mergeComponentFqName
-import com.squareup.anvil.compiler.mergeModulesFqName
+import com.squareup.anvil.compiler.mergeInterfacesFqName
 import com.squareup.anvil.compiler.mergeSubcomponentFqName
 import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.ClassName
@@ -434,10 +434,10 @@ internal class ContributesSubcomponentHandlerGenerator(
     val generationTrigger = setOf(
       mergeComponentFqName,
       mergeSubcomponentFqName,
-      // Note that we don't include @MergeInterfaces, because we would potentially generate
+      // Note that we don't include @MergeModules, because we would potentially generate
       // components twice. @MergeInterfaces and @MergeModules are doing separately what
       // @MergeComponent is doing at once.
-      mergeModulesFqName,
+      mergeInterfacesFqName,
     )
   }
 

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/AssistedFactoryGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/AssistedFactoryGenerator.kt
@@ -182,8 +182,8 @@ internal class AssistedFactoryGenerator : PrivateCodeGenerator() {
       return if (typeParameters.isEmpty()) this else parameterizedBy(typeParameters)
     }
 
-    val generatedFactoryTypeName = FqName(returnTypeFqName.generateClassName(suffix = "_Factory"))
-      .asClassName(module)
+    val generatedFactoryTypeName = returnTypeFqName.generateClassName(suffix = "_Factory")
+      .asClassName()
       .parameterized()
 
     val baseFactoryTypeName = clazz.asClassName().parameterized()

--- a/compiler/src/test/java/com/squareup/anvil/compiler/codegen/ContributesSubcomponentHandlerGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/codegen/ContributesSubcomponentHandlerGeneratorTest.kt
@@ -72,31 +72,8 @@ class ContributesSubcomponentHandlerGeneratorTest {
     }
   }
 
-  @Test fun `there is a subcomponent generated for a @MergeModules`() {
-    compile(
-      """
-        package com.squareup.test
-  
-        import com.squareup.anvil.annotations.ContributesSubcomponent
-        import com.squareup.anvil.annotations.compat.MergeModules
-  
-        @ContributesSubcomponent(Any::class, Unit::class)
-        interface SubcomponentInterface
-        
-        @MergeModules(Unit::class)
-        interface ComponentInterface
-      """.trimIndent()
-    ) {
-      val anvilComponent = subcomponentInterface.anvilComponent(componentInterface)
-      assertThat(anvilComponent).isNotNull()
-
-      val annotation = anvilComponent.getAnnotation(MergeSubcomponent::class.java)
-      assertThat(annotation).isNotNull()
-      assertThat(annotation.scope).isEqualTo(Any::class)
-    }
-  }
-
-  @Test fun `there is no subcomponent generated for a @MergeInterfaces`() {
+  @Test
+  fun `there is a subcomponent generated for a @MergeInterfaces and the parent component is added to the interface`() {
     compile(
       """
         package com.squareup.test
@@ -108,6 +85,36 @@ class ContributesSubcomponentHandlerGeneratorTest {
         interface SubcomponentInterface
         
         @MergeInterfaces(Unit::class)
+        interface ComponentInterface
+      """.trimIndent()
+    ) {
+      val anvilComponent = subcomponentInterface.anvilComponent(componentInterface)
+      assertThat(anvilComponent).isNotNull()
+
+      val annotation = anvilComponent.getAnnotation(MergeSubcomponent::class.java)
+      assertThat(annotation).isNotNull()
+      assertThat(annotation.scope).isEqualTo(Any::class)
+
+      assertThat(
+        componentInterface extends subcomponentInterface
+          .anvilComponent(componentInterface)
+          .parentComponentInterface
+      ).isTrue()
+    }
+  }
+
+  @Test fun `there is no subcomponent generated for a @MergeModules`() {
+    compile(
+      """
+        package com.squareup.test
+  
+        import com.squareup.anvil.annotations.ContributesSubcomponent
+        import com.squareup.anvil.annotations.compat.MergeModules
+  
+        @ContributesSubcomponent(Any::class, Unit::class)
+        interface SubcomponentInterface
+        
+        @MergeModules(Unit::class)
         interface ComponentInterface
       """.trimIndent()
     ) {


### PR DESCRIPTION
This PR solves an issue that the same subcomponent is generated, what results in very surprising results. We now make sure that each generated subcomponent is unique. 