### PR TITLE
Manually bind the generated Dagger factory for contribute subcomponents

### DIFF
--- a/compiler/src/main/java/com/squareup/anvil/compiler/ClassScannerIr.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/ClassScannerIr.kt
@@ -15,7 +15,7 @@ internal fun ClassScanner.findContributedClasses(
   moduleFragment: IrModuleFragment,
   packageName: String,
   annotation: FqName,
-  scope: FqName
+  scope: FqName?
 ): Sequence<IrClassSymbol> {
   return findContributedClasses(moduleFragment.descriptor, packageName, annotation, scope)
     .map {

--- a/compiler/src/main/java/com/squareup/anvil/compiler/IrUtils.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/IrUtils.kt
@@ -17,9 +17,11 @@ import org.jetbrains.kotlin.ir.types.IrType
 import org.jetbrains.kotlin.ir.types.classifierOrNull
 import org.jetbrains.kotlin.ir.types.getClass
 import org.jetbrains.kotlin.ir.types.typeOrNull
+import org.jetbrains.kotlin.ir.util.classId
 import org.jetbrains.kotlin.ir.util.fqNameWhenAvailable
 import org.jetbrains.kotlin.ir.util.getAnnotation
 import org.jetbrains.kotlin.ir.util.getArgumentsWithIr
+import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.FqName
 
 internal fun IrPluginContext.requireReferenceClass(fqName: FqName): IrClassSymbol {
@@ -27,6 +29,21 @@ internal fun IrPluginContext.requireReferenceClass(fqName: FqName): IrClassSymbo
     message = "Couldn't resolve reference for $fqName"
   )
 }
+
+internal fun ClassId.irClass(context: IrPluginContext): IrClassSymbol =
+  context.requireReferenceClass(asSingleFqName())
+
+internal fun ClassId.irClassOrNull(context: IrPluginContext): IrClassSymbol? =
+  context.referenceClass(asSingleFqName())
+
+internal fun IrClass.requireClassId(): ClassId {
+  return classId ?: throw AnvilCompilationException(
+    element = this,
+    message = "Couldn't find a ClassId for $fqName."
+  )
+}
+
+internal fun IrClassSymbol.requireClassId(): ClassId = owner.requireClassId()
 
 internal fun IrAnnotationContainer.annotationOrNull(
   annotationFqName: FqName,

--- a/compiler/src/main/java/com/squareup/anvil/compiler/Utils.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/Utils.kt
@@ -76,6 +76,7 @@ internal const val ANVIL_MODULE_SUFFIX = "AnvilModule"
 internal const val ANVIL_SUBCOMPONENT_SUFFIX = "A"
 internal const val PARENT_COMPONENT = "ParentComponent"
 internal const val SUBCOMPONENT_FACTORY = "SubcomponentFactory"
+internal const val SUBCOMPONENT_MODULE = "SubcomponentModule"
 
 internal const val REFERENCE_SUFFIX = "_reference"
 internal const val SCOPE_SUFFIX = "_scope"

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/BindingModuleGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/BindingModuleGenerator.kt
@@ -7,6 +7,7 @@ import com.squareup.anvil.compiler.HINT_BINDING_PACKAGE_PREFIX
 import com.squareup.anvil.compiler.HINT_CONTRIBUTES_PACKAGE_PREFIX
 import com.squareup.anvil.compiler.HINT_MULTIBINDING_PACKAGE_PREFIX
 import com.squareup.anvil.compiler.MODULE_PACKAGE_PREFIX
+import com.squareup.anvil.compiler.REFERENCE_SUFFIX
 import com.squareup.anvil.compiler.api.AnvilCompilationException
 import com.squareup.anvil.compiler.api.AnvilContext
 import com.squareup.anvil.compiler.api.GeneratedFile
@@ -290,6 +291,9 @@ internal class BindingModuleGenerator(
         it.findChildrenByClass(KtProperty::class.java).toList()
       }
       .mapNotNull { ktProperty ->
+        // We can safely ignore scopes, we only care about the reference classes.
+        if (ktProperty.name?.endsWith(REFERENCE_SUFFIX) != true) return@mapNotNull null
+
         (ktProperty.initializer as? KtClassLiteralExpression)
           ?.firstChild
           ?.requireFqName(module)


### PR DESCRIPTION
And don't use `@ContributesBinding`. The annotation leads to potential duplicate bindings. We used a similar solution for parent component interfaces.

Fixes #459