### PR TITLE
Reduce the number of times we resolve class descriptors

### DIFF
--- a/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/CompilerUtils.kt
+++ b/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/CompilerUtils.kt
@@ -95,7 +95,7 @@ public fun KotlinType.classDescriptorOrNull(): ClassDescriptor? {
 }
 
 @ExperimentalAnvilApi
-public fun KotlinType.requireClassDescriptor(): ClassDescriptor {
+public fun KotlinType.classDescriptor(): ClassDescriptor {
   return classDescriptorOrNull()
     ?: throw AnvilCompilationException(
       "Unable to resolve type for ${this.asTypeName()}"
@@ -118,7 +118,7 @@ public fun AnnotationDescriptor.scope(module: ModuleDescriptor): ClassDescriptor
 @ExperimentalAnvilApi
 public fun AnnotationDescriptor.scopeOrNull(module: ModuleDescriptor): ClassDescriptor? {
   val annotationValue = getAnnotationValue("scope") as? KClassValue
-  return annotationValue?.argumentType(module)?.requireClassDescriptor()
+  return annotationValue?.argumentType(module)?.classDescriptor()
 }
 
 @ExperimentalAnvilApi
@@ -129,7 +129,7 @@ public fun AnnotationDescriptor.parentScope(module: ModuleDescriptor): ClassDesc
       message = "Couldn't find parentScope for $fqName."
     )
 
-  return annotationValue.argumentType(module).requireClassDescriptor()
+  return annotationValue.argumentType(module).classDescriptor()
 }
 
 @ExperimentalAnvilApi
@@ -165,7 +165,7 @@ public fun List<KotlinType>.getAllSuperTypes(): Sequence<FqName> =
     kotlinTypes.ifEmpty { null }?.flatMap { it.supertypes() }
   }
     .flatMap { it.asSequence() }
