### PR TITLE
Suppress errors for experimental APIs in generated code.

### DIFF
--- a/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/KotlinPoetUtils.kt
+++ b/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/KotlinPoetUtils.kt
@@ -315,7 +315,23 @@ private fun FileSpec.writeToString(): String {
 }
 
 private fun FileSpec.Builder.suppressWarnings() {
-  addAnnotation(AnnotationSpec.builder(Suppress::class).addMember("\"DEPRECATION\"").build())
+  addAnnotation(
+    AnnotationSpec
+      .builder(Suppress::class)
+      // Suppress deprecation warnings.
+      .addMember("\"DEPRECATION\"")
+      // Suppress errors for experimental features in generated code.
+      .apply {
+        if (KotlinVersion.CURRENT > KotlinVersion(1, 6, 10)) {
+          addMember("\"OPT_IN_USAGE\"")
+          addMember("\"OPT_IN_USAGE_ERROR\"")
+        } else {
+          addMember("\"EXPERIMENTAL_API_USAGE_ERROR\"")
+          addMember("\"EXPERIMENTAL_API_USAGE\"")
+        }
+      }
+      .build()
+  )
 }
 
 @ExperimentalAnvilApi

--- a/compiler/src/test/java/com/squareup/anvil/compiler/codegen/CodeGenerationExtensionTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/codegen/CodeGenerationExtensionTest.kt
@@ -154,4 +154,31 @@ class CodeGenerationExtensionTest {
       assertThat(generateCodeCalled).isFalse()
     }
   }
+
+  @Test fun `errors that require an opt-in annotation are suppressed in generated code`() {
+    compile(
+      """
+      package com.squareup.test
+
+      import com.squareup.anvil.annotations.ContributesBinding
+      import javax.inject.Inject
+
+      @Retention(AnnotationRetention.BINARY)
+      @RequiresOptIn(
+          message = "",
+          level = RequiresOptIn.Level.ERROR
+      )
+      @MustBeDocumented
+      annotation class InternalApi
+
+      interface Type
+
+      @InternalApi
+      @ContributesBinding(Unit::class)
+      class SomeClass @Inject constructor() : Type 
+      """
+    ) {
+      assertThat(exitCode).isEqualTo(OK)
+    }
+  }
 }


### PR DESCRIPTION
It's impossible to suppress these errors in generated code on the file level for the user, so we must opt-out of all these checks. It's not a bad thing, because the user already must opt-into these features on the usage side.

Fixes #488.