### PR TITLE
Upgrade Dagger and remove the workaround for the metadata dependency.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -90,14 +90,6 @@ subprojects {
       substitute module("com.squareup.anvil:compiler-api") with project(':compiler-api')
       substitute module("com.squareup.anvil:compiler-utils") with project(':compiler-utils')
     }
-
-    // TODO: check if this is needed with newer Kotlin versions.
-    if (rootProject.ext.kotlinVersion.startsWith("1.6")) {
-      resolutionStrategy {
-        // Needed for Kotlin 1.6.
-        force deps.kotlin.metadata
-      }
-    }
   }
 
   // We disable configure on demand in the local gradle.properties, but you can override this flag

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -4,7 +4,7 @@ ext {
   ci = (System.getenv('CI') ?: 'false').toBoolean()
 
   autoServiceVersion = '1.0.1'
-  daggerVersion = '2.36'
+  daggerVersion = '2.40.5'
   espressoVersion = '3.2.0'
 
   agpVersion = project.hasProperty('square.agpVersion') ?


### PR DESCRIPTION
This requires Kotlin 1.6, but I wanted to put up the PR nonetheless.