-    .map { it.requireClassDescriptor().fqNameSafe }
+    .map { it.classDescriptor().fqNameSafe }
 
 @ExperimentalAnvilApi
 public fun AnnotationDescriptor.isQualifier(): Boolean {

--- a/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/KotlinPoetUtils.kt
+++ b/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/KotlinPoetUtils.kt
@@ -275,7 +275,7 @@ public fun KotlinType.asTypeNameOrNull(
 ): TypeName? {
   if (isTypeParameter()) return TypeVariableName(toString())
 
-  val className = requireClassDescriptor().asClassName()
+  val className = classDescriptor().asClassName()
   if (!rawTypeFilter(className)) {
     return null
   }
@@ -385,7 +385,7 @@ public fun AnnotationDescriptor.toAnnotationSpec(module: ModuleDescriptor): Anno
       allValueArguments.forEach { (name, value) ->
         when (value) {
           is KClassValue -> {
-            val className = value.argumentType(module).requireClassDescriptor()
+            val className = value.argumentType(module).classDescriptor()
               .asClassName()
             addMember("${name.asString()} = %T::class", className)
           }

--- a/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/reference/AnvilModuleDescriptor.kt
+++ b/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/reference/AnvilModuleDescriptor.kt
@@ -3,7 +3,10 @@ package com.squareup.anvil.compiler.internal.reference
 import com.squareup.anvil.annotations.ExperimentalAnvilApi
 import com.squareup.anvil.compiler.api.AnvilCompilationException
 import com.squareup.anvil.compiler.internal.classIdBestGuess
+import org.jetbrains.kotlin.descriptors.ClassDescriptor
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
+import org.jetbrains.kotlin.incremental.components.LookupLocation
+import org.jetbrains.kotlin.incremental.components.NoLookupLocation.FROM_BACKEND
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.psi.KtClassOrObject
@@ -12,12 +15,19 @@ import org.jetbrains.kotlin.psi.KtFile
 @ExperimentalAnvilApi
 public interface AnvilModuleDescriptor : ModuleDescriptor {
   public fun resolveClassIdOrNull(classId: ClassId): FqName?
+
+  public fun resolveFqNameOrNull(
+    fqName: FqName,
+    lookupLocation: LookupLocation = FROM_BACKEND
+  ): ClassDescriptor?
+
   public fun getClassesAndInnerClasses(ktFile: KtFile): List<KtClassOrObject>
+
   public fun getKtClassOrObjectOrNull(fqName: FqName): KtClassOrObject?
 }
 
 @Suppress("NOTHING_TO_INLINE")
-private inline fun ModuleDescriptor.asAnvilModuleDescriptor(): AnvilModuleDescriptor =
+internal inline fun ModuleDescriptor.asAnvilModuleDescriptor(): AnvilModuleDescriptor =
   this as AnvilModuleDescriptor
 
 @ExperimentalAnvilApi

--- a/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/reference/ClassReference.kt
+++ b/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/reference/ClassReference.kt
@@ -5,6 +5,7 @@ import com.squareup.anvil.compiler.api.AnvilCompilationException
 import com.squareup.anvil.compiler.internal.annotationOrNull
 import com.squareup.anvil.compiler.internal.argumentType
 import com.squareup.anvil.compiler.internal.asClassName
+import com.squareup.anvil.compiler.internal.classDescriptor
 import com.squareup.anvil.compiler.internal.classDescriptorOrNull
 import com.squareup.anvil.compiler.internal.contributesBindingFqName
 import com.squareup.anvil.compiler.internal.contributesMultibindingFqName
@@ -20,7 +21,6 @@ import com.squareup.anvil.compiler.internal.isInterface
 import com.squareup.anvil.compiler.internal.isQualifier
 import com.squareup.anvil.compiler.internal.reference.ClassReference.Descriptor
 import com.squareup.anvil.compiler.internal.reference.ClassReference.Psi
-import com.squareup.anvil.compiler.internal.requireClassDescriptor
 import com.squareup.anvil.compiler.internal.requireClassId
 import com.squareup.anvil.compiler.internal.requireFqName
 import com.squareup.anvil.compiler.internal.scope
@@ -232,7 +232,7 @@ public fun ClassReference.replaces(
 
       replacesValue
         ?.value
-        ?.map { it.argumentType(module).requireClassDescriptor().toClassReference() }
+        ?.map { it.argumentType(module).classDescriptor().toClassReference() }
     }
     is Psi ->
       clazz

--- a/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/reference/FunctionReference.kt
+++ b/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/reference/FunctionReference.kt
@@ -2,10 +2,10 @@ package com.squareup.anvil.compiler.internal.reference
 
 import com.squareup.anvil.annotations.ExperimentalAnvilApi
 import com.squareup.anvil.compiler.api.AnvilCompilationException
+import com.squareup.anvil.compiler.internal.classDescriptor
 import com.squareup.anvil.compiler.internal.isInterface
 import com.squareup.anvil.compiler.internal.reference.FunctionReference.Descriptor
 import com.squareup.anvil.compiler.internal.reference.FunctionReference.Psi
-import com.squareup.anvil.compiler.internal.requireClassDescriptor
 import com.squareup.anvil.compiler.internal.requireFqName
 import com.squareup.anvil.compiler.internal.requireTypeReference
 import com.squareup.anvil.compiler.internal.resolveTypeReference
@@ -91,6 +91,6 @@ public fun FunctionReference.returnType(module: ModuleDescriptor): ClassReferenc
     is Psi -> declaringClass.resolveTypeReference(module, function.requireTypeReference(module))
       ?.requireFqName(module)
       ?.toClassReference(module)
-    is Descriptor -> function.returnType?.requireClassDescriptor()?.toClassReference()
+    is Descriptor -> function.returnType?.classDescriptor()?.toClassReference()
   } ?: throw AnvilCompilationException(message = "Couldn't find return type for $fqName.")
 }

--- a/compiler/src/main/java/com/squareup/anvil/compiler/ClassScanner.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/ClassScanner.kt
@@ -2,7 +2,7 @@ package com.squareup.anvil.compiler
 
 import com.squareup.anvil.compiler.internal.annotationOrNull
 import com.squareup.anvil.compiler.internal.argumentType
-import com.squareup.anvil.compiler.internal.requireClassDescriptor
+import com.squareup.anvil.compiler.internal.classDescriptor
 import org.jetbrains.kotlin.descriptors.ClassDescriptor
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 import org.jetbrains.kotlin.descriptors.PackageViewDescriptor
@@ -94,5 +94,5 @@ private class ContributedHint(properties: List<PropertyDescriptor>) {
   }
 
   private fun PropertyDescriptor.toClassDescriptor(): ClassDescriptor =
-    type.argumentType().requireClassDescriptor()
+    type.argumentType().classDescriptor()
 }

--- a/compiler/src/main/java/com/squareup/anvil/compiler/InterfaceMerger.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/InterfaceMerger.kt
@@ -2,16 +2,17 @@ package com.squareup.anvil.compiler
 
 import com.squareup.anvil.compiler.api.AnvilCompilationException
 import com.squareup.anvil.compiler.codegen.generatedAnvilSubcomponent
+import com.squareup.anvil.compiler.codegen.reference.RealAnvilModuleDescriptor
 import com.squareup.anvil.compiler.internal.annotation
 import com.squareup.anvil.compiler.internal.annotationOrNull
 import com.squareup.anvil.compiler.internal.argumentType
+import com.squareup.anvil.compiler.internal.classDescriptor
 import com.squareup.anvil.compiler.internal.classDescriptorOrNull
 import com.squareup.anvil.compiler.internal.getAllSuperTypes
 import com.squareup.anvil.compiler.internal.getAnnotationValue
 import com.squareup.anvil.compiler.internal.parentScope
 import com.squareup.anvil.compiler.internal.reference.replaces
 import com.squareup.anvil.compiler.internal.reference.toClassReference
-import com.squareup.anvil.compiler.internal.requireClassDescriptor
 import com.squareup.anvil.compiler.internal.requireClassId
 import com.squareup.anvil.compiler.internal.requireFqName
 import com.squareup.anvil.compiler.internal.scope
@@ -48,7 +49,7 @@ internal class InterfaceMerger(
       return
     }
 
-    val module = thisDescriptor.module
+    val module = RealAnvilModuleDescriptor(thisDescriptor.module)
 
     val scope = mergeAnnotation.scope(module)
     val scopeFqName = scope.fqNameSafe
@@ -136,7 +137,7 @@ internal class InterfaceMerger(
 
     val excludedClasses = (mergeAnnotation.getAnnotationValue("exclude") as? ArrayValue)
       ?.value
-      ?.map { it.argumentType(module).requireClassDescriptor() }
+      ?.map { it.argumentType(module).classDescriptor() }
       ?.filter { DescriptorUtils.isInterface(it) }
       ?.map { classDescriptorForExclusion ->
         val contributesToAnnotation = classDescriptorForExclusion

--- a/compiler/src/main/java/com/squareup/anvil/compiler/ModuleMerger.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/ModuleMerger.kt
@@ -6,16 +6,16 @@ import com.squareup.anvil.annotations.MergeSubcomponent
 import com.squareup.anvil.annotations.compat.MergeModules
 import com.squareup.anvil.compiler.api.AnvilCompilationException
 import com.squareup.anvil.compiler.codegen.generatedAnvilSubcomponent
+import com.squareup.anvil.compiler.codegen.reference.RealAnvilModuleDescriptor
 import com.squareup.anvil.compiler.internal.annotation
 import com.squareup.anvil.compiler.internal.annotationOrNull
 import com.squareup.anvil.compiler.internal.argumentType
+import com.squareup.anvil.compiler.internal.classDescriptor
 import com.squareup.anvil.compiler.internal.classDescriptorOrNull
 import com.squareup.anvil.compiler.internal.getAnnotationValue
 import com.squareup.anvil.compiler.internal.parentScope
 import com.squareup.anvil.compiler.internal.reference.replaces
-import com.squareup.anvil.compiler.internal.reference.scope
 import com.squareup.anvil.compiler.internal.reference.toClassReference
-import com.squareup.anvil.compiler.internal.requireClassDescriptor
 import com.squareup.anvil.compiler.internal.requireClassId
 import com.squareup.anvil.compiler.internal.requireFqName
 import com.squareup.anvil.compiler.internal.safePackageString
@@ -67,7 +67,7 @@ internal class ModuleMerger(
       )
     }
 
-    val module = thisDescriptor.module
+    val module = RealAnvilModuleDescriptor(thisDescriptor.module)
     val scope = mergeAnnotation.scope(module)
     val scopeFqName = scope.fqNameSafe
 
@@ -136,7 +136,7 @@ internal class ModuleMerger(
       ?.value
       ?.map {
         val argumentType = it.argumentType(module)
-        val classDescriptorForExclusion = argumentType.requireClassDescriptor()
+        val classDescriptorForExclusion = argumentType.classDescriptor()
 
         val contributesToAnnotation = classDescriptorForExclusion
           .annotationOrNull(contributesToFqName)

--- a/compiler/src/main/java/com/squareup/anvil/compiler/Utils.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/Utils.kt
@@ -10,12 +10,12 @@ import com.squareup.anvil.annotations.MergeSubcomponent
 import com.squareup.anvil.annotations.compat.MergeInterfaces
 import com.squareup.anvil.annotations.compat.MergeModules
 import com.squareup.anvil.compiler.internal.argumentType
+import com.squareup.anvil.compiler.internal.classDescriptor
 import com.squareup.anvil.compiler.internal.fqName
 import com.squareup.anvil.compiler.internal.getAnnotationValue
 import com.squareup.anvil.compiler.internal.reference.ClassReference
 import com.squareup.anvil.compiler.internal.reference.ClassReference.Descriptor
 import com.squareup.anvil.compiler.internal.reference.ClassReference.Psi
-import com.squareup.anvil.compiler.internal.requireClassDescriptor
 import dagger.Component
 import dagger.Lazy
 import dagger.MapKey
@@ -92,7 +92,7 @@ internal fun FqName.isAnvilModule(): Boolean {
 internal fun AnnotationDescriptor.boundTypeOrNull(module: ModuleDescriptor): ClassDescriptor? {
   return (getAnnotationValue("boundType") as? KClassValue)
     ?.argumentType(module)
-    ?.requireClassDescriptor()
+    ?.classDescriptor()
 }
 
 internal fun AnnotationDescriptor.priority(): ContributesBinding.Priority {
@@ -111,5 +111,5 @@ internal fun AnnotationDescriptor.isMapKey(): Boolean {
 internal fun ClassReference.requireClassDescriptor(module: ModuleDescriptor): ClassDescriptor =
   when (this) {
     is Descriptor -> clazz
-    is Psi -> fqName.requireClassDescriptor(module)
+    is Psi -> fqName.classDescriptor(module)
   }

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributedBinding.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributedBinding.kt
@@ -8,6 +8,7 @@ import com.squareup.anvil.compiler.injectFqName
 import com.squareup.anvil.compiler.internal.annotation
 import com.squareup.anvil.compiler.internal.argumentType
 import com.squareup.anvil.compiler.internal.asClassName
+import com.squareup.anvil.compiler.internal.classDescriptor
 import com.squareup.anvil.compiler.internal.isMapKey
 import com.squareup.anvil.compiler.internal.isObject
 import com.squareup.anvil.compiler.internal.isQualifier
@@ -19,7 +20,6 @@ import com.squareup.anvil.compiler.internal.reference.directSuperClassReferences
 import com.squareup.anvil.compiler.internal.reference.getKtClassOrObject
 import com.squareup.anvil.compiler.internal.reference.qualifiers
 import com.squareup.anvil.compiler.internal.requireAnnotation
-import com.squareup.anvil.compiler.internal.requireClassDescriptor
 import com.squareup.anvil.compiler.internal.requireFqName
 import com.squareup.anvil.compiler.internal.toAnnotationSpec
 import com.squareup.anvil.compiler.isMapKey
@@ -237,7 +237,7 @@ private fun KtClassOrObject.qualifiersKey(
       val descriptor = annotationEntry.typeReference
         ?.requireFqName(module)
         ?.takeIf { it != injectFqName }
-        ?.requireClassDescriptor(module)
+        ?.classDescriptor(module)
         ?.takeIf { it.annotations.hasAnnotation(qualifierFqName) }
         ?: return@mapNotNull null
       annotationEntry to descriptor
@@ -297,7 +297,7 @@ private fun ClassDescriptor.qualifiersKey(
         .map { (name, value) ->
           val valueString = when (value) {
             is KClassValue -> value.argumentType(module)
-              .requireClassDescriptor().fqNameSafe.asString()
+              .classDescriptor().fqNameSafe.asString()
             is EnumValue -> value.enumEntryName.asString()
             // String, int, long, ... other primitives.
             else -> value.toString()

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesBindingGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesBindingGenerator.kt
@@ -12,14 +12,12 @@ import com.squareup.anvil.compiler.api.createGeneratedFile
 import com.squareup.anvil.compiler.contributesBindingFqName
 import com.squareup.anvil.compiler.internal.asClassName
 import com.squareup.anvil.compiler.internal.buildFile
+import com.squareup.anvil.compiler.internal.classDescriptor
 import com.squareup.anvil.compiler.internal.fqNameOrNull
 import com.squareup.anvil.compiler.internal.generateClassName
 import com.squareup.anvil.compiler.internal.hasAnnotation
 import com.squareup.anvil.compiler.internal.isQualifier
-import com.squareup.anvil.compiler.internal.reference.asClassName
 import com.squareup.anvil.compiler.internal.reference.classesAndInnerClasses
-import com.squareup.anvil.compiler.internal.reference.scope
-import com.squareup.anvil.compiler.internal.requireClassDescriptor
 import com.squareup.anvil.compiler.internal.requireFqName
 import com.squareup.anvil.compiler.internal.safePackageString
 import com.squareup.anvil.compiler.internal.scope
@@ -172,7 +170,7 @@ internal fun KtClassOrObject.checkClassExtendsBoundType(
   val hasSuperTypePsi = superTypeListEntries.any { it.fqNameOrNull(module) == boundType }
   if (hasSuperTypePsi) return
 
-  val descriptor = requireClassDescriptor(module)
+  val descriptor = classDescriptor(module)
   val hasSuperType = descriptor.getAllSuperClassifiers()
     .any { it.fqNameSafe == boundType }
 

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesMultibindingGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesMultibindingGenerator.kt
@@ -12,12 +12,10 @@ import com.squareup.anvil.compiler.api.createGeneratedFile
 import com.squareup.anvil.compiler.contributesMultibindingFqName
 import com.squareup.anvil.compiler.internal.asClassName
 import com.squareup.anvil.compiler.internal.buildFile
+import com.squareup.anvil.compiler.internal.classDescriptor
 import com.squareup.anvil.compiler.internal.generateClassName
 import com.squareup.anvil.compiler.internal.hasAnnotation
-import com.squareup.anvil.compiler.internal.reference.asClassName
 import com.squareup.anvil.compiler.internal.reference.classesAndInnerClasses
-import com.squareup.anvil.compiler.internal.reference.scope
-import com.squareup.anvil.compiler.internal.requireClassDescriptor
 import com.squareup.anvil.compiler.internal.requireFqName
 import com.squareup.anvil.compiler.internal.safePackageString
 import com.squareup.anvil.compiler.internal.scope
@@ -110,7 +108,7 @@ private fun KtClassOrObject.checkNotMoreThanOneMapKey(
   // annotations, then there can't be more than two map keys.
   if (annotationEntries.size <= 2) return
 
-  val mapKeys = requireClassDescriptor(module).annotations.filter { it.isMapKey() }
+  val mapKeys = classDescriptor(module).annotations.filter { it.isMapKey() }
 
   if (mapKeys.size > 1) {
     throw AnvilCompilationException(

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/DescriptorUtils.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/DescriptorUtils.kt
@@ -6,9 +6,9 @@ import com.squareup.anvil.compiler.injectFqName
 import com.squareup.anvil.compiler.internal.argumentType
 import com.squareup.anvil.compiler.internal.asTypeName
 import com.squareup.anvil.compiler.internal.capitalize
+import com.squareup.anvil.compiler.internal.classDescriptor
 import com.squareup.anvil.compiler.internal.classDescriptorOrNull
 import com.squareup.anvil.compiler.internal.isQualifier
-import com.squareup.anvil.compiler.internal.requireClassDescriptor
 import com.squareup.anvil.compiler.internal.toAnnotationSpec
 import com.squareup.anvil.compiler.internal.withJvmSuppressWildcardsIfNeeded
 import com.squareup.anvil.compiler.providerFqName
@@ -50,7 +50,7 @@ fun PropertyDescriptor.isSetterInjected(): Boolean {
 
 fun KotlinType.fqNameOrNull(): FqName? = classDescriptorOrNull()?.fqNameOrNull()
 
-fun KotlinType.fqName(): FqName = requireClassDescriptor().fqNameSafe
+fun KotlinType.fqName(): FqName = classDescriptor().fqNameSafe
 
 internal fun List<CallableMemberDescriptor>.mapToMemberInjectParameters(
   module: ModuleDescriptor,

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/reference/RealAnvilModuleDescriptor.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/reference/RealAnvilModuleDescriptor.kt
@@ -1,10 +1,12 @@
 package com.squareup.anvil.compiler.codegen.reference
 
+import com.squareup.anvil.compiler.internal.classIdBestGuess
 import com.squareup.anvil.compiler.internal.reference.AnvilModuleDescriptor
+import org.jetbrains.kotlin.descriptors.ClassDescriptor
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 import org.jetbrains.kotlin.descriptors.findTypeAliasAcrossModuleDependencies
 import org.jetbrains.kotlin.descriptors.resolveClassByFqName
-import org.jetbrains.kotlin.incremental.components.NoLookupLocation.FROM_BACKEND
+import org.jetbrains.kotlin.incremental.components.LookupLocation
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.psi.KtClassOrObject
@@ -21,6 +23,7 @@ class RealAnvilModuleDescriptor(
   private val allClasses: Sequence<KtClassOrObject>
     get() = classesMap.values.asSequence().flatMap { it }
 
+  private val resolveDescriptorCache = mutableMapOf<FqName, ClassDescriptor?>()
   private val resolveClassIdCache = mutableMapOf<ClassId, FqName?>()
 
   fun addFiles(files: Collection<KtFile>) {
@@ -41,10 +44,20 @@ class RealAnvilModuleDescriptor(
     resolveClassIdCache.computeIfAbsent(classId) {
       val fqName = classId.asSingleFqName()
 
-      resolveClassByFqName(fqName, FROM_BACKEND)?.fqNameSafe
-        ?: findTypeAliasAcrossModuleDependencies(classId)?.fqNameSafe
+      resolveFqNameOrNull(fqName)?.fqNameSafe
         ?: allClasses.firstOrNull { it.fqName == fqName }?.fqName
     }
+
+  override fun resolveFqNameOrNull(
+    fqName: FqName,
+    lookupLocation: LookupLocation
+  ): ClassDescriptor? {
+    return resolveDescriptorCache.computeIfAbsent(fqName) {
+      // In the case of a typealias, we need to look up the original reference instead.
+      resolveClassByFqName(fqName, lookupLocation)
+        ?: findTypeAliasAcrossModuleDependencies(fqName.classIdBestGuess())?.classDescriptor
+    }
+  }
 
   override fun getKtClassOrObjectOrNull(fqName: FqName): KtClassOrObject? {
     return allClasses.firstOrNull { it.fqName == fqName }


### PR DESCRIPTION
Cache the results, because these operations are heavy and can add up.