### PR TITLE
Cache instances of `ClassReference`, `AnnotationReference` and `FunctionReference`

### DIFF
--- a/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/PsiUtils.kt
+++ b/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/PsiUtils.kt
@@ -639,7 +639,7 @@ public fun KtClassOrObject.resolveTypeReference(
   typeReference.typeElement?.fqNameOrNull(module)
     ?.let { return typeReference }
 
-  val declaringClass = typeReference.requireContainingClassReference()
+  val declaringClass = typeReference.requireContainingClassReference(module)
   val parameterName = typeReference.text
 
   return resolveGenericTypeReference(module, declaringClass, parameterName)
@@ -754,8 +754,8 @@ public fun KtClassOrObject.superTypeListEntryOrNull(
   module: ModuleDescriptor,
   superTypeFqName: FqName
 ): KtSuperTypeListEntry? {
-  return toClassReference()
-    .allSuperTypeClassReferences(module, includeSelf = true)
+  return toClassReference(module)
+    .allSuperTypeClassReferences(includeSelf = true)
     .filterIsInstance<Psi>()
     .firstNotNullOfOrNull { classReference ->
       classReference.clazz
@@ -877,15 +877,19 @@ public fun KtClassOrObject.generateClassName(
     }
 
 @ExperimentalAnvilApi
-public fun KtTypeReference.containingClassReferenceOrNull(): ClassReference? {
+public fun KtTypeReference.containingClassReferenceOrNull(
+  module: ModuleDescriptor
+): ClassReference? {
   return typeElement
     ?.containingClass()
-    ?.toClassReference()
+    ?.toClassReference(module)
 }
 
 @ExperimentalAnvilApi
-public fun KtTypeReference.requireContainingClassReference(): ClassReference {
-  return containingClassReferenceOrNull()
+public fun KtTypeReference.requireContainingClassReference(
+  module: ModuleDescriptor
+): ClassReference {
+  return containingClassReferenceOrNull(module)
     ?: throw AnvilCompilationException(
       "Unable to find a containing class.",
       element = this

--- a/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/reference/AnvilModuleDescriptor.kt
+++ b/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/reference/AnvilModuleDescriptor.kt
@@ -3,6 +3,8 @@ package com.squareup.anvil.compiler.internal.reference
 import com.squareup.anvil.annotations.ExperimentalAnvilApi
 import com.squareup.anvil.compiler.api.AnvilCompilationException
 import com.squareup.anvil.compiler.internal.classIdBestGuess
+import com.squareup.anvil.compiler.internal.reference.ClassReference.Descriptor
+import com.squareup.anvil.compiler.internal.reference.ClassReference.Psi
 import org.jetbrains.kotlin.descriptors.ClassDescriptor
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 import org.jetbrains.kotlin.incremental.components.LookupLocation
@@ -24,6 +26,12 @@ public interface AnvilModuleDescriptor : ModuleDescriptor {
   public fun getClassesAndInnerClasses(ktFile: KtFile): List<KtClassOrObject>
 
   public fun getKtClassOrObjectOrNull(fqName: FqName): KtClassOrObject?
+
+  public fun getClassReference(clazz: KtClassOrObject): Psi
+
+  public fun getClassReference(descriptor: ClassDescriptor): Descriptor
+
+  public fun getClassReferenceOrNull(fqName: FqName): ClassReference?
 }
 
 @Suppress("NOTHING_TO_INLINE")

--- a/compiler/src/main/java/com/squareup/anvil/compiler/InterfaceMerger.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/InterfaceMerger.kt
@@ -89,8 +89,8 @@ internal class InterfaceMerger(
 
     val replacedClasses = classes
       .flatMap { (classDescriptor, contributeAnnotation) ->
-        classDescriptor.toClassReference()
-          .replaces(module, contributeAnnotation.requireFqName())
+        classDescriptor.toClassReference(module)
+          .replaces(contributeAnnotation.requireFqName())
           .map { it.requireClassDescriptor(module) }
           .onEach { classDescriptorForReplacement ->
             // Verify the other class is an interface. It doesn't make sense for a contributed

--- a/compiler/src/main/java/com/squareup/anvil/compiler/ModuleMerger.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/ModuleMerger.kt
@@ -177,8 +177,8 @@ internal class ModuleMerger(
         classDescriptor.defaultType.asmType(codegen.typeMapper) !in excludedModules
       }
       .flatMap { (classDescriptor, contributeAnnotation) ->
-        classDescriptor.toClassReference()
-          .replaces(module, contributeAnnotation.requireFqName())
+        classDescriptor.toClassReference(module)
+          .replaces(contributeAnnotation.requireFqName())
           .map { it.requireClassDescriptor(module) }
           .map { classDescriptorForReplacement ->
             // Verify has @Module annotation. It doesn't make sense for a Dagger module to
@@ -215,8 +215,8 @@ internal class ModuleMerger(
         .flatMap { contributedClass ->
           val annotation = contributedClass.annotation(annotationFqName)
           if (scopeFqName == annotation.scope(module).fqNameSafe) {
-            contributedClass.toClassReference()
-              .replaces(module, annotationFqName)
+            contributedClass.toClassReference(module)
+              .replaces(annotationFqName)
               .map { it.requireClassDescriptor(module) }
               .map { classDescriptorForReplacement ->
                 checkSameScope(

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/BindingModuleGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/BindingModuleGenerator.kt
@@ -171,7 +171,7 @@ internal class BindingModuleGenerator(
         // Ignore replaced bindings specified by excluded modules for this scope.
         .filter { it.fqName !in excludedNames }
         .flatMap { clazz ->
-          clazz.toClassReference().replaces(module, contributesToFqName).map { it.fqName }
+          clazz.toClassReference(module).replaces(contributesToFqName).map { it.fqName }
         }
         .plus(
           classScanner
@@ -185,7 +185,7 @@ internal class BindingModuleGenerator(
             // Ignore replaced bindings specified by excluded modules for this scope.
             .filter { it.fqNameSafe !in excludedNames }
             .flatMap {
-              it.toClassReference().replaces(module, contributesToFqName)
+              it.toClassReference(module).replaces(contributesToFqName)
             }
             .map { it.fqName }
         )
@@ -207,7 +207,7 @@ internal class BindingModuleGenerator(
           packageName = hintPackagePrefix,
           annotation = annotationFqName,
           scope = scope
-        ).map { it.toClassReference() }
+        ).map { it.toClassReference(module) }
 
         val allContributedClasses = collectedClasses
           .map { name -> name.toClassReference(module) }
@@ -215,7 +215,7 @@ internal class BindingModuleGenerator(
 
         val replacedBindings = allContributedClasses
           .flatMap { classReference ->
-            classReference.replaces(module, annotationFqName).map { it.fqName }
+            classReference.replaces(annotationFqName).map { it.fqName }
           }
 
         return allContributedClasses
@@ -223,7 +223,7 @@ internal class BindingModuleGenerator(
           .filterNot { it.fqName in replacedBindings }
           .filterNot { it.fqName in bindingsReplacedInDaggerModules }
           .filterNot { it.fqName in excludedNames }
-          .filter { scope == it.scopeOrNull(module, annotationFqName) }
+          .filter { scope == it.scopeOrNull(annotationFqName) }
           .map {
             it.toContributedBinding(
               module = module,

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributedBinding.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributedBinding.kt
@@ -68,7 +68,7 @@ internal fun ClassReference.toContributedBinding(
   val qualifiers = if (ignoreQualifier) {
     emptyList()
   } else {
-    qualifiers(module)
+    qualifiers()
   }
 
   val boundTypeClassName = when (boundType) {
@@ -100,7 +100,7 @@ private fun ClassReference.requireBoundType(
 
   if (boundFromAnnotation != null) {
     // ensure that the bound type is actually a supertype of the contributing class
-    val boundType = allSuperTypeClassReferences(module)
+    val boundType = allSuperTypeClassReferences()
       .firstOrNull { it.fqName == boundFromAnnotation }
       ?: throw AnvilCompilationException(
         "$fqName contributes a binding for $boundFromAnnotation, but doesn't extend this type."
@@ -112,7 +112,7 @@ private fun ClassReference.requireBoundType(
 
   // If there's no bound type in the annotation,
   // it must be the only supertype of the contributing class
-  val boundType = directSuperClassReferences(module).singleOrNull()
+  val boundType = directSuperClassReferences().singleOrNull()
     ?: throw AnvilCompilationException(
       message = "$annotationFqName contributes a binding, but does not " +
         "specify the bound type. This is only allowed with exactly one direct super type. " +

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesSubcomponentGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesSubcomponentGenerator.kt
@@ -23,7 +23,6 @@ import com.squareup.anvil.compiler.internal.hasAnnotation
 import com.squareup.anvil.compiler.internal.isInterface
 import com.squareup.anvil.compiler.internal.parentScope
 import com.squareup.anvil.compiler.internal.reference.ClassReference
-import com.squareup.anvil.compiler.internal.reference.annotations
 import com.squareup.anvil.compiler.internal.reference.classesAndInnerClasses
 import com.squareup.anvil.compiler.internal.reference.replaces
 import com.squareup.anvil.compiler.internal.reference.scope
@@ -245,7 +244,7 @@ internal class ContributesSubcomponentGenerator : CodeGenerator {
     scope: FqName,
     subcomponent: KtClassOrObject
   ) {
-    annotations()
+    annotations
       .filter { it.fqName == contributesSubcomponentFqName }
       .ifEmpty {
         throw AnvilCompilationException(

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesSubcomponentGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesSubcomponentGenerator.kt
@@ -85,10 +85,10 @@ internal class ContributesSubcomponentGenerator : CodeGenerator {
 
         val scope = clazz.scope(contributesSubcomponentFqName, module)
 
-        clazz.toClassReference()
-          .replaces(module, contributesSubcomponentFqName)
+        clazz.toClassReference(module)
+          .replaces(contributesSubcomponentFqName)
           .onEach {
-            it.checkUsesSameScope(scope, clazz, module)
+            it.checkUsesSameScope(scope, clazz)
           }
       }
       .map { clazz ->
@@ -243,10 +243,9 @@ internal class ContributesSubcomponentGenerator : CodeGenerator {
 
   private fun ClassReference.checkUsesSameScope(
     scope: FqName,
-    subcomponent: KtClassOrObject,
-    module: ModuleDescriptor
+    subcomponent: KtClassOrObject
   ) {
-    annotations(module)
+    annotations()
       .filter { it.fqName == contributesSubcomponentFqName }
       .ifEmpty {
         throw AnvilCompilationException(
@@ -255,7 +254,7 @@ internal class ContributesSubcomponentGenerator : CodeGenerator {
         )
       }
       .forEach { annotation ->
-        val otherScope = annotation.scope(module).fqName
+        val otherScope = annotation.scope().fqName
         if (otherScope != scope) {
           throw AnvilCompilationException(
             element = subcomponent,

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesSubcomponentHandlerGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesSubcomponentHandlerGenerator.kt
@@ -28,11 +28,9 @@ import com.squareup.anvil.compiler.internal.parentScope
 import com.squareup.anvil.compiler.internal.reference.AnvilCompilationExceptionClassReference
 import com.squareup.anvil.compiler.internal.reference.ClassReference
 import com.squareup.anvil.compiler.internal.reference.FunctionReference
-import com.squareup.anvil.compiler.internal.reference.annotations
 import com.squareup.anvil.compiler.internal.reference.asClassName
 import com.squareup.anvil.compiler.internal.reference.classesAndInnerClasses
 import com.squareup.anvil.compiler.internal.reference.daggerScopes
-import com.squareup.anvil.compiler.internal.reference.functions
 import com.squareup.anvil.compiler.internal.reference.innerClasses
 import com.squareup.anvil.compiler.internal.reference.isAbstract
 import com.squareup.anvil.compiler.internal.reference.isAbstractClass
@@ -338,7 +336,7 @@ internal class ContributesSubcomponentHandlerGenerator(
       .innerClasses()
       .filter { it.isInterface() }
       .filter { classReference ->
-        classReference.annotations()
+        classReference.annotations
           .any {
             it.fqName == contributesToFqName && it.scope().fqName == contribution.parentScope
           }
@@ -355,7 +353,7 @@ internal class ContributesSubcomponentHandlerGenerator(
       )
     }
 
-    val functions = componentInterface.functions()
+    val functions = componentInterface.functions
       .filter { it.isAbstract() && it.isPublic() }
       .filter {
         val returnType = it.returnType().fqName
@@ -383,7 +381,7 @@ internal class ContributesSubcomponentHandlerGenerator(
     val contributedFactories = contribution.classReference
       .innerClasses()
       .filter { classReference ->
-        classReference.annotations().any { it.fqName == contributesSubcomponentFactoryFqName }
+        classReference.annotations.any { it.fqName == contributesSubcomponentFactoryFqName }
       }
       .onEach { factory ->
         if (!factory.isInterface() && !factory.isAbstractClass()) {
@@ -393,7 +391,7 @@ internal class ContributesSubcomponentHandlerGenerator(
           )
         }
 
-        val createComponentFunctions = factory.functions()
+        val createComponentFunctions = factory.functions
           .filter { it.isAbstract() }
           .filter { it.returnType().fqName == contributionFqName }
 

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesSubcomponentHandlerGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesSubcomponentHandlerGenerator.kt
@@ -146,7 +146,7 @@ internal class ContributesSubcomponentHandlerGenerator(
           ?: emptyList()
 
         Contribution(
-          classReference = clazz.toClassReference(),
+          classReference = clazz.toClassReference(module),
           scope = clazz.scope(contributesSubcomponentFqName, module),
           parentScope = clazz.parentScope(contributesSubcomponentFqName, module),
           modules = modules,
@@ -157,7 +157,7 @@ internal class ContributesSubcomponentHandlerGenerator(
       .also { contributions ->
         // Find all replaced subcomponents and remember them.
         replacedReferences += contributions.flatMap { contribution ->
-          contribution.classReference.replaces(module, contributesSubcomponentFqName)
+          contribution.classReference.replaces(contributesSubcomponentFqName)
             .also {
               checkReplacedSubcomponentWasNotAlreadyGenerated(contribution.classReference, it)
             }
@@ -192,7 +192,7 @@ internal class ContributesSubcomponentHandlerGenerator(
         val generatedPackage = generatedAnvilSubcomponent.packageFqName.asString()
         val componentClassName = generatedAnvilSubcomponent.relativeClassName.asString()
 
-        val factoryClass = findFactoryClass(contribution, generatedAnvilSubcomponent, module)
+        val factoryClass = findFactoryClass(contribution, generatedAnvilSubcomponent)
 
         val content = FileSpec.buildFile(generatedPackage, componentClassName) {
           TypeSpec
@@ -221,7 +221,7 @@ internal class ContributesSubcomponentHandlerGenerator(
                 }
                 .build()
             )
-            .addAnnotations(contribution.classReference.daggerScopes(module))
+            .addAnnotations(contribution.classReference.daggerScopes())
             .apply {
               if (factoryClass != null) {
                 addType(generateFactory(factoryClass.originalReference))
@@ -230,7 +230,7 @@ internal class ContributesSubcomponentHandlerGenerator(
             }
             .addType(
               generateParentComponent(
-                contribution, generatedAnvilSubcomponent, module, factoryClass
+                contribution, generatedAnvilSubcomponent, factoryClass
               )
             )
             .build()
@@ -290,11 +290,10 @@ internal class ContributesSubcomponentHandlerGenerator(
   private fun generateParentComponent(
     contribution: Contribution,
     generatedAnvilSubcomponent: ClassId,
-    module: ModuleDescriptor,
     factoryClass: FactoryClassHolder?,
   ): TypeSpec {
     val parentComponentInterface = findParentComponentInterface(
-      contribution, module, factoryClass?.originalReference?.fqName
+      contribution, factoryClass?.originalReference?.fqName
     )
 
     return TypeSpec
@@ -331,7 +330,6 @@ internal class ContributesSubcomponentHandlerGenerator(
 
   private fun findParentComponentInterface(
     contribution: Contribution,
-    module: ModuleDescriptor,
     factoryClass: FqName?
   ): ParentComponentInterfaceHolder? {
     val contributionFqName = contribution.clazzFqName
@@ -340,9 +338,9 @@ internal class ContributesSubcomponentHandlerGenerator(
       .innerClasses()
       .filter { it.isInterface() }
       .filter { classReference ->
-        classReference.annotations(module)
+        classReference.annotations()
           .any {
-            it.fqName == contributesToFqName && it.scope(module).fqName == contribution.parentScope
+            it.fqName == contributesToFqName && it.scope().fqName == contribution.parentScope
           }
       }
       .toList()
@@ -360,7 +358,7 @@ internal class ContributesSubcomponentHandlerGenerator(
     val functions = componentInterface.functions()
       .filter { it.isAbstract() && it.isPublic() }
       .filter {
-        val returnType = it.returnType(module).fqName
+        val returnType = it.returnType().fqName
         returnType == contributionFqName || (factoryClass != null && returnType == factoryClass)
       }
 
@@ -378,15 +376,14 @@ internal class ContributesSubcomponentHandlerGenerator(
 
   private fun findFactoryClass(
     contribution: Contribution,
-    generatedAnvilSubcomponent: ClassId,
-    module: ModuleDescriptor
+    generatedAnvilSubcomponent: ClassId
   ): FactoryClassHolder? {
     val contributionFqName = contribution.clazzFqName
 
     val contributedFactories = contribution.classReference
       .innerClasses()
       .filter { classReference ->
-        classReference.annotations(module).any { it.fqName == contributesSubcomponentFactoryFqName }
+        classReference.annotations().any { it.fqName == contributesSubcomponentFactoryFqName }
       }
       .onEach { factory ->
         if (!factory.isInterface() && !factory.isAbstractClass()) {
@@ -398,7 +395,7 @@ internal class ContributesSubcomponentHandlerGenerator(
 
         val createComponentFunctions = factory.functions()
           .filter { it.isAbstract() }
-          .filter { it.returnType(module).fqName == contributionFqName }
+          .filter { it.returnType().fqName == contributionFqName }
 
         if (createComponentFunctions.size != 1) {
           throw AnvilCompilationExceptionClassReference(
@@ -469,7 +466,7 @@ internal class ContributesSubcomponentHandlerGenerator(
           ?: emptyList()
 
         Contribution(
-          classReference = descriptor.toClassReference(),
+          classReference = descriptor.toClassReference(module),
           scope = annotation.scope(module).fqNameSafe,
           parentScope = annotation.parentScope(module).fqNameSafe,
           modules = modules,
@@ -480,7 +477,7 @@ internal class ContributesSubcomponentHandlerGenerator(
     // Find all replaced subcomponents from precompiled dependencies.
     replacedReferences += contributions
       .flatMap {
-        it.classReference.replaces(module, contributesSubcomponentFqName)
+        it.classReference.replaces(contributesSubcomponentFqName)
       }
   }
 

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/AssistedFactoryGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/AssistedFactoryGenerator.kt
@@ -311,7 +311,7 @@ internal class AssistedFactoryGenerator : PrivateCodeGenerator() {
             ?.fqNameSafe
             ?: factoryClass.resolveGenericKotlinType(
               module,
-              containingClass.toClassReference(),
+              containingClass.toClassReference(module),
               returnType ?: fail()
             )?.fqNameOrNull(module)
             ?: fail()
@@ -326,7 +326,7 @@ internal class AssistedFactoryGenerator : PrivateCodeGenerator() {
               ?.asTypeName()
               ?: factoryClass.resolveGenericKotlinType(
                 module,
-                containingClass.toClassReference(),
+                containingClass.toClassReference(module),
                 param.type
               )?.requireTypeName(module)
               ?: throw AnvilCompilationException(
@@ -426,8 +426,8 @@ internal class AssistedFactoryGenerator : PrivateCodeGenerator() {
     // `clazz` must be first in the list because of `distinctBy { ... }`, which keeps the first
     // matched element.  If the function's inherited, it can be overridden as well.  Prioritizing
     // the version from the file we're parsing ensures the correct variance of the referenced types.
-    val assistedFunctions = toClassReference()
-      .allSuperTypeClassReferences(module, includeSelf = true)
+    val assistedFunctions = toClassReference(module)
+      .allSuperTypeClassReferences(includeSelf = true)
       .distinctBy { it.fqName }
       .flatMap { it.assistedFunctions() }
       .distinctBy { it.name }
@@ -483,7 +483,7 @@ internal class AssistedFactoryGenerator : PrivateCodeGenerator() {
             ?.asTypeNameOrNull()
             ?: factoryClass.resolveGenericKotlinType(
               module = module,
-              declaringClass = containingClass.toClassReference(),
+              declaringClass = containingClass.toClassReference(module),
               typeToResolve = descriptor.type
             )?.requireTypeName(module)
             ?: throw AnvilCompilationException(

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/MembersInjectionUtils.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/MembersInjectionUtils.kt
@@ -88,8 +88,8 @@ internal fun KtClassOrObject.memberInjectParameters(
   module: ModuleDescriptor,
   inheritedOnly: Boolean = false
 ): List<MemberInjectParameter> {
-  return toClassReference()
-    .allSuperTypeClassReferences(module, includeSelf = !inheritedOnly)
+  return toClassReference(module)
+    .allSuperTypeClassReferences(includeSelf = !inheritedOnly)
     .filterNot { it.isInterface() }
     .toList()
     .foldRight(listOf()) { classReference, acc ->


### PR DESCRIPTION
This avoid parsing / resolving the types and symbols over and over again. 