### PR TITLE
Support resolving an `FqName` for lambdas.

### DIFF
--- a/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/PsiUtils.kt
+++ b/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/PsiUtils.kt
@@ -361,6 +361,19 @@ public fun PsiElement.requireFqName(
       return element.requireFqName(module)
     }
     is KtSuperTypeListEntry -> return typeReference?.requireFqName(module) ?: failTypeHandling()
+    is KtFunctionType -> {
+      // KtFunctionType is a lambda. The compiler will translate lambdas to one of the function
+      // interfaces. More details are available here:
+      // https://github.com/JetBrains/kotlin/blob/master/spec-docs/function-types.md
+      val parameterCount = parameters.size
+      if (parameterCount !in 0..22) {
+        throw AnvilCompilationException(
+          element = this,
+          message = "Couldn't find function type for $parameterCount parameters."
+        )
+      }
+      return FqName("kotlin.jvm.functions.Function$parameterCount")
+    }
     else -> failTypeHandling()
   }
 

--- a/compiler/src/test/java/com/squareup/anvil/compiler/dagger/InjectConstructorFactoryGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/dagger/InjectConstructorFactoryGeneratorTest.kt
@@ -675,6 +675,22 @@ public final class InjectClass_Factory implements Factory<InjectClass> {
     }
   }
 
+  @Test fun `a factory class is generated for an inject constructor with a lambda as super type`() {
+    compile(
+      """
+        package com.squareup.test
+
+        import javax.inject.Inject
+  
+        class InjectClass @Inject constructor() : (Int) -> Unit {
+          override fun invoke(integer: Int) = Unit
+        }
+      """,
+    ) {
+      assertThat(injectClass.factoryClass()).isNotNull()
+    }
+  }
+
   @Test fun `a factory class is generated for an inject constructor inner class`() {
     /*
 package com.squareup.test;


### PR DESCRIPTION
That was a regression introduced by https://github.com/square/anvil/commit/403e83577682faa241f987b2c93661344b4d6a29. I found while testing the new release. 