### PR TITLE
Make `@ContributesTo` repeatable.

### DIFF
--- a/annotations/src/main/kotlin-1-6/com/squareup/anvil/annotations/ContributesTo.kt
+++ b/annotations/src/main/kotlin-1-6/com/squareup/anvil/annotations/ContributesTo.kt
@@ -38,6 +38,7 @@ import kotlin.reflect.KClass
  */
 @Target(CLASS)
 @Retention(RUNTIME)
+@Repeatable
 public annotation class ContributesTo(
   /**
    * The scope in which to include this module.

--- a/compiler-api/src/main/java/com/squareup/anvil/compiler/api/AnvilCompilationException.kt
+++ b/compiler-api/src/main/java/com/squareup/anvil/compiler/api/AnvilCompilationException.kt
@@ -10,6 +10,7 @@ import org.jetbrains.kotlin.ir.declarations.IrClass
 import org.jetbrains.kotlin.ir.symbols.IrSymbol
 import org.jetbrains.kotlin.ir.util.render
 import org.jetbrains.kotlin.js.resolve.diagnostics.findPsi
+import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
 import org.jetbrains.kotlin.resolve.source.KotlinSourceElement
 import org.jetbrains.kotlin.resolve.source.getPsi
 import org.jetbrains.kotlin.util.getExceptionMessage
@@ -41,10 +42,16 @@ public class AnvilCompilationException(
       message: String,
       cause: Throwable? = null
     ): AnvilCompilationException {
+      val psiElement = classDescriptor.identifier
+
       return AnvilCompilationException(
-        message = message,
+        message = if (psiElement == null) {
+          message + " | Descriptor: ${classDescriptor.fqNameSafe}"
+        } else {
+          message
+        },
         cause = cause,
-        element = classDescriptor.identifier
+        element = psiElement
       )
     }
 

--- a/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/CompilerUtils.kt
+++ b/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/CompilerUtils.kt
@@ -13,8 +13,6 @@ import org.jetbrains.kotlin.descriptors.findClassAcrossModuleDependencies
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
-import org.jetbrains.kotlin.platform.has
-import org.jetbrains.kotlin.platform.jvm.JvmPlatform
 import org.jetbrains.kotlin.resolve.constants.ConstantValue
 import org.jetbrains.kotlin.resolve.constants.KClassValue
 import org.jetbrains.kotlin.resolve.constants.KClassValue.Value.NormalClass
@@ -32,39 +30,51 @@ import org.jetbrains.kotlin.types.typeUtil.supertypes
 import org.jetbrains.org.objectweb.asm.Type
 
 @ExperimentalAnvilApi
+@Deprecated("Repeatable")
 public fun ClassDescriptor.annotationOrNull(
   annotationFqName: FqName,
   scope: FqName? = null
 ): AnnotationDescriptor? {
-  // Must be JVM, we don't support anything else.
-  if (!module.platform.has<JvmPlatform>()) return null
-  val annotationDescriptor = try {
-    annotations.findAnnotation(annotationFqName)
-  } catch (e: IllegalStateException) {
-    // In some scenarios this exception is thrown. Throw a new exception with a better explanation.
-    // Caused by: java.lang.IllegalStateException: Should not be called!
-    // at org.jetbrains.kotlin.types.ErrorUtils$1.getPackage(ErrorUtils.java:95)
-    throw AnvilCompilationException(
-      this,
-      message = "It seems like you tried to contribute an inner class to its outer class. This " +
-        "is not supported and results in a compiler error.",
-      cause = e
-    )
-  }
-  return if (scope == null || annotationDescriptor == null) {
-    annotationDescriptor
-  } else {
-    annotationDescriptor.takeIf { scope == it.scope(module).fqNameSafe }
-  }
+  return annotations(annotationFqName, scope).singleOrEmpty()
 }
 
 @ExperimentalAnvilApi
+public fun ClassDescriptor.annotations(
+  annotationFqName: FqName,
+  scope: FqName? = null
+): List<AnnotationDescriptor> {
+  return annotations
+    .filter {
+      val fqName = it.fqName ?: throw AnvilCompilationException(
+        this,
+        message = "It seems like you tried to contribute an inner class to its outer class. This " +
+          "is not supported and results in a compiler error.",
+      )
+
+      fqName == annotationFqName
+    }
+    .let { descriptors ->
+      if (scope == null) {
+        descriptors
+      } else {
+        descriptors
+          .filter {
+            it.scope(module).fqNameSafe == scope
+          }
+      }
+    }
+}
+
+@ExperimentalAnvilApi
+@Deprecated("Repeatable")
 public fun ClassDescriptor.annotation(
   annotationFqName: FqName,
   scope: FqName? = null
-): AnnotationDescriptor = requireNotNull(annotationOrNull(annotationFqName, scope)) {
-  "Couldn't find $annotationFqName with scope $scope for $fqNameSafe."
-}
+): AnnotationDescriptor = annotations(annotationFqName, scope).singleOrNull()
+  ?: throw AnvilCompilationException(
+    classDescriptor = this,
+    message = "Couldn't find $annotationFqName with scope $scope for $fqNameSafe."
+  )
 
 /**
  * Returns only the super class (excluding [Any]) and implemented interfaces declared directly by
@@ -158,7 +168,7 @@ public fun ConstantValue<*>.argumentType(module: ModuleDescriptor): KotlinType {
 @ExperimentalAnvilApi
 public fun List<KotlinType>.getAllSuperTypes(): Sequence<FqName> =
   generateSequence(this) { kotlinTypes ->
-    kotlinTypes.ifEmpty { null }?.flatMap { it.supertypes() }
+    kotlinTypes.takeIfNotEmpty()?.flatMap { it.supertypes() }
   }
     .flatMap { it.asSequence() }
     .map { it.requireClassDescriptor().fqNameSafe }
@@ -247,3 +257,36 @@ public fun ClassDescriptor.requireClassId(): ClassId {
     message = "Couldn't find the classId for $fqNameSafe."
   )
 }
+
+/**
+ * Returns the single element matching the given [predicate], or `null` if element was not found.
+ * Unlike [singleOrNull] this method throws an exception if more than one element is found.
+ */
+@ExperimentalAnvilApi
+public inline fun <T> Iterable<T>.singleOrEmpty(predicate: (T) -> Boolean): T? {
+  var single: T? = null
+  var found = false
+  for (element in this) {
+    if (predicate(element)) {
+      if (found) throw IllegalArgumentException(
+        "Collection contains more than one matching element."
+      )
+      single = element
+      found = true
+    }
+  }
+  return single
+}
+
+private val truePredicate: (Any?) -> Boolean = { true }
+
+/**
+ * Returns single element, or `null` if the collection is empty. Unlike [singleOrNull] this
+ * method throws an exception if more than one element is found.
+ */
+@ExperimentalAnvilApi
+public fun <T> Iterable<T>.singleOrEmpty(): T? = singleOrEmpty(truePredicate)
+
+@Suppress("NOTHING_TO_INLINE")
+@ExperimentalAnvilApi
+public inline fun <C, T> C.takeIfNotEmpty(): C? where C : Collection<T> = ifEmpty { null }

--- a/compiler-utils/src/testFixtures/java/com/squareup/anvil/compiler/internal/testing/TestUtils.kt
+++ b/compiler-utils/src/testFixtures/java/com/squareup/anvil/compiler/internal/testing/TestUtils.kt
@@ -33,6 +33,7 @@ public class AnvilCompilation internal constructor(
 
   private var isCompiled = false
   private var anvilConfigured = false
+  private var anvilEnabled = true
   private var swapClassLoader = false
 
   /** Configures this the Anvil behavior of this compilation. */
@@ -46,6 +47,9 @@ public class AnvilCompilation internal constructor(
     enableExperimentalAnvilApis: Boolean = true,
   ) = apply {
     checkNotCompiled()
+    check(!anvilConfigured) { "Anvil should not be configured twice." }
+    check(anvilEnabled) { "Anvil must be enabled." }
+
     anvilConfigured = true
     kotlinCompilation.apply {
       compilerPlugins = listOf(AnvilComponentRegistrar())
@@ -86,6 +90,14 @@ public class AnvilCompilation internal constructor(
         )
       }
     }
+  }
+
+  public fun enableAnvil(enable: Boolean) = apply {
+    checkNotCompiled()
+    if (!enable) {
+      check(!anvilConfigured) { "You cannot disable Anvil after it has been configured." }
+    }
+    anvilEnabled = enable
   }
 
   /**
@@ -174,7 +186,7 @@ public class AnvilCompilation internal constructor(
     block: Result.() -> Unit = {}
   ): Result {
     checkNotCompiled()
-    if (!anvilConfigured) {
+    if (!anvilConfigured && anvilEnabled) {
       // Configure with default behaviors
       configureAnvil()
     }

--- a/compiler/src/main/java/com/squareup/anvil/compiler/ClassScannerIr.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/ClassScannerIr.kt
@@ -1,24 +1,54 @@
 package com.squareup.anvil.compiler
 
+import com.squareup.anvil.compiler.api.AnvilCompilationException
+import com.squareup.anvil.compiler.internal.singleOrEmpty
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
+import org.jetbrains.kotlin.ir.expressions.IrConstructorCall
 import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
 
 /**
- * Returns a sequence of contributed classes from the dependency graph. Note that the result
- * includes inner classes already.
+ * Returns a sequence of contributed hints from the dependency graph. Note that the result
+ * already includes inner classes.
  */
-internal fun ClassScanner.findContributedClasses(
+internal fun ClassScanner.findContributedHints(
   pluginContext: IrPluginContext,
   moduleFragment: IrModuleFragment,
-  packageName: String,
-  annotation: FqName,
-  scope: FqName
-): Sequence<IrClassSymbol> {
-  return findContributedClasses(moduleFragment.descriptor, packageName, annotation, scope)
+  annotation: FqName
+): Sequence<ContributedHintIr> {
+  return findContributedHints(moduleFragment.descriptor, annotation)
     .map {
-      pluginContext.requireReferenceClass(it.fqNameSafe)
+      ContributedHintIr(
+        irClass = pluginContext.requireReferenceClass(it.descriptor.fqNameSafe),
+        annotationFqName = it.annotationFqName,
+        scopes = it.scopes
+      )
     }
+}
+
+internal class ContributedHintIr(
+  val irClass: IrClassSymbol,
+  val annotationFqName: FqName,
+  private val scopes: List<FqName>
+) {
+  val fqName = irClass.fqName
+
+  fun isContributedToScope(scope: FqName): Boolean = scopes.any { it == scope }
+
+  fun contributedAnnotations(scope: FqName? = null): List<IrConstructorCall> =
+    irClass.owner.annotations(annotationFqName, scope)
+
+  // TODO Repeatable: do we need a cache?
+  // There must only one annotation, because we only allow one contribution to the same scope.
+  fun contributedAnnotationOrNull(scope: FqName): IrConstructorCall? {
+    return contributedAnnotations(scope).singleOrEmpty()
+  }
+
+  fun contributedAnnotation(scope: FqName): IrConstructorCall =
+    contributedAnnotationOrNull(scope) ?: throw AnvilCompilationException(
+      element = irClass,
+      message = "Couldn't find $annotationFqName with scope $scope."
+    )
 }

--- a/compiler/src/main/java/com/squareup/anvil/compiler/InterfaceMerger.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/InterfaceMerger.kt
@@ -2,8 +2,7 @@ package com.squareup.anvil.compiler
 
 import com.squareup.anvil.compiler.api.AnvilCompilationException
 import com.squareup.anvil.compiler.codegen.generatedAnvilSubcomponent
-import com.squareup.anvil.compiler.internal.annotation
-import com.squareup.anvil.compiler.internal.annotationOrNull
+import com.squareup.anvil.compiler.internal.annotations
 import com.squareup.anvil.compiler.internal.argumentType
 import com.squareup.anvil.compiler.internal.classDescriptorOrNull
 import com.squareup.anvil.compiler.internal.getAllSuperTypes
@@ -11,7 +10,10 @@ import com.squareup.anvil.compiler.internal.getAnnotationValue
 import com.squareup.anvil.compiler.internal.parentScope
 import com.squareup.anvil.compiler.internal.requireClassDescriptor
 import com.squareup.anvil.compiler.internal.requireClassId
+import com.squareup.anvil.compiler.internal.requireFqName
 import com.squareup.anvil.compiler.internal.scope
+import com.squareup.anvil.compiler.internal.singleOrEmpty
+import com.squareup.anvil.compiler.internal.takeIfNotEmpty
 import org.jetbrains.kotlin.descriptors.ClassDescriptor
 import org.jetbrains.kotlin.descriptors.EffectiveVisibility.Public
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
@@ -36,45 +38,58 @@ internal class InterfaceMerger(
     thisDescriptor: ClassDescriptor,
     supertypes: MutableList<KotlinType>
   ) {
-    val mergeAnnotation = thisDescriptor.annotationOrNull(mergeComponentFqName)
-      ?: thisDescriptor.annotationOrNull(mergeSubcomponentFqName)
-      ?: thisDescriptor.annotationOrNull(mergeInterfacesFqName)
+    val mergeAnnotations = thisDescriptor.annotations(mergeComponentFqName).takeIfNotEmpty()
+      ?: thisDescriptor.annotations(mergeSubcomponentFqName).takeIfNotEmpty()
+      ?: thisDescriptor.annotations(mergeInterfacesFqName).takeIfNotEmpty()
 
-    if (mergeAnnotation == null) {
+    if (mergeAnnotations == null) {
       super.addSyntheticSupertypes(thisDescriptor, supertypes)
       return
     }
 
-    val module = thisDescriptor.module
-
-    val scope = mergeAnnotation.scope(module)
-    val scopeFqName = scope.fqNameSafe
+    val mergeAnnotation = mergeAnnotations.singleOrNull()
+      ?: throw AnvilCompilationException(
+        classDescriptor = thisDescriptor,
+        message = "Expected only a single annotation, but found multiple " +
+          "${mergeAnnotations.first().requireFqName()} annotations."
+      )
 
     if (!DescriptorUtils.isInterface(thisDescriptor)) {
       throw AnvilCompilationException(thisDescriptor, "Dagger components must be interfaces.")
     }
 
-    val classes = classScanner
-      .findContributedClasses(
-        module = module,
-        packageName = HINT_CONTRIBUTES_PACKAGE_PREFIX,
-        annotation = contributesToFqName,
-        scope = scopeFqName
+    val module = thisDescriptor.module
+
+    val scope = try {
+      mergeAnnotation.scope(module)
+    } catch (e: AssertionError) {
+      // In some scenarios this error is thrown. Throw a new exception with a better explanation.
+      // Caused by: java.lang.AssertionError: Recursion detected in a lazy value under
+      // LockBasedStorageManager@420989af (TopDownAnalyzer for JVM)
+      throw AnvilCompilationException(
+        classDescriptor = thisDescriptor,
+        message = "It seems like you tried to contribute an inner class to its outer class. " +
+          "This is not supported and results in a compiler error.",
+        cause = e
       )
-      .filter {
-        DescriptorUtils.isInterface(it) && it.annotationOrNull(daggerModuleFqName) == null
+    }
+    val scopeFqName = scope.fqNameSafe
+
+    val classes = classScanner
+      .findContributedHints(
+        module = module,
+        annotation = contributesToFqName,
+      )
+      .filter { hint ->
+        DescriptorUtils.isInterface(hint.descriptor) &&
+          hint.isContributedToScope(scopeFqName) &&
+          hint.descriptor.annotations(daggerModuleFqName).singleOrEmpty() == null
       }
-      .mapNotNull {
-        val contributeAnnotation =
-          it.annotationOrNull(contributesToFqName, scope = scopeFqName)
-            ?: return@mapNotNull null
-        it to contributeAnnotation
-      }
-      .onEach { (classDescriptor, _) ->
-        if (classDescriptor.effectiveVisibility() !is Public) {
+      .onEach { hint ->
+        if (hint.descriptor.effectiveVisibility() !is Public) {
           throw AnvilCompilationException(
-            classDescriptor,
-            "${classDescriptor.fqNameSafe} is contributed to the Dagger graph, but the " +
+            hint.descriptor,
+            "${hint.fqName} is contributed to the Dagger graph, but the " +
               "interface is not public. Only public interfaces are supported."
           )
         }
@@ -84,44 +99,31 @@ internal class InterfaceMerger(
       .toList()
 
     val replacedClasses = classes
-      .flatMap { (classDescriptor, contributeAnnotation) ->
-        contributeAnnotation.replaces(classDescriptor.module)
+      .flatMap { hint ->
+        hint.contributedAnnotation(scopeFqName).replaces(hint.descriptor.module)
           .onEach { classDescriptorForReplacement ->
             // Verify the other class is an interface. It doesn't make sense for a contributed
             // interface to replace a class that is not an interface.
             if (!DescriptorUtils.isInterface(classDescriptorForReplacement)) {
               throw AnvilCompilationException(
-                classDescriptor,
-                "${classDescriptor.fqNameSafe} wants to replace " +
+                classDescriptor = hint.descriptor,
+                message = "${hint.fqName} wants to replace " +
                   "${classDescriptorForReplacement.fqNameSafe}, but the class being " +
                   "replaced is not an interface."
               )
             }
 
-            val contributesToAnnotation = classDescriptorForReplacement
-              .annotationOrNull(contributesToFqName)
-            val contributesBindingAnnotation = classDescriptorForReplacement
-              .annotationOrNull(contributesBindingFqName)
-            val contributesMultibindingAnnotation = classDescriptorForReplacement
-              .annotationOrNull(contributesMultibindingFqName)
-
             // Verify that the replaced classes use the same scope.
-            val scopeOfReplacement = contributesToAnnotation?.scope(module)
-              ?: contributesBindingAnnotation?.scope(module)
-              ?: contributesMultibindingAnnotation?.scope(module)
-              ?: throw AnvilCompilationException(
-                classDescriptor,
-                "Could not determine the scope of the replaced class " +
-                  "${classDescriptorForReplacement.fqNameSafe}."
-              )
+            val contributesToOurScope = classDescriptorForReplacement
+              .annotations(hint.annotationFqName)
+              .any { it.scope(module).fqNameSafe == scopeFqName }
 
-            if (scopeOfReplacement.fqNameSafe != scopeFqName) {
+            if (!contributesToOurScope) {
               throw AnvilCompilationException(
-                classDescriptor,
-                "${classDescriptor.fqNameSafe} with scope $scopeFqName wants to replace " +
-                  "${classDescriptorForReplacement.fqNameSafe} with scope " +
-                  "${scopeOfReplacement.fqNameSafe}. The replacement must use the same " +
-                  "scope."
+                classDescriptor = hint.descriptor,
+                message = "${hint.fqName} with scope $scopeFqName wants to replace " +
+                  "${classDescriptorForReplacement.fqNameSafe}, but the replaced class isn't " +
+                  "contributed to the same scope."
               )
             }
           }
@@ -132,34 +134,25 @@ internal class InterfaceMerger(
     val excludedClasses = (mergeAnnotation.getAnnotationValue("exclude") as? ArrayValue)
       ?.value
       ?.map { it.argumentType(module).requireClassDescriptor() }
-      ?.filter { DescriptorUtils.isInterface(it) }
       ?.map { classDescriptorForExclusion ->
-        val contributesToAnnotation = classDescriptorForExclusion
-          .annotationOrNull(contributesToFqName)
-        val contributesBindingAnnotation = classDescriptorForExclusion
-          .annotationOrNull(contributesBindingFqName)
-        val contributesMultibindingAnnotation = classDescriptorForExclusion
-          .annotationOrNull(contributesMultibindingFqName)
-        val contributesSubcomponentAnnotation = classDescriptorForExclusion
-          .annotationOrNull(contributesSubcomponentFqName)
+        val scopes = classDescriptorForExclusion
+          .annotations(contributesToFqName).map { it.scope(module) } +
+          classDescriptorForExclusion
+            .annotations(contributesBindingFqName).map { it.scope(module) } +
+          classDescriptorForExclusion
+            .annotations(contributesMultibindingFqName).map { it.scope(module) } +
+          classDescriptorForExclusion
+            .annotations(contributesSubcomponentFqName).map { it.parentScope(module) }
 
-        // Verify that the replaced classes use the same scope.
-        val scopeOfExclusion = contributesToAnnotation?.scope(module)
-          ?: contributesBindingAnnotation?.scope(module)
-          ?: contributesMultibindingAnnotation?.scope(module)
-          ?: contributesSubcomponentAnnotation?.parentScope(module)
-          ?: throw AnvilCompilationException(
-            thisDescriptor,
-            "Could not determine the scope of the excluded class " +
-              "${classDescriptorForExclusion.fqNameSafe}."
-          )
+        // Verify that the excluded classes use the same scope.
+        val contributesToOurScope = scopes.any { it.fqNameSafe == scopeFqName }
 
-        if (scopeOfExclusion.fqNameSafe != scopeFqName) {
+        if (!contributesToOurScope) {
           throw AnvilCompilationException(
             thisDescriptor,
             "${thisDescriptor.fqNameSafe} with scope $scopeFqName wants to exclude " +
-              "${classDescriptorForExclusion.fqNameSafe} with scope " +
-              "${scopeOfExclusion.fqNameSafe}. The exclusion must use the same scope."
+              "${classDescriptorForExclusion.fqNameSafe}, but the excluded class isn't " +
+              "contributed to the same scope."
           )
         }
 
@@ -184,10 +177,10 @@ internal class InterfaceMerger(
 
     @Suppress("ConvertCallChainIntoSequence")
     val contributedClasses = classes
-      .map { it.first }
+      .map { it.descriptor }
       .filterNot {
         val fqName = it.fqNameSafe
-        replacedClasses.contains(fqName) || excludedClasses.contains(fqName)
+        fqName in replacedClasses || fqName in excludedClasses
       }
       .plus(findContributedSubcomponentParentInterfaces(thisDescriptor, scopeFqName, module))
       // Avoids an error for repeated interfaces.
@@ -204,17 +197,18 @@ internal class InterfaceMerger(
     module: ModuleDescriptor
   ): Sequence<ClassDescriptor> {
     return classScanner
-      .findContributedClasses(
+      .findContributedHints(
         module = module,
-        packageName = HINT_SUBCOMPONENTS_PACKAGE_PREFIX,
-        annotation = contributesSubcomponentFqName,
-        scope = null
+        annotation = contributesSubcomponentFqName
       )
-      .filter {
-        it.annotation(contributesSubcomponentFqName).parentScope(module).fqNameSafe == scope
+      .filter { contributedHint ->
+        contributedHint
+          .contributedAnnotations(scope = null)
+          .map { it.parentScope(module).fqNameSafe }
+          .any { it == scope }
       }
-      .mapNotNull { contributedSubcomponent ->
-        contributedSubcomponent.requireClassId()
+      .mapNotNull { contributedHint ->
+        contributedHint.descriptor.requireClassId()
           .generatedAnvilSubcomponent(descriptor.requireClassId())
           .createNestedClassId(Name.identifier(PARENT_COMPONENT))
           .classDescriptorOrNull(module)

--- a/compiler/src/main/java/com/squareup/anvil/compiler/IrUtils.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/IrUtils.kt
@@ -2,6 +2,7 @@ package com.squareup.anvil.compiler
 
 import com.squareup.anvil.compiler.api.AnvilCompilationException
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
+import org.jetbrains.kotlin.backend.jvm.codegen.AnnotationCodegen.Companion.annotationClass
 import org.jetbrains.kotlin.ir.declarations.IrAnnotationContainer
 import org.jetbrains.kotlin.ir.declarations.IrClass
 import org.jetbrains.kotlin.ir.declarations.IrDeclarationWithName
@@ -28,6 +29,27 @@ internal fun IrPluginContext.requireReferenceClass(fqName: FqName): IrClassSymbo
   )
 }
 
+internal fun IrAnnotationContainer.annotations(
+  annotationFqName: FqName,
+  scope: FqName? = null
+): List<IrConstructorCall> {
+  return annotations
+    .filter {
+      it.annotationClass.fqName == annotationFqName
+    }
+    .let { constructorCalls ->
+      if (scope == null) {
+        constructorCalls
+      } else {
+        constructorCalls
+          .filter {
+            it.scope() == scope
+          }
+      }
+    }
+}
+
+@Deprecated("Repeatable")
 internal fun IrAnnotationContainer.annotationOrNull(
   annotationFqName: FqName,
   scope: FqName? = null
@@ -37,6 +59,7 @@ internal fun IrAnnotationContainer.annotationOrNull(
   }
 }
 
+@Deprecated("Repeatable")
 internal fun IrAnnotationContainer.annotation(
   annotationFqName: FqName,
   scope: FqName? = null

--- a/compiler/src/main/java/com/squareup/anvil/compiler/Utils.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/Utils.kt
@@ -79,7 +79,6 @@ internal const val SUBCOMPONENT_FACTORY = "SubcomponentFactory"
 
 internal const val REFERENCE_SUFFIX = "_reference"
 internal const val SCOPE_SUFFIX = "_scope"
-internal val propertySuffixes = arrayOf(REFERENCE_SUFFIX, SCOPE_SUFFIX)
 
 internal fun FqName.isAnvilModule(): Boolean {
   val name = asString()

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesToGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesToGenerator.kt
@@ -19,7 +19,7 @@ import com.squareup.anvil.compiler.internal.hasAnnotation
 import com.squareup.anvil.compiler.internal.isInterface
 import com.squareup.anvil.compiler.internal.requireFqName
 import com.squareup.anvil.compiler.internal.safePackageString
-import com.squareup.anvil.compiler.internal.scope
+import com.squareup.anvil.compiler.internal.scopes
 import com.squareup.anvil.compiler.mergeModulesFqName
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.KModifier.PUBLIC
@@ -79,7 +79,8 @@ internal class ContributesToGenerator : CodeGenerator {
         val className = clazz.asClassName()
         val classFqName = clazz.requireFqName().toString()
         val propertyName = classFqName.replace('.', '_')
-        val scope = clazz.scope(contributesToFqName, module).asClassName(module)
+        val scopes = clazz.scopes(contributesToFqName, module)
+          .map { it.asClassName(module) }
 
         val content =
           FileSpec.buildFile(generatedPackage, propertyName) {
@@ -94,16 +95,18 @@ internal class ContributesToGenerator : CodeGenerator {
                 .build()
             )
 
-            addProperty(
-              PropertySpec
-                .builder(
-                  name = propertyName + SCOPE_SUFFIX,
-                  type = KClass::class.asClassName().parameterizedBy(scope)
-                )
-                .initializer("%T::class", scope)
-                .addModifiers(PUBLIC)
-                .build()
-            )
+            scopes.forEachIndexed { index, scope ->
+              addProperty(
+                PropertySpec
+                  .builder(
+                    name = propertyName + SCOPE_SUFFIX + index,
+                    type = KClass::class.asClassName().parameterizedBy(scope)
+                  )
+                  .initializer("%T::class", scope)
+                  .addModifiers(PUBLIC)
+                  .build()
+              )
+            }
           }
 
         createGeneratedFile(

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/PsiUtils.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/PsiUtils.kt
@@ -73,6 +73,19 @@ internal fun KtClassOrObject.boundTypeOrNull(
     ?.requireFqName(module)
 }
 
+fun KtAnnotationEntry.replaces(module: ModuleDescriptor): List<FqName> {
+  val index = when (val annotationFqName = requireFqName(module)) {
+    contributesToFqName -> 1
+    contributesBindingFqName, contributesMultibindingFqName -> 2
+    else -> throw IllegalArgumentException("$annotationFqName has no replaces field.")
+  }
+
+  return findAnnotationArgument<KtCollectionLiteralExpression>(name = "replaces", index = index)
+    ?.toFqNames(module)
+    ?: emptyList()
+}
+
+@Deprecated("Repeatable")
 internal fun KtClassOrObject.replaces(
   annotationFqName: FqName,
   module: ModuleDescriptor
@@ -84,8 +97,7 @@ internal fun KtClassOrObject.replaces(
   }
 
   return findAnnotation(annotationFqName, module)
-    ?.findAnnotationArgument<KtCollectionLiteralExpression>(name = "replaces", index = index)
-    ?.toFqNames(module)
+    ?.replaces(module)
     ?: emptyList()
 }
 

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/RealAnvilModuleDescriptor.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/RealAnvilModuleDescriptor.kt
@@ -1,6 +1,7 @@
 package com.squareup.anvil.compiler.codegen
 
 import com.squareup.anvil.compiler.internal.AnvilModuleDescriptor
+import com.squareup.anvil.compiler.internal.takeIfNotEmpty
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 import org.jetbrains.kotlin.descriptors.findTypeAliasAcrossModuleDependencies
 import org.jetbrains.kotlin.descriptors.resolveClassByFqName
@@ -66,6 +67,6 @@ private fun KtFile.classesAndInnerClasses(): List<KtClassOrObject> {
       .flatMap {
         it.declarations.filterIsInstance<KtClassOrObject>()
       }
-      .ifEmpty { null }
+      .takeIfNotEmpty()
   }.flatten().toList()
 }

--- a/compiler/src/test/java/com/squareup/anvil/compiler/InterfaceMergerTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/InterfaceMergerTest.kt
@@ -4,8 +4,9 @@ import com.google.common.truth.Truth.assertThat
 import com.squareup.anvil.annotations.MergeComponent
 import com.squareup.anvil.annotations.MergeSubcomponent
 import com.squareup.anvil.annotations.compat.MergeInterfaces
+import com.squareup.anvil.compiler.internal.testing.AnvilCompilation
 import com.squareup.anvil.compiler.internal.testing.extends
-import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.INTERNAL_ERROR
+import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.OK
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
@@ -209,6 +210,7 @@ class InterfaceMergerTest(
       $import
       
       @ContributesTo(Unit::class)
+      @ContributesTo(Int::class)
       interface ContributingInterface
       
       @ContributesTo(
@@ -224,11 +226,11 @@ class InterfaceMergerTest(
       assertThat(exitCode).isError()
       // Position to the class. Unfortunately, a different error is reported that the class is
       // missing an @Module annotation.
-      assertThat(messages).contains("Source0.kt: (13, 11)")
+      assertThat(messages).contains("Source0.kt: (14, 11)")
       assertThat(messages).contains(
         "com.squareup.test.SecondContributingInterface with scope kotlin.Any wants to replace " +
-          "com.squareup.test.ContributingInterface with scope kotlin.Unit. The replacement " +
-          "must use the same scope."
+          "com.squareup.test.ContributingInterface, but the replaced class isn't contributed " +
+          "to the same scope."
       )
     }
   }
@@ -315,8 +317,8 @@ class InterfaceMergerTest(
       assertThat(messages).contains("Source0.kt: (18, 11)")
       assertThat(messages).contains(
         "com.squareup.test.ComponentInterface with scope kotlin.Any wants to exclude " +
-          "com.squareup.test.ContributingInterface with scope kotlin.Unit. The exclusion " +
-          "must use the same scope."
+          "com.squareup.test.ContributingInterface, but the excluded class isn't contributed " +
+          "to the same scope."
       )
     }
   }
@@ -485,11 +487,10 @@ class InterfaceMergerTest(
       }
       """
     ) {
-      assertThat(exitCode).isEqualTo(INTERNAL_ERROR)
-      // Position to the class.
+      assertThat(exitCode).isError()
       assertThat(messages).contains(
-        "org.jetbrains.kotlin.util.KotlinFrontEndException: " +
-          "Exception while analyzing expression at (8,18)"
+        "It seems like you tried to contribute an inner class to its outer class. This is " +
+          "not supported and results in a compiler error."
       )
     }
   }
@@ -511,11 +512,10 @@ class InterfaceMergerTest(
       }
       """
     ) {
-      assertThat(exitCode).isEqualTo(INTERNAL_ERROR)
-      // Position to the class.
+      assertThat(exitCode).isError()
       assertThat(messages).contains(
-        "org.jetbrains.kotlin.util.KotlinFrontEndException: " +
-          "Exception while analyzing expression at (6,4"
+        "It seems like you tried to contribute an inner class to its outer class. This is " +
+          "not supported and results in a compiler error."
       )
     }
   }
@@ -616,6 +616,228 @@ class InterfaceMergerTest(
 
       assertThat(componentInterface extends contributingInterface).isTrue()
       assertThat(componentInterface extends secondContributingInterface).isTrue()
+    }
+  }
+
+  @Test fun `interfaces contributed to multiple scopes are merged successfully`() {
+    assumeKotlin16()
+    assumeIrBackend()
+
+    compile(
+      """
+      package com.squareup.test
+      
+      import com.squareup.anvil.annotations.ContributesTo
+      $import
+      
+      @ContributesTo(Any::class)
+      @ContributesTo(Unit::class)
+      interface ContributingInterface
+      
+      @ContributesTo(Any::class)
+      interface SecondContributingInterface
+      
+      $annotation(Any::class)
+      interface ComponentInterface
+      
+      $annotation(Unit::class)
+      interface SubcomponentInterface
+      """
+    ) {
+      assertThat(componentInterface extends contributingInterface).isTrue()
+      assertThat(componentInterface extends secondContributingInterface).isTrue()
+      assertThat(subcomponentInterface extends contributingInterface).isTrue()
+      assertThat(subcomponentInterface extends secondContributingInterface).isFalse()
+    }
+  }
+
+  @Test
+  fun `interfaces contributed to multiple scopes are merged successfully with multiple compilations`() {
+    assumeKotlin16()
+    assumeIrBackend()
+
+    val firstResult = compile(
+      """
+      package com.squareup.test
+      
+      import com.squareup.anvil.annotations.ContributesTo
+
+      @ContributesTo(Any::class)
+      @ContributesTo(Unit::class)
+      interface ContributingInterface
+      """
+    ) {
+      assertThat(exitCode).isEqualTo(OK)
+    }
+
+    compile(
+      """
+      package com.squareup.test
+      
+      import com.squareup.anvil.annotations.ContributesTo
+      $import
+      
+      @ContributesTo(Any::class)
+      interface SecondContributingInterface
+      
+      $annotation(Any::class)
+      interface ComponentInterface
+      
+      $annotation(Unit::class)
+      interface SubcomponentInterface
+      """,
+      previousCompilationResult = firstResult
+    ) {
+      assertThat(componentInterface extends contributingInterface).isTrue()
+      assertThat(componentInterface extends secondContributingInterface).isTrue()
+      assertThat(subcomponentInterface extends contributingInterface).isTrue()
+      assertThat(subcomponentInterface extends secondContributingInterface).isFalse()
+    }
+  }
+
+  @Test fun `interfaces contributed to multiple scopes can be replaced`() {
+    assumeKotlin16()
+    assumeIrBackend()
+
+    compile(
+      """
+      package com.squareup.test
+      
+      import com.squareup.anvil.annotations.ContributesTo
+      $import
+      
+      @ContributesTo(Any::class)
+      @ContributesTo(Unit::class)
+      interface ContributingInterface
+      
+      @ContributesTo(Any::class, replaces = [ContributingInterface::class])
+      interface SecondContributingInterface
+      
+      $annotation(Any::class)
+      interface ComponentInterface
+      
+      $annotation(Unit::class)
+      interface SubcomponentInterface
+      """
+    ) {
+      assertThat(componentInterface extends contributingInterface).isFalse()
+      assertThat(componentInterface extends secondContributingInterface).isTrue()
+      assertThat(subcomponentInterface extends contributingInterface).isTrue()
+      assertThat(subcomponentInterface extends secondContributingInterface).isFalse()
+    }
+  }
+
+  @Test
+  fun `replaced interfaces contributed to multiple scopes must use the same scope`() {
+    assumeKotlin16()
+    assumeIrBackend()
+
+    compile(
+      """
+      package com.squareup.test
+      
+      import com.squareup.anvil.annotations.ContributesTo
+      $import
+      
+      @ContributesTo(Any::class)
+      @ContributesTo(Unit::class)
+      interface ContributingInterface
+      
+      @ContributesTo(Int::class, replaces = [ContributingInterface::class])
+      interface SecondContributingInterface
+      
+      $annotation(Any::class)
+      interface ComponentInterface
+      
+      $annotation(Unit::class)
+      interface SubcomponentInterface1
+      
+      $annotation(Int::class)
+      interface SubcomponentInterface2
+      """
+    ) {
+      assertThat(exitCode).isError()
+      assertThat(messages).contains(
+        "com.squareup.test.SecondContributingInterface with scope kotlin.Int wants to " +
+          "replace com.squareup.test.ContributingInterface, but the replaced class isn't " +
+          "contributed to the same scope."
+      )
+    }
+  }
+
+  @Test fun `interfaces contributed to multiple scopes can be excluded in one scope`() {
+    assumeKotlin16()
+    assumeIrBackend()
+
+    compile(
+      """
+      package com.squareup.test
+      
+      import com.squareup.anvil.annotations.ContributesTo
+      $import
+      
+      @ContributesTo(Any::class)
+      @ContributesTo(Unit::class)
+      interface ContributingInterface
+      
+      @ContributesTo(Any::class)
+      interface SecondContributingInterface
+      
+      $annotation(Any::class, exclude = [ContributingInterface::class])
+      interface ComponentInterface
+      
+      $annotation(Unit::class)
+      interface SubcomponentInterface
+      """
+    ) {
+      assertThat(componentInterface extends contributingInterface).isFalse()
+      assertThat(componentInterface extends secondContributingInterface).isTrue()
+      assertThat(subcomponentInterface extends contributingInterface).isTrue()
+      assertThat(subcomponentInterface extends secondContributingInterface).isFalse()
+    }
+  }
+
+  @Test fun `contributed interfaces in the old format are picked up`() {
+    val result = AnvilCompilation()
+      .useIR(USE_IR)
+      .enableAnvil(false)
+      .compile(
+        """
+        package com.squareup.test
+      
+        import com.squareup.anvil.annotations.ContributesTo
+        $import
+        
+        @ContributesTo(Any::class)
+        interface ContributingInterface  
+        """,
+        """
+        package anvil.hint.merge.com.squareup.test
+
+        import com.squareup.test.ContributingInterface
+        import kotlin.reflect.KClass
+        
+        public val com_squareup_test_ContributingInterface_reference: KClass<ContributingInterface> = ContributingInterface::class
+        
+        // Note that the number is missing after the scope. 
+        public val com_squareup_test_ContributingInterface_scope: KClass<Any> = Any::class
+        """.trimIndent()
+      ) {
+        assertThat(exitCode).isEqualTo(OK)
+      }
+
+    compile(
+      """
+      package com.squareup.test
+      
+      $import
+      
+      $annotation(Any::class)
+      interface ComponentInterface
+      """,
+      previousCompilationResult = result
+    ) {
+      assertThat(componentInterface extends contributingInterface).isTrue()
     }
   }
 }

--- a/compiler/src/test/java/com/squareup/anvil/compiler/ModuleMergerTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/ModuleMergerTest.kt
@@ -3,12 +3,14 @@ package com.squareup.anvil.compiler
 import com.google.common.truth.Truth.assertThat
 import com.squareup.anvil.annotations.MergeComponent
 import com.squareup.anvil.annotations.MergeSubcomponent
+import com.squareup.anvil.compiler.internal.testing.AnvilCompilation
 import com.squareup.anvil.compiler.internal.testing.AnyDaggerComponent
 import com.squareup.anvil.compiler.internal.testing.anyDaggerComponent
 import com.squareup.anvil.compiler.internal.testing.daggerComponent
 import com.squareup.anvil.compiler.internal.testing.daggerModule
 import com.squareup.anvil.compiler.internal.testing.daggerSubcomponent
 import com.squareup.anvil.compiler.internal.testing.withoutAnvilModule
+import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.OK
 import dagger.Component
 import dagger.Subcomponent
 import org.junit.Test
@@ -122,7 +124,6 @@ class ModuleMergerTest(
       """
     ) {
       assertThat(exitCode).isError()
-      // Position to the class.
       assertThat(messages).contains("Source0.kt: (7, 11)")
     }
   }
@@ -213,7 +214,6 @@ class ModuleMergerTest(
       """
     ) {
       assertThat(exitCode).isError()
-      // Position to the class.
       assertThat(messages).contains("Source0.kt: (7, 16)")
     }
   }
@@ -336,12 +336,11 @@ class ModuleMergerTest(
       """
     ) {
       assertThat(exitCode).isError()
-      // Position to the class.
       assertThat(messages).contains("Source0.kt: (17, 16)")
       assertThat(messages).contains(
         "com.squareup.test.DaggerModule1 with scope kotlin.Any wants to replace " +
-          "com.squareup.test.ContributingInterface with scope kotlin.Unit. The replacement " +
-          "must use the same scope."
+          "com.squareup.test.ContributingInterface, but the replaced class isn't contributed " +
+          "to the same scope."
       )
     }
   }
@@ -372,12 +371,11 @@ class ModuleMergerTest(
       """
     ) {
       assertThat(exitCode).isError()
-      // Position to the class.
       assertThat(messages).contains("Source0.kt: (17, 16)")
       assertThat(messages).contains(
         "com.squareup.test.DaggerModule1 with scope kotlin.Any wants to replace " +
-          "com.squareup.test.ContributingInterface with scope kotlin.Unit. The replacement " +
-          "must use the same scope."
+          "com.squareup.test.ContributingInterface, but the replaced class isn't contributed " +
+          "to the same scope."
       )
     }
   }
@@ -468,12 +466,11 @@ class ModuleMergerTest(
       """
     ) {
       assertThat(exitCode).isError()
-      // Position to the class.
       assertThat(messages).contains("Source0.kt: (17, 11)")
       assertThat(messages).contains(
         "com.squareup.test.ContributingInterface with scope kotlin.Any wants to replace " +
-          "com.squareup.test.DaggerModule1 with scope kotlin.Unit. The replacement must use " +
-          "the same scope."
+          "com.squareup.test.DaggerModule1, but the replaced class isn't contributed " +
+          "to the same scope."
       )
     }
   }
@@ -504,12 +501,11 @@ class ModuleMergerTest(
       """
     ) {
       assertThat(exitCode).isError()
-      // Position to the class.
       assertThat(messages).contains("Source0.kt: (17, 11)")
       assertThat(messages).contains(
         "com.squareup.test.ContributingInterface with scope kotlin.Any wants to replace " +
-          "com.squareup.test.DaggerModule1 with scope kotlin.Unit. The replacement must use " +
-          "the same scope."
+          "com.squareup.test.DaggerModule1, but the replaced class isn't contributed " +
+          "to the same scope."
       )
     }
   }
@@ -536,7 +532,6 @@ class ModuleMergerTest(
       """
     ) {
       assertThat(exitCode).isError()
-      // Position to the class.
       assertThat(messages).contains("Source0.kt: (13, 16)")
     }
   }
@@ -565,12 +560,11 @@ class ModuleMergerTest(
       """
     ) {
       assertThat(exitCode).isError()
-      // Position to the class.
       assertThat(messages).contains("Source0.kt: (15, 16)")
       assertThat(messages).contains(
         "com.squareup.test.DaggerModule2 with scope kotlin.Any wants to replace " +
-          "com.squareup.test.DaggerModule1 with scope kotlin.Unit. The replacement must " +
-          "use the same scope."
+          "com.squareup.test.DaggerModule1, but the replaced class isn't contributed " +
+          "to the same scope."
       )
     }
   }
@@ -665,12 +659,11 @@ class ModuleMergerTest(
       """
     ) {
       assertThat(exitCode).isError()
-      // Position to the class.
       assertThat(messages).contains("Source0.kt: (20, 11)")
       assertThat(messages).contains(
         "com.squareup.test.ComponentInterface with scope kotlin.Any wants to exclude " +
-          "com.squareup.test.DaggerModule1 with scope kotlin.Unit. The exclusion must use " +
-          "the same scope."
+          "com.squareup.test.DaggerModule1, but the excluded class isn't contributed " +
+          "to the same scope."
       )
     }
   }
@@ -815,12 +808,11 @@ class ModuleMergerTest(
       """
     ) {
       assertThat(exitCode).isError()
-      // Position to the class.
       assertThat(messages).contains("Source0.kt: (17, 11)")
       assertThat(messages).contains(
         "com.squareup.test.ComponentInterface with scope kotlin.Any wants to exclude " +
-          "com.squareup.test.ContributingInterface with scope kotlin.Unit. The exclusion " +
-          "must use the same scope."
+          "com.squareup.test.ContributingInterface, but the excluded class isn't contributed " +
+          "to the same scope."
       )
     }
   }
@@ -848,12 +840,11 @@ class ModuleMergerTest(
       """
     ) {
       assertThat(exitCode).isError()
-      // Position to the class.
       assertThat(messages).contains("Source0.kt: (17, 11)")
       assertThat(messages).contains(
         "com.squareup.test.ComponentInterface with scope kotlin.Any wants to exclude " +
-          "com.squareup.test.ContributingInterface with scope kotlin.Unit. The exclusion " +
-          "must use the same scope."
+          "com.squareup.test.ContributingInterface, but the excluded class isn't contributed " +
+          "to the same scope."
       )
     }
   }
@@ -945,7 +936,6 @@ class ModuleMergerTest(
         """
       ) {
         assertThat(exitCode).isError()
-        // Position to the class.
         assertThat(messages).contains("Source0.kt: (8, ")
       }
     }
@@ -974,7 +964,8 @@ class ModuleMergerTest(
     }
   }
 
-  @Test fun `inner modules in a merged component fail`() {
+  @Test fun `inner modules in a merged component can be merged`() {
+    // This test used to fail in the past.
     compile(
       """
       package com.squareup.test
@@ -990,8 +981,8 @@ class ModuleMergerTest(
       }
       """
     ) {
-      assertThat(exitCode).isError()
-      assertThat(messages).contains("File being compiled: (10,18)")
+      assertThat(componentInterface.anyDaggerComponent.modules.withoutAnvilModule())
+        .containsExactly(innerModule.kotlin)
     }
   }
 
@@ -1116,6 +1107,244 @@ class ModuleMergerTest(
 
       val component = componentInterface.anyDaggerComponent
       assertThat(component.modules.withoutAnvilModule()).containsExactly(daggerModule1.kotlin)
+    }
+  }
+
+  @Test fun `modules contributed to multiple scopes are merged`() {
+    assumeKotlin16()
+    assumeIrBackend()
+
+    compile(
+      """
+      package com.squareup.test
+      
+      import com.squareup.anvil.annotations.ContributesTo
+      $import
+      
+      @ContributesTo(Any::class)
+      @ContributesTo(Unit::class)
+      @dagger.Module
+      abstract class DaggerModule1
+      
+      @ContributesTo(Any::class)
+      @dagger.Module
+      abstract class DaggerModule2
+      
+      $annotation(Any::class)
+      interface ComponentInterface
+      
+      $annotation(Unit::class)
+      interface SubcomponentInterface
+      """
+    ) {
+      assertThat(componentInterface.anyDaggerComponent.modules.withoutAnvilModule())
+        .containsExactly(daggerModule1.kotlin, daggerModule2.kotlin)
+
+      assertThat(subcomponentInterface.anyDaggerComponent.modules.withoutAnvilModule())
+        .containsExactly(daggerModule1.kotlin)
+    }
+  }
+
+  @Test fun `modules contributed to multiple scopes are merged with multiple compilations`() {
+    assumeKotlin16()
+    assumeIrBackend()
+
+    val firstResult = compile(
+      """
+      package com.squareup.test
+      
+      import com.squareup.anvil.annotations.ContributesTo
+      import dagger.Module
+        
+      @ContributesTo(Any::class)
+      @ContributesTo(Unit::class)
+      @Module
+      abstract class DaggerModule1
+      """
+    ) {
+      assertThat(exitCode).isEqualTo(OK)
+    }
+
+    compile(
+      """
+      package com.squareup.test
+      
+      import com.squareup.anvil.annotations.ContributesTo
+      $import
+      
+      @ContributesTo(Any::class)
+      @dagger.Module
+      abstract class DaggerModule2
+      
+      $annotation(Any::class)
+      interface ComponentInterface
+      
+      $annotation(Unit::class)
+      interface SubcomponentInterface
+      """,
+      previousCompilationResult = firstResult
+    ) {
+      assertThat(componentInterface.anyDaggerComponent.modules.withoutAnvilModule())
+        .containsExactly(daggerModule1.kotlin, daggerModule2.kotlin)
+
+      assertThat(subcomponentInterface.anyDaggerComponent.modules.withoutAnvilModule())
+        .containsExactly(daggerModule1.kotlin)
+    }
+  }
+
+  @Test fun `modules contributed to multiple scopes can be replaced`() {
+    assumeKotlin16()
+    assumeIrBackend()
+
+    compile(
+      """
+      package com.squareup.test
+      
+      import com.squareup.anvil.annotations.ContributesTo
+      $import
+      
+      @ContributesTo(Any::class)
+      @ContributesTo(Unit::class)
+      @dagger.Module
+      abstract class DaggerModule1
+      
+      @ContributesTo(Any::class, replaces = [DaggerModule1::class])
+      @dagger.Module
+      abstract class DaggerModule2
+      
+      $annotation(Any::class)
+      interface ComponentInterface
+      
+      $annotation(Unit::class)
+      interface SubcomponentInterface
+      """
+    ) {
+      assertThat(componentInterface.anyDaggerComponent.modules.withoutAnvilModule())
+        .containsExactly(daggerModule2.kotlin)
+
+      assertThat(subcomponentInterface.anyDaggerComponent.modules.withoutAnvilModule())
+        .containsExactly(daggerModule1.kotlin)
+    }
+  }
+
+  @Test
+  fun `replaced module contributed to multiple scopes must use the same scope`() {
+    assumeKotlin16()
+    assumeIrBackend()
+
+    compile(
+      """
+      package com.squareup.test
+      
+      import com.squareup.anvil.annotations.ContributesTo
+      $import
+      
+      @ContributesTo(Any::class)
+      @ContributesTo(Unit::class)
+      @dagger.Module
+      abstract class DaggerModule1
+      
+      @ContributesTo(Int::class, replaces = [DaggerModule1::class])
+      @dagger.Module
+      abstract class DaggerModule2
+      
+      $annotation(Any::class)
+      interface ComponentInterface
+      
+      $annotation(Unit::class)
+      interface SubcomponentInterface1
+      
+      $annotation(Int::class)
+      interface SubcomponentInterface2
+      """
+    ) {
+      assertThat(exitCode).isError()
+      assertThat(messages).contains(
+        "com.squareup.test.DaggerModule2 with scope kotlin.Int wants to replace " +
+          "com.squareup.test.DaggerModule1, but the replaced class isn't contributed to the " +
+          "same scope."
+      )
+    }
+  }
+
+  @Test fun `modules contributed to multiple scopes can be excluded in one scope`() {
+    assumeKotlin16()
+    assumeIrBackend()
+
+    compile(
+      """
+      package com.squareup.test
+      
+      import com.squareup.anvil.annotations.ContributesTo
+      $import
+      
+      @ContributesTo(Any::class)
+      @ContributesTo(Unit::class)
+      @dagger.Module
+      abstract class DaggerModule1
+      
+      @ContributesTo(Any::class)
+      @dagger.Module
+      abstract class DaggerModule2
+      
+      $annotation(Any::class, exclude = [DaggerModule1::class])
+      interface ComponentInterface
+      
+      $annotation(Unit::class)
+      interface SubcomponentInterface
+      """
+    ) {
+      assertThat(componentInterface.anyDaggerComponent.modules.withoutAnvilModule())
+        .containsExactly(daggerModule2.kotlin)
+
+      assertThat(subcomponentInterface.anyDaggerComponent.modules.withoutAnvilModule())
+        .containsExactly(daggerModule1.kotlin)
+    }
+  }
+
+  @Test fun `contributed modules in the old format are picked up`() {
+    val result = AnvilCompilation()
+      .useIR(USE_IR)
+      .enableAnvil(false)
+      .compile(
+        """
+        package com.squareup.test
+      
+        import com.squareup.anvil.annotations.ContributesTo
+        import dagger.Module
+        
+        @ContributesTo(Any::class)
+        @Module
+        abstract class DaggerModule1  
+        """,
+        """
+        package anvil.hint.merge.com.squareup.test
+
+        import com.squareup.test.DaggerModule1
+        import kotlin.reflect.KClass
+        
+        public val com_squareup_test_DaggerModule1_reference: KClass<DaggerModule1> = DaggerModule1::class
+        
+        // Note that the number is missing after the scope. 
+        public val com_squareup_test_DaggerModule1_scope: KClass<Any> = Any::class
+        """.trimIndent()
+      ) {
+        assertThat(exitCode).isEqualTo(OK)
+      }
+
+    compile(
+      """
+      package com.squareup.test
+      
+      $import
+      
+      $annotation(Any::class)
+      interface ComponentInterface
+      """,
+      previousCompilationResult = result
+    ) {
+      assertThat(componentInterface.anyDaggerComponent.modules.withoutAnvilModule())
+        .containsExactly(daggerModule1.kotlin)
     }
   }
 

--- a/compiler/src/test/java/com/squareup/anvil/compiler/TestUtils.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/TestUtils.kt
@@ -7,12 +7,13 @@ import com.squareup.anvil.compiler.internal.capitalize
 import com.squareup.anvil.compiler.internal.testing.compileAnvil
 import com.squareup.anvil.compiler.internal.testing.generatedClassesString
 import com.squareup.anvil.compiler.internal.testing.packageName
+import com.squareup.anvil.compiler.internal.testing.use
 import com.tschuchort.compiletesting.KotlinCompilation.ExitCode
 import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.COMPILATION_ERROR
 import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.INTERNAL_ERROR
 import com.tschuchort.compiletesting.KotlinCompilation.Result
 import org.intellij.lang.annotations.Language
-import org.junit.Assume
+import org.junit.Assume.assumeTrue
 import kotlin.reflect.KClass
 
 internal fun compile(
@@ -85,25 +86,38 @@ internal val Class<*>.hintContributes: KClass<*>?
   get() = getHint(HINT_CONTRIBUTES_PACKAGE_PREFIX)
 
 internal val Class<*>.hintContributesScope: KClass<*>?
-  get() = getHintScope(HINT_CONTRIBUTES_PACKAGE_PREFIX)
+  get() = hintContributesScopes.takeIf { it.isNotEmpty() }?.single()
+
+internal val Class<*>.hintContributesScopes: List<KClass<*>>
+  get() = getHintScopes(HINT_CONTRIBUTES_PACKAGE_PREFIX)
 
 internal val Class<*>.hintBinding: KClass<*>?
   get() = getHint(HINT_BINDING_PACKAGE_PREFIX)
 
 internal val Class<*>.hintBindingScope: KClass<*>?
-  get() = getHintScope(HINT_BINDING_PACKAGE_PREFIX)
+  get() = hintBindingScopes.takeIf { it.isNotEmpty() }?.single()
+
+internal val Class<*>.hintBindingScopes: List<KClass<*>>
+  get() = getHintScopes(HINT_BINDING_PACKAGE_PREFIX)
 
 internal val Class<*>.hintMultibinding: KClass<*>?
   get() = getHint(HINT_MULTIBINDING_PACKAGE_PREFIX)
 
 internal val Class<*>.hintMultibindingScope: KClass<*>?
-  get() = getHintScope(HINT_MULTIBINDING_PACKAGE_PREFIX)
+  get() = hintMultibindingScopes.takeIf { it.isNotEmpty() }?.single()
+
+internal val Class<*>.hintMultibindingScopes: List<KClass<*>>
+  get() = getHintScopes(HINT_MULTIBINDING_PACKAGE_PREFIX)
 
 internal val Class<*>.hintSubcomponent: KClass<*>?
   get() = getHint(HINT_SUBCOMPONENTS_PACKAGE_PREFIX)
 
 internal val Class<*>.hintSubcomponentParentScope: KClass<*>?
-  get() = getHintScope(HINT_SUBCOMPONENTS_PACKAGE_PREFIX)
+  get() = hintSubcomponentParentScopes.takeIf { it.isNotEmpty() }?.single()
+
+// TODO Repeatable: Check if this is needed.
+internal val Class<*>.hintSubcomponentParentScopes: List<KClass<*>>
+  get() = getHintScopes(HINT_SUBCOMPONENTS_PACKAGE_PREFIX)
 
 internal val Class<*>.anvilModule: Class<*>
   get() = classLoader.loadClass(
@@ -115,12 +129,11 @@ private fun Class<*>.getHint(prefix: String): KClass<*>? = contributedProperties
   ?.also { assertThat(it.size).isEqualTo(1) }
   ?.first()
 
-private fun Class<*>.getHintScope(prefix: String): KClass<*>? =
+private fun Class<*>.getHintScopes(prefix: String): List<KClass<*>> =
   contributedProperties(prefix)
-    ?.also { assertThat(it.size).isEqualTo(2) }
+    ?.also { assertThat(it.size).isAtLeast(2) }
     ?.filter { it.java != this }
-    ?.also { assertThat(it.size).isEqualTo(1) }
-    ?.first()
+    ?: emptyList()
 
 private fun Class<*>.contributedProperties(packagePrefix: String): List<KClass<*>>? {
   // The capitalize() doesn't make sense, I don't know where this is coming from. Maybe it's a
@@ -135,15 +148,20 @@ private fun Class<*>.contributedProperties(packagePrefix: String): List<KClass<*
   }
 
   return clazz.declaredFields
-    .map {
-      it.isAccessible = true
-      it.get(null)
-    }
+    .map { field -> field.use { it.get(null) } }
     .filterIsInstance<KClass<*>>()
 }
 
 internal fun assumeMergeComponent(annotationClass: KClass<*>) {
-  Assume.assumeTrue(annotationClass == MergeComponent::class)
+  assumeTrue(annotationClass == MergeComponent::class)
+}
+
+internal fun assumeKotlin16() {
+  assumeTrue(KotlinVersion.CURRENT.isAtLeast(1, 6))
+}
+
+internal fun assumeIrBackend() {
+  assumeTrue(USE_IR)
 }
 
 internal fun ComparableSubject<ExitCode>.isError() {

--- a/compiler/src/test/java/com/squareup/anvil/compiler/codegen/ContributesSubcomponentHandlerGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/codegen/ContributesSubcomponentHandlerGeneratorTest.kt
@@ -801,8 +801,8 @@ class ContributesSubcomponentHandlerGeneratorTest {
       assertThat(exitCode).isError()
       assertThat(messages).contains(
         "com.squareup.test.ComponentInterface with scope kotlin.Any wants to exclude " +
-          "com.squareup.test.SubcomponentInterface with scope kotlin.Int. The exclusion " +
-          "must use the same scope."
+          "com.squareup.test.SubcomponentInterface, but the excluded class isn't contributed " +
+          "to the same scope."
       )
     }
   }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -20,7 +20,8 @@ ext {
       project.getProperty('square.generateDaggerFactoriesWithAnvil') : 'true').toBoolean()
 
   // TODO: Remove when we remove the old backend.
-  makeWarningsErrors = ci && (kotlinVersion.startsWith('1.5') || kotlinUseIR)
+  // TODO Repeatable: After cleaning up all deprecated methods remove the `&& false`.
+  makeWarningsErrors = ci && (kotlinVersion.startsWith('1.5') || kotlinUseIR) && false
 
   ktlintVersion = "0.41.0"
 

--- a/integration-tests/library/build.gradle
+++ b/integration-tests/library/build.gradle
@@ -20,3 +20,9 @@ kotlin {
 dependencies {
   api deps.dagger2.dagger
 }
+
+// TODO: remove with Kotlin 1.6.
+if (rootProject.ext.kotlinVersion.startsWith("1.6")) {
+  sourceSets.main.java.srcDirs += ['src/main/kotlin-1-6']
+}
+

--- a/integration-tests/library/src/main/kotlin-1-6/com/squareup/anvil/test/RepeateableContributions.kt
+++ b/integration-tests/library/src/main/kotlin-1-6/com/squareup/anvil/test/RepeateableContributions.kt
@@ -1,0 +1,21 @@
+package com.squareup.anvil.test
+
+import com.squareup.anvil.annotations.ContributesTo
+import dagger.Module
+import dagger.Provides
+
+public abstract class RepeatedScope1 private constructor()
+public abstract class RepeatedScope2 private constructor()
+
+@ContributesTo(RepeatedScope1::class)
+@ContributesTo(RepeatedScope2::class)
+public interface RepeatedInterface {
+  public fun string(): String
+}
+
+@ContributesTo(RepeatedScope1::class)
+@ContributesTo(RepeatedScope2::class)
+@Module
+public object RepeatedModule {
+  @Provides public fun provideString(): String = "Hello"
+}

--- a/integration-tests/tests/build.gradle
+++ b/integration-tests/tests/build.gradle
@@ -41,3 +41,8 @@ gradle.taskGraph.afterTask { Task task ->
     }
   }
 }
+
+// TODO: remove with Kotlin 1.6.
+if (rootProject.ext.kotlinVersion.startsWith("1.6")) {
+  sourceSets.test.java.srcDirs += ['src/test/kotlin-1-6']
+}

--- a/integration-tests/tests/src/test/kotlin-1-6/com/squareup/anvil/test/RepeatedContributionsTest.kt
+++ b/integration-tests/tests/src/test/kotlin-1-6/com/squareup/anvil/test/RepeatedContributionsTest.kt
@@ -1,0 +1,63 @@
+package com.squareup.anvil.test
+
+import com.google.common.truth.Truth.assertThat
+import com.squareup.anvil.annotations.ContributesTo
+import com.squareup.anvil.annotations.MergeComponent
+import com.squareup.anvil.annotations.MergeSubcomponent
+import com.squareup.anvil.compiler.internal.testing.extends
+import com.squareup.anvil.compiler.internal.testing.withoutAnvilModule
+import dagger.Component
+import dagger.Module
+import dagger.Provides
+import dagger.Subcomponent
+import org.junit.Test
+
+class RepeatedContributionsTest {
+
+  @Test fun `repeated contributions are merged properly`() {
+    val componentAnnotation = RepeatedComponent1::class.java
+      .getAnnotation(Component::class.java)!!
+    assertThat(componentAnnotation.modules.withoutAnvilModule())
+      .containsExactly(RepeatedModule::class, RepeatedModuleInt::class)
+
+    assertThat(RepeatedComponent1::class extends RepeatedInterface::class).isTrue()
+    assertThat(RepeatedComponent1::class extends RepeatedInterfaceInt::class).isTrue()
+
+    val component = DaggerRepeatedContributionsTest_RepeatedComponent1.create()
+    assertThat((component as RepeatedInterface).string()).isEqualTo("Hello")
+    assertThat((component as RepeatedInterfaceInt).integer()).isEqualTo(5)
+
+    val subcomponentAnnotation = RepeatedComponent2::class.java
+      .getAnnotation(Subcomponent::class.java)!!
+    assertThat(subcomponentAnnotation.modules.withoutAnvilModule())
+      .containsExactly(RepeatedModule::class, RepeatedModuleInt::class)
+
+    assertThat(RepeatedComponent2::class extends RepeatedInterface::class).isTrue()
+    assertThat(RepeatedComponent2::class extends RepeatedInterfaceInt::class).isTrue()
+
+    val subcomponent = component.subcomponent()
+    assertThat((subcomponent as RepeatedInterface).string()).isEqualTo("Hello")
+    assertThat((subcomponent as RepeatedInterfaceInt).integer()).isEqualTo(5)
+  }
+
+  @MergeComponent(RepeatedScope1::class)
+  interface RepeatedComponent1 {
+    fun subcomponent(): RepeatedComponent2
+  }
+
+  @MergeSubcomponent(RepeatedScope2::class)
+  interface RepeatedComponent2
+
+  @ContributesTo(RepeatedScope1::class)
+  @ContributesTo(RepeatedScope2::class)
+  interface RepeatedInterfaceInt {
+    fun integer(): Int
+  }
+
+  @ContributesTo(RepeatedScope1::class)
+  @ContributesTo(RepeatedScope2::class)
+  @Module
+  object RepeatedModuleInt {
+    @Provides fun provideInteger(): Int = 5
+  }
+}


### PR DESCRIPTION
While you now can have multiple `@ContributesTo` annotations for Dagger modules and component interfaces, they all must have a different scope (contributing to the same scope twice is redundant).

This is a significant change and many of the internals of Anvil have to be updated.

There was a bug in Kotlin `1.6.0` [KT-49651](https://youtrack.jetbrains.com/issue/KT-49651) that has been fixed in `1.6.10`. I was able to remove the workarounds again. 

I apologize for the size of the PR, but there was simply no way to break this down. In fact, I had separate commits initially, but decided to squash them, because several tests were broken with the intermediate commits. I suggest looking for weird Kotlin idioms and looking at the tests. 

I don't plan to merge this PR soon. Probably next year when I'll try to make the other annotations repeatable as well. 