### PR TITLE
Move `AnvilModuleDescriptor` into a new, more specific package.

### DIFF
--- a/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/ClassReference.kt
+++ b/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/ClassReference.kt
@@ -4,6 +4,7 @@ import com.squareup.anvil.annotations.ExperimentalAnvilApi
 import com.squareup.anvil.compiler.api.AnvilCompilationException
 import com.squareup.anvil.compiler.internal.ClassReference.Descriptor
 import com.squareup.anvil.compiler.internal.ClassReference.Psi
+import com.squareup.anvil.compiler.internal.reference.getKtClassOrObjectOrNull
 import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.ClassName
 import org.jetbrains.kotlin.descriptors.ClassDescriptor
@@ -84,7 +85,7 @@ public fun KtClassOrObject.toClassReference(): Psi {
 @ExperimentalAnvilApi
 public fun FqName.toClassReferenceOrNull(module: ModuleDescriptor): ClassReference? {
   return classDescriptorOrNull(module)?.toClassReference()
-    ?: module.getKtClassOrObjectOrNull(this)?.toClassReference()
+    ?: getKtClassOrObjectOrNull(module)?.toClassReference()
 }
 
 @ExperimentalAnvilApi

--- a/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/FqName.kt
+++ b/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/FqName.kt
@@ -4,9 +4,11 @@ import com.squareup.anvil.annotations.ContributesBinding
 import com.squareup.anvil.annotations.ContributesMultibinding
 import com.squareup.anvil.annotations.ContributesSubcomponent
 import com.squareup.anvil.annotations.ContributesTo
+import com.squareup.anvil.annotations.ExperimentalAnvilApi
 import dagger.Lazy
 import dagger.MapKey
 import dagger.Provides
+import org.jetbrains.kotlin.name.FqName
 import javax.inject.Inject
 import javax.inject.Qualifier
 import javax.inject.Scope
@@ -24,3 +26,7 @@ internal val contributesToFqName = ContributesTo::class.fqName
 internal val contributesBindingFqName = ContributesBinding::class.fqName
 internal val contributesMultibindingFqName = ContributesMultibinding::class.fqName
 internal val contributesSubcomponentFqName = ContributesSubcomponent::class.fqName
+
+@ExperimentalAnvilApi
+public fun FqName.descendant(segments: String): FqName =
+  if (isRoot) FqName(segments) else FqName("${asString()}.$segments")

--- a/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/reference/AnvilModuleDescriptor.kt
+++ b/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/reference/AnvilModuleDescriptor.kt
@@ -1,11 +1,11 @@
-package com.squareup.anvil.compiler.internal
+package com.squareup.anvil.compiler.internal.reference
 
 import com.squareup.anvil.annotations.ExperimentalAnvilApi
 import com.squareup.anvil.compiler.api.AnvilCompilationException
+import com.squareup.anvil.compiler.internal.classIdBestGuess
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.FqName
-import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.psi.KtFile
 
@@ -21,38 +21,20 @@ private inline fun ModuleDescriptor.asAnvilModuleDescriptor(): AnvilModuleDescri
   this as AnvilModuleDescriptor
 
 @ExperimentalAnvilApi
-public fun ModuleDescriptor.resolveFqNameOrNull(
-  fqName: FqName
-): FqName? = asAnvilModuleDescriptor().resolveClassIdOrNull(fqName.classIdBestGuess())
+public fun FqName.getKtClassOrObjectOrNull(
+  module: ModuleDescriptor
+): KtClassOrObject? = module.asAnvilModuleDescriptor().getKtClassOrObjectOrNull(this)
 
 @ExperimentalAnvilApi
-public fun ModuleDescriptor.getKtClassOrObjectOrNull(
-  fqName: FqName
-): KtClassOrObject? = asAnvilModuleDescriptor().getKtClassOrObjectOrNull(fqName)
+public fun FqName.getKtClassOrObject(
+  module: ModuleDescriptor
+): KtClassOrObject = getKtClassOrObjectOrNull(module)
+  ?: throw AnvilCompilationException("Couldn't resolve KtClassOrObject for ${asString()}")
 
 @ExperimentalAnvilApi
-public fun ModuleDescriptor.requireKtClassOrObject(
-  fqName: FqName
-): KtClassOrObject = getKtClassOrObjectOrNull(fqName)
-  ?: throw AnvilCompilationException("Couldn't resolve KtClassOrObject for ${fqName.asString()}")
-
-@ExperimentalAnvilApi
-public fun ModuleDescriptor.canResolveFqName(
-  fqName: FqName
-): Boolean = resolveFqNameOrNull(fqName) != null
-
-@ExperimentalAnvilApi
-public fun ModuleDescriptor.resolveFqNameOrNull(
-  packageName: FqName,
-  className: String
-): FqName? = asAnvilModuleDescriptor()
-  .resolveClassIdOrNull(ClassId(packageName, Name.identifier(className)))
-
-@ExperimentalAnvilApi
-public fun ModuleDescriptor.canResolveFqName(
-  packageName: FqName,
-  className: String
-): Boolean = resolveFqNameOrNull(packageName, className) != null
+public fun FqName.canResolveFqName(
+  module: ModuleDescriptor
+): Boolean = module.asAnvilModuleDescriptor().resolveClassIdOrNull(classIdBestGuess()) != null
 
 @ExperimentalAnvilApi
 public fun KtFile.classesAndInnerClasses(
@@ -62,7 +44,7 @@ public fun KtFile.classesAndInnerClasses(
 }
 
 @ExperimentalAnvilApi
-public fun Collection<KtFile>.classesAndInnerClass(
+public fun Collection<KtFile>.classesAndInnerClasses(
   module: ModuleDescriptor
 ): Sequence<KtClassOrObject> {
   return asSequence().flatMap { it.classesAndInnerClasses(module) }

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/BindingModuleGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/BindingModuleGenerator.kt
@@ -21,11 +21,11 @@ import com.squareup.anvil.compiler.internal.annotationOrNull
 import com.squareup.anvil.compiler.internal.asClassName
 import com.squareup.anvil.compiler.internal.buildFile
 import com.squareup.anvil.compiler.internal.capitalize
-import com.squareup.anvil.compiler.internal.classesAndInnerClass
 import com.squareup.anvil.compiler.internal.decapitalize
 import com.squareup.anvil.compiler.internal.findAnnotation
 import com.squareup.anvil.compiler.internal.generateClassName
 import com.squareup.anvil.compiler.internal.hasAnnotation
+import com.squareup.anvil.compiler.internal.reference.classesAndInnerClasses
 import com.squareup.anvil.compiler.internal.replaces
 import com.squareup.anvil.compiler.internal.requireFqName
 import com.squareup.anvil.compiler.internal.safePackageString
@@ -98,7 +98,7 @@ internal class BindingModuleGenerator(
       hintPackagePrefix = HINT_MULTIBINDING_PACKAGE_PREFIX
     )
 
-    val classes = projectFiles.classesAndInnerClass(module).toList()
+    val classes = projectFiles.classesAndInnerClasses(module).toList()
 
     // Similar to the explanation above, we must track contributed modules.
     findContributedModules(classes, module)

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/CodeGenerationExtension.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/CodeGenerationExtension.kt
@@ -3,6 +3,7 @@ package com.squareup.anvil.compiler.codegen
 import com.squareup.anvil.compiler.api.AnvilCompilationException
 import com.squareup.anvil.compiler.api.CodeGenerator
 import com.squareup.anvil.compiler.api.GeneratedFile
+import com.squareup.anvil.compiler.codegen.reference.RealAnvilModuleDescriptor
 import org.jetbrains.kotlin.analyzer.AnalysisResult
 import org.jetbrains.kotlin.analyzer.AnalysisResult.RetryWithAdditionalRoots
 import org.jetbrains.kotlin.com.intellij.openapi.project.Project

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributedBinding.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributedBinding.kt
@@ -17,10 +17,10 @@ import com.squareup.anvil.compiler.internal.isMapKey
 import com.squareup.anvil.compiler.internal.isObject
 import com.squareup.anvil.compiler.internal.isQualifier
 import com.squareup.anvil.compiler.internal.qualifiers
+import com.squareup.anvil.compiler.internal.reference.getKtClassOrObject
 import com.squareup.anvil.compiler.internal.requireAnnotation
 import com.squareup.anvil.compiler.internal.requireClassDescriptor
 import com.squareup.anvil.compiler.internal.requireFqName
-import com.squareup.anvil.compiler.internal.requireKtClassOrObject
 import com.squareup.anvil.compiler.internal.toAnnotationSpec
 import com.squareup.anvil.compiler.isMapKey
 import com.squareup.anvil.compiler.priority
@@ -118,7 +118,7 @@ private fun ClassReference.requireBoundType(
         "specify the bound type. This is only allowed with exactly one direct super type. " +
         "If there are multiple or none, then the bound type must be explicitly defined in " +
         "the @${annotationFqName.shortName()} annotation.",
-      element = module.requireKtClassOrObject(fqName)
+      element = fqName.getKtClassOrObject(module)
     )
 
   boundType.checkNotGeneric(contributedFqName = fqName)

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesBindingGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesBindingGenerator.kt
@@ -12,11 +12,11 @@ import com.squareup.anvil.compiler.api.createGeneratedFile
 import com.squareup.anvil.compiler.contributesBindingFqName
 import com.squareup.anvil.compiler.internal.asClassName
 import com.squareup.anvil.compiler.internal.buildFile
-import com.squareup.anvil.compiler.internal.classesAndInnerClass
 import com.squareup.anvil.compiler.internal.fqNameOrNull
 import com.squareup.anvil.compiler.internal.generateClassName
 import com.squareup.anvil.compiler.internal.hasAnnotation
 import com.squareup.anvil.compiler.internal.isQualifier
+import com.squareup.anvil.compiler.internal.reference.classesAndInnerClasses
 import com.squareup.anvil.compiler.internal.requireClassDescriptor
 import com.squareup.anvil.compiler.internal.requireFqName
 import com.squareup.anvil.compiler.internal.safePackageString
@@ -53,7 +53,7 @@ internal class ContributesBindingGenerator : CodeGenerator {
     projectFiles: Collection<KtFile>
   ): Collection<GeneratedFile> {
     return projectFiles
-      .classesAndInnerClass(module)
+      .classesAndInnerClasses(module)
       .filter { it.hasAnnotation(contributesBindingFqName, module) }
       .onEach { clazz ->
         clazz.checkClassIsPublic()

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesMultibindingGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesMultibindingGenerator.kt
@@ -12,9 +12,9 @@ import com.squareup.anvil.compiler.api.createGeneratedFile
 import com.squareup.anvil.compiler.contributesMultibindingFqName
 import com.squareup.anvil.compiler.internal.asClassName
 import com.squareup.anvil.compiler.internal.buildFile
-import com.squareup.anvil.compiler.internal.classesAndInnerClass
 import com.squareup.anvil.compiler.internal.generateClassName
 import com.squareup.anvil.compiler.internal.hasAnnotation
+import com.squareup.anvil.compiler.internal.reference.classesAndInnerClasses
 import com.squareup.anvil.compiler.internal.requireClassDescriptor
 import com.squareup.anvil.compiler.internal.requireFqName
 import com.squareup.anvil.compiler.internal.safePackageString
@@ -47,7 +47,7 @@ internal class ContributesMultibindingGenerator : CodeGenerator {
     projectFiles: Collection<KtFile>
   ): Collection<GeneratedFile> {
     return projectFiles
-      .classesAndInnerClass(module)
+      .classesAndInnerClasses(module)
       .filter { it.hasAnnotation(contributesMultibindingFqName, module) }
       .onEach { clazz ->
         clazz.checkClassIsPublic()

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesSubcomponentGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesSubcomponentGenerator.kt
@@ -19,12 +19,12 @@ import com.squareup.anvil.compiler.internal.ClassReference
 import com.squareup.anvil.compiler.internal.annotations
 import com.squareup.anvil.compiler.internal.asClassName
 import com.squareup.anvil.compiler.internal.buildFile
-import com.squareup.anvil.compiler.internal.classesAndInnerClass
 import com.squareup.anvil.compiler.internal.fqNameOrNull
 import com.squareup.anvil.compiler.internal.generateClassName
 import com.squareup.anvil.compiler.internal.hasAnnotation
 import com.squareup.anvil.compiler.internal.isInterface
 import com.squareup.anvil.compiler.internal.parentScope
+import com.squareup.anvil.compiler.internal.reference.classesAndInnerClasses
 import com.squareup.anvil.compiler.internal.replaces
 import com.squareup.anvil.compiler.internal.requireFqName
 import com.squareup.anvil.compiler.internal.safePackageString
@@ -63,7 +63,7 @@ internal class ContributesSubcomponentGenerator : CodeGenerator {
     projectFiles: Collection<KtFile>
   ): Collection<GeneratedFile> {
     return projectFiles
-      .classesAndInnerClass(module)
+      .classesAndInnerClasses(module)
       .filter { it.hasAnnotation(contributesSubcomponentFqName, module) }
       .onEach { clazz ->
         if (!clazz.isInterface() && !clazz.hasModifier(ABSTRACT_KEYWORD)) {

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesSubcomponentHandlerGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesSubcomponentHandlerGenerator.kt
@@ -23,7 +23,6 @@ import com.squareup.anvil.compiler.internal.annotations
 import com.squareup.anvil.compiler.internal.argumentType
 import com.squareup.anvil.compiler.internal.asClassName
 import com.squareup.anvil.compiler.internal.buildFile
-import com.squareup.anvil.compiler.internal.classesAndInnerClass
 import com.squareup.anvil.compiler.internal.daggerScopes
 import com.squareup.anvil.compiler.internal.findAnnotation
 import com.squareup.anvil.compiler.internal.findAnnotationArgument
@@ -37,6 +36,7 @@ import com.squareup.anvil.compiler.internal.isAbstractClass
 import com.squareup.anvil.compiler.internal.isInterface
 import com.squareup.anvil.compiler.internal.isPublic
 import com.squareup.anvil.compiler.internal.parentScope
+import com.squareup.anvil.compiler.internal.reference.classesAndInnerClasses
 import com.squareup.anvil.compiler.internal.replaces
 import com.squareup.anvil.compiler.internal.requireFqName
 import com.squareup.anvil.compiler.internal.returnType
@@ -114,7 +114,7 @@ internal class ContributesSubcomponentHandlerGenerator(
 
     // Find new @MergeComponent (and similar triggers) that would cause generating new code.
     triggers += projectFiles
-      .classesAndInnerClass(module)
+      .classesAndInnerClasses(module)
       .mapNotNull { clazz ->
         val annotation = generationTrigger.firstOrNull { trigger ->
           clazz.hasAnnotation(trigger, module)
@@ -128,7 +128,7 @@ internal class ContributesSubcomponentHandlerGenerator(
     // Find new contributed subcomponents in this module. If there's a trigger for them, then we
     // also need to generate code for them later.
     contributions += projectFiles
-      .classesAndInnerClass(module)
+      .classesAndInnerClasses(module)
       .mapNotNull { clazz ->
         val annotation = clazz.findAnnotation(contributesSubcomponentFqName, module)
           ?: return@mapNotNull null

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesToGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesToGenerator.kt
@@ -14,10 +14,10 @@ import com.squareup.anvil.compiler.contributesToFqName
 import com.squareup.anvil.compiler.daggerModuleFqName
 import com.squareup.anvil.compiler.internal.asClassName
 import com.squareup.anvil.compiler.internal.buildFile
-import com.squareup.anvil.compiler.internal.classesAndInnerClass
 import com.squareup.anvil.compiler.internal.generateClassName
 import com.squareup.anvil.compiler.internal.hasAnnotation
 import com.squareup.anvil.compiler.internal.isInterface
+import com.squareup.anvil.compiler.internal.reference.classesAndInnerClasses
 import com.squareup.anvil.compiler.internal.requireFqName
 import com.squareup.anvil.compiler.internal.safePackageString
 import com.squareup.anvil.compiler.internal.scope
@@ -51,7 +51,7 @@ internal class ContributesToGenerator : CodeGenerator {
     projectFiles: Collection<KtFile>
   ): Collection<GeneratedFile> {
     return projectFiles
-      .classesAndInnerClass(module)
+      .classesAndInnerClasses(module)
       .filter { it.hasAnnotation(contributesToFqName, module) }
       .onEach { clazz ->
         if (!clazz.isInterface() &&

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/AnvilAnnotationDetectorCheck.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/AnvilAnnotationDetectorCheck.kt
@@ -8,8 +8,8 @@ import com.squareup.anvil.compiler.codegen.PrivateCodeGenerator
 import com.squareup.anvil.compiler.contributesBindingFqName
 import com.squareup.anvil.compiler.contributesSubcomponentFqName
 import com.squareup.anvil.compiler.contributesToFqName
-import com.squareup.anvil.compiler.internal.classesAndInnerClass
 import com.squareup.anvil.compiler.internal.hasAnnotation
+import com.squareup.anvil.compiler.internal.reference.classesAndInnerClasses
 import com.squareup.anvil.compiler.mergeComponentFqName
 import com.squareup.anvil.compiler.mergeInterfacesFqName
 import com.squareup.anvil.compiler.mergeModulesFqName
@@ -30,7 +30,7 @@ internal class AnvilAnnotationDetectorCheck : PrivateCodeGenerator() {
     projectFiles: Collection<KtFile>
   ) {
     val clazz = projectFiles
-      .classesAndInnerClass(module)
+      .classesAndInnerClasses(module)
       .firstOrNull {
         it.hasAnnotation(mergeComponentFqName, module) ||
           it.hasAnnotation(mergeSubcomponentFqName, module) ||

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/AnvilMergeAnnotationDetectorCheck.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/AnvilMergeAnnotationDetectorCheck.kt
@@ -5,8 +5,8 @@ import com.squareup.anvil.compiler.api.AnvilCompilationException
 import com.squareup.anvil.compiler.api.AnvilContext
 import com.squareup.anvil.compiler.api.CodeGenerator
 import com.squareup.anvil.compiler.codegen.PrivateCodeGenerator
-import com.squareup.anvil.compiler.internal.classesAndInnerClass
 import com.squareup.anvil.compiler.internal.hasAnnotation
+import com.squareup.anvil.compiler.internal.reference.classesAndInnerClasses
 import com.squareup.anvil.compiler.mergeComponentFqName
 import com.squareup.anvil.compiler.mergeInterfacesFqName
 import com.squareup.anvil.compiler.mergeModulesFqName
@@ -26,7 +26,7 @@ internal class AnvilMergeAnnotationDetectorCheck : PrivateCodeGenerator() {
     projectFiles: Collection<KtFile>
   ) {
     val clazz = projectFiles
-      .classesAndInnerClass(module)
+      .classesAndInnerClasses(module)
       .firstOrNull {
         it.hasAnnotation(mergeComponentFqName, module) ||
           it.hasAnnotation(mergeSubcomponentFqName, module) ||

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/AssistedFactoryGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/AssistedFactoryGenerator.kt
@@ -23,15 +23,15 @@ import com.squareup.anvil.compiler.internal.asTypeName
 import com.squareup.anvil.compiler.internal.asTypeNameOrNull
 import com.squareup.anvil.compiler.internal.buildFile
 import com.squareup.anvil.compiler.internal.classDescriptorOrNull
-import com.squareup.anvil.compiler.internal.classesAndInnerClass
 import com.squareup.anvil.compiler.internal.findAnnotation
 import com.squareup.anvil.compiler.internal.findAnnotationArgument
 import com.squareup.anvil.compiler.internal.fqNameOrNull
 import com.squareup.anvil.compiler.internal.functions
 import com.squareup.anvil.compiler.internal.generateClassName
-import com.squareup.anvil.compiler.internal.getKtClassOrObjectOrNull
 import com.squareup.anvil.compiler.internal.hasAnnotation
 import com.squareup.anvil.compiler.internal.isInterface
+import com.squareup.anvil.compiler.internal.reference.classesAndInnerClasses
+import com.squareup.anvil.compiler.internal.reference.getKtClassOrObjectOrNull
 import com.squareup.anvil.compiler.internal.requireFqName
 import com.squareup.anvil.compiler.internal.requireTypeName
 import com.squareup.anvil.compiler.internal.resolveGenericKotlinType
@@ -88,7 +88,7 @@ internal class AssistedFactoryGenerator : PrivateCodeGenerator() {
     projectFiles: Collection<KtFile>
   ) {
     projectFiles
-      .classesAndInnerClass(module)
+      .classesAndInnerClasses(module)
       .filter { it.hasAnnotation(assistedFactoryFqName, module) }
       .forEach { clazz ->
         generateFactoryClass(codeGenDir, module, clazz)
@@ -110,7 +110,7 @@ internal class AssistedFactoryGenerator : PrivateCodeGenerator() {
     val returnTypeFqName = function.returnTypeLazy.value
 
     // The return type of the function must have an @AssistedInject constructor.
-    val injectedClass = module.getKtClassOrObjectOrNull(returnTypeFqName)
+    val injectedClass = returnTypeFqName.getKtClassOrObjectOrNull(module)
     val constructor = injectedClass
       ?.injectConstructor(assistedInjectFqName, module)
       ?: throw AnvilCompilationException(

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/AssistedInjectGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/AssistedInjectGenerator.kt
@@ -14,8 +14,8 @@ import com.squareup.anvil.compiler.codegen.injectConstructor
 import com.squareup.anvil.compiler.codegen.mapToConstructorParameters
 import com.squareup.anvil.compiler.internal.asClassName
 import com.squareup.anvil.compiler.internal.buildFile
-import com.squareup.anvil.compiler.internal.classesAndInnerClass
 import com.squareup.anvil.compiler.internal.generateClassName
+import com.squareup.anvil.compiler.internal.reference.classesAndInnerClasses
 import com.squareup.anvil.compiler.internal.safePackageString
 import com.squareup.anvil.compiler.internal.typeVariableNames
 import com.squareup.kotlinpoet.ClassName
@@ -53,7 +53,7 @@ internal class AssistedInjectGenerator : PrivateCodeGenerator() {
     projectFiles: Collection<KtFile>
   ) {
     projectFiles
-      .classesAndInnerClass(module)
+      .classesAndInnerClasses(module)
       .forEach { clazz ->
         clazz.injectConstructor(assistedInjectFqName, module)
           ?.let {

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/ComponentDetectorCheck.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/ComponentDetectorCheck.kt
@@ -6,8 +6,8 @@ import com.squareup.anvil.compiler.api.AnvilContext
 import com.squareup.anvil.compiler.api.CodeGenerator
 import com.squareup.anvil.compiler.codegen.PrivateCodeGenerator
 import com.squareup.anvil.compiler.daggerComponentFqName
-import com.squareup.anvil.compiler.internal.classesAndInnerClass
 import com.squareup.anvil.compiler.internal.hasAnnotation
+import com.squareup.anvil.compiler.internal.reference.classesAndInnerClasses
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 import org.jetbrains.kotlin.psi.KtFile
 import java.io.File
@@ -23,7 +23,7 @@ internal class ComponentDetectorCheck : PrivateCodeGenerator() {
     projectFiles: Collection<KtFile>
   ) {
     val component = projectFiles
-      .classesAndInnerClass(module)
+      .classesAndInnerClasses(module)
       .firstOrNull { it.hasAnnotation(daggerComponentFqName, module) }
 
     if (component != null) {

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/InjectConstructorFactoryGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/InjectConstructorFactoryGenerator.kt
@@ -12,8 +12,8 @@ import com.squareup.anvil.compiler.codegen.mapToConstructorParameters
 import com.squareup.anvil.compiler.injectFqName
 import com.squareup.anvil.compiler.internal.asClassName
 import com.squareup.anvil.compiler.internal.buildFile
-import com.squareup.anvil.compiler.internal.classesAndInnerClass
 import com.squareup.anvil.compiler.internal.generateClassName
+import com.squareup.anvil.compiler.internal.reference.classesAndInnerClasses
 import com.squareup.anvil.compiler.internal.safePackageString
 import com.squareup.anvil.compiler.internal.typeVariableNames
 import com.squareup.kotlinpoet.ClassName
@@ -44,7 +44,7 @@ internal class InjectConstructorFactoryGenerator : PrivateCodeGenerator() {
     projectFiles: Collection<KtFile>
   ) {
     projectFiles
-      .classesAndInnerClass(module)
+      .classesAndInnerClasses(module)
       .forEach { clazz ->
         clazz.injectConstructor(injectFqName, module)
           ?.let {

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/MembersInjectorGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/MembersInjectorGenerator.kt
@@ -11,10 +11,10 @@ import com.squareup.anvil.compiler.codegen.mapToMemberInjectParameters
 import com.squareup.anvil.compiler.internal.asClassName
 import com.squareup.anvil.compiler.internal.buildFile
 import com.squareup.anvil.compiler.internal.capitalize
-import com.squareup.anvil.compiler.internal.classesAndInnerClass
 import com.squareup.anvil.compiler.internal.generateClassName
 import com.squareup.anvil.compiler.internal.isGenericClass
 import com.squareup.anvil.compiler.internal.isInterface
+import com.squareup.anvil.compiler.internal.reference.classesAndInnerClasses
 import com.squareup.anvil.compiler.internal.safePackageString
 import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.ClassName
@@ -46,7 +46,7 @@ internal class MembersInjectorGenerator : PrivateCodeGenerator() {
     projectFiles: Collection<KtFile>
   ) {
     projectFiles
-      .classesAndInnerClass(module)
+      .classesAndInnerClasses(module)
       .filterNot { it.isInterface() }
       .forEach { clazz ->
 

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/ProvidesMethodFactoryGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/ProvidesMethodFactoryGenerator.kt
@@ -14,7 +14,6 @@ import com.squareup.anvil.compiler.daggerProvidesFqName
 import com.squareup.anvil.compiler.internal.asClassName
 import com.squareup.anvil.compiler.internal.buildFile
 import com.squareup.anvil.compiler.internal.capitalize
-import com.squareup.anvil.compiler.internal.classesAndInnerClass
 import com.squareup.anvil.compiler.internal.findAnnotation
 import com.squareup.anvil.compiler.internal.functions
 import com.squareup.anvil.compiler.internal.generateClassName
@@ -22,6 +21,7 @@ import com.squareup.anvil.compiler.internal.hasAnnotation
 import com.squareup.anvil.compiler.internal.isInterface
 import com.squareup.anvil.compiler.internal.isNullable
 import com.squareup.anvil.compiler.internal.properties
+import com.squareup.anvil.compiler.internal.reference.classesAndInnerClasses
 import com.squareup.anvil.compiler.internal.requireFqName
 import com.squareup.anvil.compiler.internal.requireTypeName
 import com.squareup.anvil.compiler.internal.requireTypeReference
@@ -64,7 +64,7 @@ internal class ProvidesMethodFactoryGenerator : PrivateCodeGenerator() {
     projectFiles: Collection<KtFile>
   ) {
     projectFiles
-      .classesAndInnerClass(module)
+      .classesAndInnerClasses(module)
       .filter { it.hasAnnotation(daggerModuleFqName, module) }
       .forEach { clazz ->
         clazz

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/reference/RealAnvilModuleDescriptor.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/reference/RealAnvilModuleDescriptor.kt
@@ -1,6 +1,6 @@
-package com.squareup.anvil.compiler.codegen
+package com.squareup.anvil.compiler.codegen.reference
 
-import com.squareup.anvil.compiler.internal.AnvilModuleDescriptor
+import com.squareup.anvil.compiler.internal.reference.AnvilModuleDescriptor
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 import org.jetbrains.kotlin.descriptors.findTypeAliasAcrossModuleDependencies
 import org.jetbrains.kotlin.descriptors.resolveClassByFqName

--- a/compiler/src/test/java/com/squareup/anvil/compiler/codegen/CodeGenerationExtensionTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/codegen/CodeGenerationExtensionTest.kt
@@ -6,8 +6,8 @@ import com.squareup.anvil.compiler.api.CodeGenerator
 import com.squareup.anvil.compiler.api.GeneratedFile
 import com.squareup.anvil.compiler.api.createGeneratedFile
 import com.squareup.anvil.compiler.compile
-import com.squareup.anvil.compiler.internal.classesAndInnerClass
 import com.squareup.anvil.compiler.internal.isInterface
+import com.squareup.anvil.compiler.internal.reference.classesAndInnerClasses
 import com.squareup.anvil.compiler.isError
 import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.OK
 import org.intellij.lang.annotations.Language
@@ -28,7 +28,7 @@ class CodeGenerationExtensionTest {
         projectFiles: Collection<KtFile>
       ): Collection<GeneratedFile> {
         return projectFiles
-          .classesAndInnerClass(module)
+          .classesAndInnerClasses(module)
           .filter { it.isInterface() }
           .map { clazz ->
             val generatedPackage = "generated.com.squareup.test"
@@ -85,7 +85,7 @@ class CodeGenerationExtensionTest {
         projectFiles: Collection<KtFile>
       ): Collection<GeneratedFile> {
         return projectFiles
-          .classesAndInnerClass(module)
+          .classesAndInnerClasses(module)
           .filter { it.isInterface() }
           .map { _ ->
             val generatedPackage = "generated.com.squareup.test"

--- a/compiler/src/test/java/com/squareup/anvil/compiler/codegen/ContributesSubcomponentHandlerGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/codegen/ContributesSubcomponentHandlerGeneratorTest.kt
@@ -15,8 +15,8 @@ import com.squareup.anvil.compiler.compile
 import com.squareup.anvil.compiler.componentInterface
 import com.squareup.anvil.compiler.contributingInterface
 import com.squareup.anvil.compiler.daggerModule1
-import com.squareup.anvil.compiler.internal.classesAndInnerClass
 import com.squareup.anvil.compiler.internal.hasAnnotation
+import com.squareup.anvil.compiler.internal.reference.classesAndInnerClasses
 import com.squareup.anvil.compiler.internal.testing.extends
 import com.squareup.anvil.compiler.internal.testing.packageName
 import com.squareup.anvil.compiler.internal.testing.use
@@ -1629,7 +1629,7 @@ class ContributesSubcomponentHandlerGeneratorTest {
         projectFiles: Collection<KtFile>
       ): Collection<GeneratedFile> {
         return projectFiles
-          .classesAndInnerClass(module)
+          .classesAndInnerClasses(module)
           .filter { it.hasAnnotation(mergeComponentFqName, module) }
           .map { _ ->
             val generatedPackage = "com.squareup.test"
@@ -1699,7 +1699,7 @@ class ContributesSubcomponentHandlerGeneratorTest {
         projectFiles: Collection<KtFile>
       ): Collection<GeneratedFile> {
         return projectFiles
-          .classesAndInnerClass(module)
+          .classesAndInnerClasses(module)
           .filter { it.hasAnnotation(mergeComponentFqName, module) }
           .map { _ ->
             val generatedPackage = "com.squareup.test"
@@ -1930,7 +1930,7 @@ class ContributesSubcomponentHandlerGeneratorTest {
         projectFiles: Collection<KtFile>
       ): Collection<GeneratedFile> {
         return projectFiles
-          .classesAndInnerClass(module)
+          .classesAndInnerClasses(module)
           .filter { it.hasAnnotation(mergeComponentFqName, module) }
           .map {
             val generatedPackage = "com.squareup.test"

--- a/integration-tests/code-generator/src/main/java/com/squareup/anvil/test/TestCodeGenerator.kt
+++ b/integration-tests/code-generator/src/main/java/com/squareup/anvil/test/TestCodeGenerator.kt
@@ -5,8 +5,8 @@ import com.squareup.anvil.compiler.api.AnvilContext
 import com.squareup.anvil.compiler.api.CodeGenerator
 import com.squareup.anvil.compiler.api.GeneratedFile
 import com.squareup.anvil.compiler.api.createGeneratedFile
-import com.squareup.anvil.compiler.internal.classesAndInnerClass
 import com.squareup.anvil.compiler.internal.hasAnnotation
+import com.squareup.anvil.compiler.internal.reference.classesAndInnerClasses
 import com.squareup.anvil.compiler.internal.safePackageString
 import org.intellij.lang.annotations.Language
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
@@ -31,7 +31,7 @@ class TestCodeGenerator : CodeGenerator {
     projectFiles: Collection<KtFile>
   ): Collection<GeneratedFile> {
     return projectFiles
-      .classesAndInnerClass(module)
+      .classesAndInnerClasses(module)
       .filter { it.hasAnnotation(FqName("com.squareup.anvil.test.Trigger"), module) }
       .flatMap { clazz ->
         val generatedPackage = "generated.test" + clazz.containingKtFile.packageFqName

--- a/integration-tests/code-generator/src/main/java/com/squareup/anvil/test/TestWithKaptCodeGenerator.kt
+++ b/integration-tests/code-generator/src/main/java/com/squareup/anvil/test/TestWithKaptCodeGenerator.kt
@@ -5,8 +5,8 @@ import com.squareup.anvil.compiler.api.AnvilContext
 import com.squareup.anvil.compiler.api.CodeGenerator
 import com.squareup.anvil.compiler.api.GeneratedFile
 import com.squareup.anvil.compiler.api.createGeneratedFile
-import com.squareup.anvil.compiler.internal.classesAndInnerClass
 import com.squareup.anvil.compiler.internal.hasAnnotation
+import com.squareup.anvil.compiler.internal.reference.classesAndInnerClasses
 import com.squareup.anvil.compiler.internal.safePackageString
 import org.intellij.lang.annotations.Language
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
@@ -29,7 +29,7 @@ class TestWithKaptCodeGenerator : CodeGenerator {
     projectFiles: Collection<KtFile>
   ): Collection<GeneratedFile> {
     return projectFiles
-      .classesAndInnerClass(module)
+      .classesAndInnerClasses(module)
       .filter { it.hasAnnotation(FqName("com.squareup.anvil.test.TriggerWithKapt"), module) }
       .flatMap { clazz ->
         val generatedPackage = "generated.test" + clazz.containingKtFile.packageFqName


### PR DESCRIPTION
Combine some of the utility functions. Always make sure that the receiver of extension function is the type the utility is made for and not the module descriptor. This improves discoverability.