### PR TITLE
Convert `AssistedFactoryGenerator` to rely on `ClassReference` only. 

### DIFF
--- a/compiler-api/src/main/java/com/squareup/anvil/compiler/api/AnvilCompilationException.kt
+++ b/compiler-api/src/main/java/com/squareup/anvil/compiler/api/AnvilCompilationException.kt
@@ -4,7 +4,9 @@ import org.jetbrains.kotlin.codegen.CompilationException
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.com.intellij.psi.PsiNameIdentifierOwner
 import org.jetbrains.kotlin.descriptors.ClassDescriptor
+import org.jetbrains.kotlin.descriptors.DeclarationDescriptorWithSource
 import org.jetbrains.kotlin.descriptors.FunctionDescriptor
+import org.jetbrains.kotlin.descriptors.ValueParameterDescriptor
 import org.jetbrains.kotlin.descriptors.annotations.AnnotationDescriptor
 import org.jetbrains.kotlin.ir.IrElement
 import org.jetbrains.kotlin.ir.declarations.IrClass
@@ -46,6 +48,18 @@ public class AnvilCompilationException(
         message = message,
         cause = cause,
         element = functionDescriptor.identifier
+      )
+    }
+
+    public operator fun invoke(
+      parameterDescriptor: ValueParameterDescriptor,
+      message: String,
+      cause: Throwable? = null
+    ): AnvilCompilationException {
+      return AnvilCompilationException(
+        message = message,
+        cause = cause,
+        element = parameterDescriptor.identifier
       )
     }
 
@@ -102,7 +116,7 @@ private val ClassDescriptor.identifier: PsiElement?
 private val AnnotationDescriptor.identifier: PsiElement?
   get() = (source as? KotlinSourceElement)?.psi
 
-private val FunctionDescriptor.identifier: PsiElement?
+private val DeclarationDescriptorWithSource.identifier: PsiElement?
   get() = (source as? KotlinSourceElement)?.psi
 
 private val IrElement.psi: PsiElement?

--- a/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/reference/AnvilModuleDescriptor.kt
+++ b/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/reference/AnvilModuleDescriptor.kt
@@ -51,17 +51,6 @@ public fun FqName.canResolveFqName(
 ): Boolean = module.asAnvilModuleDescriptor().resolveClassIdOrNull(classIdBestGuess()) != null
 
 @ExperimentalAnvilApi
-@Deprecated(
-  message = "Use ClassReference instead.",
-  replaceWith = ReplaceWith("classAndInnerClassReferences(module)")
-)
-public fun Collection<KtFile>.classesAndInnerClasses(
-  module: ModuleDescriptor
-): Sequence<KtClassOrObject> {
-  return classAndInnerClassReferences(module).map { it.clazz }
-}
-
-@ExperimentalAnvilApi
 public fun Collection<KtFile>.classAndInnerClassReferences(
   module: ModuleDescriptor
 ): Sequence<Psi> {

--- a/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/reference/ClassReference.kt
+++ b/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/reference/ClassReference.kt
@@ -4,6 +4,7 @@ import com.squareup.anvil.annotations.ExperimentalAnvilApi
 import com.squareup.anvil.compiler.api.AnvilCompilationException
 import com.squareup.anvil.compiler.internal.annotationOrNull
 import com.squareup.anvil.compiler.internal.asClassName
+import com.squareup.anvil.compiler.internal.fqNameOrNull
 import com.squareup.anvil.compiler.internal.functions
 import com.squareup.anvil.compiler.internal.properties
 import com.squareup.anvil.compiler.internal.reference.ClassReference.Descriptor
@@ -12,12 +13,15 @@ import com.squareup.anvil.compiler.internal.reference.Visibility.INTERNAL
 import com.squareup.anvil.compiler.internal.reference.Visibility.PRIVATE
 import com.squareup.anvil.compiler.internal.reference.Visibility.PROTECTED
 import com.squareup.anvil.compiler.internal.reference.Visibility.PUBLIC
+import com.squareup.anvil.compiler.internal.requireContainingClassReference
 import com.squareup.anvil.compiler.internal.requireFqName
 import com.squareup.anvil.compiler.internal.scope
 import com.squareup.anvil.compiler.internal.scopeOrNull
+import com.squareup.anvil.compiler.internal.superTypeListEntryOrNull
 import com.squareup.kotlinpoet.ClassName
 import org.jetbrains.kotlin.descriptors.ClassDescriptor
 import org.jetbrains.kotlin.descriptors.ClassKind
+import org.jetbrains.kotlin.descriptors.ConstructorDescriptor
 import org.jetbrains.kotlin.descriptors.DescriptorVisibilities
 import org.jetbrains.kotlin.descriptors.FunctionDescriptor
 import org.jetbrains.kotlin.descriptors.Modality.ABSTRACT
@@ -33,6 +37,10 @@ import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.psi.KtObjectDeclaration
+import org.jetbrains.kotlin.psi.KtTypeArgumentList
+import org.jetbrains.kotlin.psi.KtTypeReference
+import org.jetbrains.kotlin.psi.allConstructors
+import org.jetbrains.kotlin.psi.psiUtil.getChildOfType
 import org.jetbrains.kotlin.psi.psiUtil.parents
 import org.jetbrains.kotlin.psi.psiUtil.visibilityModifierTypeOrDefault
 import org.jetbrains.kotlin.resolve.DescriptorUtils
@@ -42,6 +50,9 @@ import org.jetbrains.kotlin.resolve.descriptorUtil.getSuperInterfaces
 import org.jetbrains.kotlin.resolve.descriptorUtil.parents
 import org.jetbrains.kotlin.resolve.scopes.DescriptorKindFilter
 import org.jetbrains.kotlin.resolve.scopes.getDescriptorsFiltered
+import org.jetbrains.kotlin.types.DefinitelyNotNullType
+import org.jetbrains.kotlin.types.FlexibleType
+import org.jetbrains.kotlin.types.KotlinType
 import org.jetbrains.kotlin.utils.addToStdlib.cast
 import kotlin.LazyThreadSafetyMode.NONE
 
@@ -61,6 +72,7 @@ public sealed class ClassReference {
   public val shortName: String get() = fqName.shortName().asString()
   public val packageFqName: FqName get() = classId.packageFqName
 
+  public abstract val constructors: List<FunctionReference>
   public abstract val functions: List<FunctionReference>
   public abstract val annotations: List<AnnotationReference>
   public abstract val properties: List<PropertyReference>
@@ -118,6 +130,10 @@ public sealed class ClassReference {
     override val module: AnvilModuleDescriptor
   ) : ClassReference() {
     override val fqName: FqName = classId.asSingleFqName()
+
+    override val constructors: List<FunctionReference.Psi> by lazy(NONE) {
+      clazz.allConstructors.map { it.toFunctionReference(this) }
+    }
 
     override val functions: List<FunctionReference.Psi> by lazy(NONE) {
       clazz
@@ -190,6 +206,130 @@ public sealed class ClassReference {
     override fun companionObjects(): List<Psi> {
       return super.companionObjects().cast()
     }
+
+    /**
+     * Safely resolves a [KotlinType], when that type reference is a generic expressed by a type
+     * variable name. This is done by inspecting the class hierarchy to find where the generic
+     * type is declared, then resolving *that* reference.
+     *
+     * For instance, given:
+     *
+     * ```
+     * interface SomeFactory : Function1<String, SomeClass>
+     * ```
+     *
+     * There's an invisible `fun invoke(p1: P1): R`. If `SomeFactory` is parsed using PSI (such
+     * as if it's generated), then the function can only be parsed to have the projected types
+     * of `P1` and `R`
+     *
+     * @receiver The class which actually references the type. In the above example, this
+     * would be `SomeFactory`.
+     * @param declaringClass The class which declares the generic type name. In the above
+     * example, this would be `Function1`.
+     * @param typeToResolve The generic reference to be resolved. In the above example, this
+     * is the `T` **return type**.
+     */
+    public fun resolveGenericKotlinTypeOrNull(
+      declaringClass: ClassReference,
+      typeToResolve: KotlinType
+    ): KtTypeReference? {
+      val parameterKotlinType = when (typeToResolve) {
+        is FlexibleType -> {
+          // A FlexibleType comes from Java code where the compiler doesn't know whether it's a
+          // nullable or non-nullable type. toString() returns something like "(T..T?)". To get
+          // proper results we use the type that's not nullable, "T" in this example.
+          if (typeToResolve.lowerBound.isMarkedNullable) {
+            typeToResolve.upperBound
+          } else {
+            typeToResolve.lowerBound
+          }
+        }
+        is DefinitelyNotNullType -> {
+          // This is known to be not null in Java, such as something annotated `@NotNull` or
+          // controlled by a JSR305 or jSpecify annotation.
+          // This is a special type and this logic appears to match how kotlinc is handling it here
+          // https://github.com/JetBrains/kotlin/blob/9ee0d6b60ac4f0ea0ccc5dd01146bab92fabcdf2/core/descriptors/src/org/jetbrains/kotlin/types/TypeUtils.java#L455-L458
+          typeToResolve.original
+        }
+        else -> {
+          typeToResolve
+        }
+      }
+
+      return clazz.resolveGenericTypeReference(declaringClass, parameterKotlinType.toString())
+    }
+
+    /**
+     * Safely resolves a PSI [KtTypeReference], when that type reference may be a generic
+     * expressed by a type variable name. This is done by inspecting the class hierarchy to
+     * find where the generic type is declared, then resolving *that* reference.
+     *
+     * For instance, given:
+     *
+     * ```
+     * interface Factory<T> {
+     *   fun create(): T
+     * }
+     *
+     * interface ServiceFactory : Factory<Service>
+     * ```
+     *
+     * The KtTypeReference `T` will fail to resolve, since it isn't a type. This function will
+     * instead look to the `ServiceFactory` interface, then look at the supertype declaration
+     * in order to determine the type.
+     *
+     * @receiver The class which actually references the type. In the above example, this would
+     * be `ServiceFactory`.
+     * @param typeReference The generic reference to be resolved. In the above example, this
+     * is `T`.
+     */
+    public fun resolveTypeReference(typeReference: KtTypeReference): KtTypeReference? {
+
+      // if the element isn't a type variable name like `T`, it can be resolved through imports.
+      typeReference.typeElement?.fqNameOrNull(module)
+        ?.let { return typeReference }
+
+      val declaringClass = typeReference.requireContainingClassReference(module)
+      val parameterName = typeReference.text
+
+      return clazz.resolveGenericTypeReference(declaringClass, parameterName)
+    }
+
+    private fun KtClassOrObject.resolveGenericTypeReference(
+      declaringClass: ClassReference,
+      parameterName: String
+    ): KtTypeReference? {
+      val declaringClassFqName = declaringClass.fqName
+
+      // If the class/interface declaring the generic is the receiver class,
+      // then the generic hasn't been set to a concrete type and can't be resolved.
+      if (requireFqName() == declaringClassFqName) {
+        return null
+      }
+
+      // Used to determine which parameter to look at in a KtTypeArgumentList
+      val indexOfType = declaringClass.indexOfTypeParameter(parameterName)
+
+      // Find where the supertype is actually declared by matching the FqName of the
+      // SuperTypeListEntry to the type which declares the generic we're trying to resolve.
+      // After finding the SuperTypeListEntry, just take the TypeReference from its type
+      // argument list.
+      val resolvedTypeReference = superTypeListEntryOrNull(module, declaringClassFqName)
+        ?.typeReference
+        ?.typeElement
+        ?.getChildOfType<KtTypeArgumentList>()
+        ?.arguments
+        ?.get(indexOfType)
+        ?.typeReference
+
+      // TODO: check if the first line can be removed.
+      return if (resolvedTypeReference != null) {
+        // This will check that the type can be imported.
+        resolveTypeReference(resolvedTypeReference)
+      } else {
+        null
+      }
+    }
   }
 
   public class Descriptor(
@@ -199,10 +339,15 @@ public sealed class ClassReference {
   ) : ClassReference() {
     override val fqName: FqName = classId.asSingleFqName()
 
-    override val functions: List<FunctionReference> by lazy(NONE) {
+    override val constructors: List<FunctionReference.Descriptor> by lazy(NONE) {
+      clazz.constructors.map { it.toFunctionReference(this) }
+    }
+
+    override val functions: List<FunctionReference.Descriptor> by lazy(NONE) {
       clazz.unsubstitutedMemberScope
         .getContributedDescriptors(kindFilter = DescriptorKindFilter.FUNCTIONS)
         .filterIsInstance<FunctionDescriptor>()
+        .filterNot { it is ConstructorDescriptor }
         .map { it.toFunctionReference(this) }
     }
 
@@ -288,13 +433,6 @@ public fun KtClassOrObject.toClassReference(module: ModuleDescriptor): Psi =
 @ExperimentalAnvilApi
 public fun FqName.toClassReferenceOrNull(module: ModuleDescriptor): ClassReference? =
   module.asAnvilModuleDescriptor().getClassReferenceOrNull(this)
-
-@Suppress("DeprecatedCallableAddReplaceWith")
-@Deprecated("Don't rely on PSI and make the code agnostic to the underlying implementation.")
-@ExperimentalAnvilApi
-public fun FqName.toClassReferencePsiOrNull(module: ModuleDescriptor): Psi? =
-  module.asAnvilModuleDescriptor()
-    .getClassReferenceOrNull(this, preferDescriptor = false) as? Psi
 
 @ExperimentalAnvilApi
 public fun FqName.toClassReference(module: ModuleDescriptor): ClassReference {

--- a/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/reference/ParameterReference.kt
+++ b/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/reference/ParameterReference.kt
@@ -1,0 +1,208 @@
+package com.squareup.anvil.compiler.internal.reference
+
+import com.squareup.anvil.annotations.ExperimentalAnvilApi
+import com.squareup.anvil.compiler.api.AnvilCompilationException
+import com.squareup.anvil.compiler.internal.asFunctionType
+import com.squareup.anvil.compiler.internal.asTypeNameOrNull
+import com.squareup.anvil.compiler.internal.classDescriptorOrNull
+import com.squareup.anvil.compiler.internal.fqNameOrNull
+import com.squareup.anvil.compiler.internal.reference.ParameterReference.Descriptor
+import com.squareup.anvil.compiler.internal.reference.ParameterReference.Psi
+import com.squareup.anvil.compiler.internal.requireFqName
+import com.squareup.anvil.compiler.internal.requireTypeName
+import com.squareup.kotlinpoet.LambdaTypeName
+import com.squareup.kotlinpoet.TypeName
+import org.jetbrains.kotlin.descriptors.ValueParameterDescriptor
+import org.jetbrains.kotlin.psi.KtParameter
+import kotlin.LazyThreadSafetyMode.NONE
+
+@ExperimentalAnvilApi
+public sealed class ParameterReference {
+
+  public abstract val name: String
+  public abstract val declaringFunction: FunctionReference
+  public val module: AnvilModuleDescriptor get() = declaringFunction.module
+
+  public abstract val annotations: List<AnnotationReference>
+
+  /**
+   * The type can be null for generic type parameters like `T`. In this case try to resolve the
+   * type with [resolveGenericTypeOrNull].
+   */
+  public abstract fun typeOrNull(): ClassReference?
+  public fun type(): ClassReference = typeOrNull()
+    ?: throw AnvilCompilationExceptionParameterReference(
+      parameterReference = this,
+      message = "Unable to get type for the parameter with name $name of " +
+        "function ${declaringFunction.fqName}"
+    )
+
+  public abstract fun resolveGenericTypeOrNull(
+    implementingClass: ClassReference.Psi
+  ): ClassReference?
+
+  public fun resolveGenericType(implementingClass: ClassReference.Psi): ClassReference =
+    resolveGenericTypeOrNull(implementingClass)
+      ?: throw AnvilCompilationExceptionParameterReference(
+        parameterReference = this,
+        message = "Unable to resolve type for the parameter with name $name with the " +
+          "implementing class ${implementingClass.fqName}."
+      )
+
+  public abstract fun resolveTypeNameOrNull(
+    implementingClass: ClassReference.Psi
+  ): TypeName?
+
+  public fun resolveTypeName(implementingClass: ClassReference.Psi): TypeName =
+    resolveTypeNameOrNull(implementingClass)
+      ?: throw AnvilCompilationExceptionParameterReference(
+        message = "Unable to resolve type name for parameter with name $name with the " +
+          "implementing class ${implementingClass.fqName}.",
+        parameterReference = this
+      )
+
+  override fun toString(): String {
+    return "${this::class.qualifiedName}(${declaringFunction.fqName}(.., $name,..))"
+  }
+
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other !is ParameterReference) return false
+
+    if (name != other.name) return false
+    if (declaringFunction != other.declaringFunction) return false
+
+    return true
+  }
+
+  override fun hashCode(): Int {
+    var result = name.hashCode()
+    result = 31 * result + declaringFunction.hashCode()
+    return result
+  }
+
+  public class Psi(
+    public val parameter: KtParameter,
+    override val declaringFunction: FunctionReference.Psi
+  ) : ParameterReference() {
+    override val name: String = parameter.nameAsSafeName.asString()
+
+    override val annotations: List<AnnotationReference.Psi> by lazy(NONE) {
+      parameter.annotationEntries.map {
+        it.toAnnotationReference(declaringClass = null, module)
+      }
+    }
+
+    override fun typeOrNull(): ClassReference? {
+      return parameter.typeReference
+        ?.let { declaringFunction.declaringClass.resolveTypeReference(it) }
+        ?.requireFqName(module)
+        ?.toClassReference(module)
+    }
+
+    override fun resolveGenericTypeOrNull(implementingClass: ClassReference.Psi): ClassReference? {
+      typeOrNull()?.let { return it }
+
+      val typeReference = parameter.typeReference
+        ?.let { typeReference ->
+          implementingClass.resolveTypeReference(typeReference)
+        }
+        ?: parameter.typeReference
+
+      return typeReference?.fqNameOrNull(module)?.toClassReference(module)
+    }
+
+    override fun resolveTypeNameOrNull(implementingClass: ClassReference.Psi): TypeName? {
+      return parameter.typeReference
+        ?.let { typeReference ->
+          implementingClass.resolveTypeReference(typeReference)
+            ?: typeReference
+        }
+        ?.requireTypeName(module)
+        ?.let { typeName ->
+          // This is a special case when mixing parsing between descriptors and PSI.  Descriptors
+          // will always represent lambda types as kotlin.Function* types, so lambda arguments
+          // must be converted or their signatures won't match.
+          // see https://github.com/square/anvil/issues/400
+          (typeName as? LambdaTypeName)?.asFunctionType()
+            ?: typeName
+        }
+    }
+  }
+
+  public class Descriptor(
+    public val parameter: ValueParameterDescriptor,
+    override val declaringFunction: FunctionReference
+  ) : ParameterReference() {
+    override val name: String = parameter.name.asString()
+
+    override val annotations: List<AnnotationReference.Descriptor> by lazy(NONE) {
+      parameter.annotations.map {
+        it.toAnnotationReference(declaringClass = null, module)
+      }
+    }
+
+    override fun typeOrNull(): ClassReference? {
+      return parameter.type.classDescriptorOrNull()?.toClassReference(declaringFunction.module)
+    }
+
+    override fun resolveGenericTypeOrNull(implementingClass: ClassReference.Psi): ClassReference? {
+      typeOrNull()?.let { return it }
+
+      return implementingClass
+        .resolveGenericKotlinTypeOrNull(declaringFunction.declaringClass, parameter.type)
+        ?.fqNameOrNull(module)
+        ?.toClassReferenceOrNull(module)
+    }
+
+    override fun resolveTypeNameOrNull(implementingClass: ClassReference.Psi): TypeName? {
+      return parameter.type
+        .let {
+          if (it.classDescriptorOrNull() != null) {
+            // Then it's a normal type and not a generic type.
+            it.asTypeNameOrNull()
+          } else {
+            null
+          }
+        }
+        ?: implementingClass.resolveGenericKotlinTypeOrNull(
+          declaringClass = declaringFunction.declaringClass,
+          typeToResolve = parameter.type
+        )?.requireTypeName(module)
+        ?: parameter.type.asTypeNameOrNull()
+    }
+  }
+}
+
+@ExperimentalAnvilApi
+public fun KtParameter.toParameterReference(
+  declaringFunction: FunctionReference.Psi
+): Psi {
+  return Psi(this, declaringFunction)
+}
+
+@ExperimentalAnvilApi
+public fun ValueParameterDescriptor.toParameterReference(
+  declaringFunction: FunctionReference.Descriptor
+): Descriptor {
+  return Descriptor(this, declaringFunction)
+}
+
+@ExperimentalAnvilApi
+@Suppress("FunctionName")
+public fun AnvilCompilationExceptionParameterReference(
+  parameterReference: ParameterReference,
+  message: String,
+  cause: Throwable? = null
+): AnvilCompilationException = when (parameterReference) {
+  is Psi -> AnvilCompilationException(
+    element = parameterReference.parameter,
+    message = message,
+    cause = cause
+  )
+  is Descriptor -> AnvilCompilationException(
+    parameterDescriptor = parameterReference.parameter,
+    message = message,
+    cause = cause
+  )
+}

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesSubcomponentGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesSubcomponentGenerator.kt
@@ -22,7 +22,6 @@ import com.squareup.anvil.compiler.internal.reference.asClassName
 import com.squareup.anvil.compiler.internal.reference.classAndInnerClassReferences
 import com.squareup.anvil.compiler.internal.reference.generateClassName
 import com.squareup.anvil.compiler.internal.reference.isAnnotatedWith
-import com.squareup.anvil.compiler.internal.reference.returnType
 import com.squareup.anvil.compiler.internal.safePackageString
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.KModifier.PUBLIC

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesSubcomponentHandlerGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesSubcomponentHandlerGenerator.kt
@@ -26,7 +26,6 @@ import com.squareup.anvil.compiler.internal.reference.Visibility.PUBLIC
 import com.squareup.anvil.compiler.internal.reference.asClassName
 import com.squareup.anvil.compiler.internal.reference.classAndInnerClassReferences
 import com.squareup.anvil.compiler.internal.reference.isAnnotatedWith
-import com.squareup.anvil.compiler.internal.reference.returnType
 import com.squareup.anvil.compiler.internal.reference.toClassReference
 import com.squareup.anvil.compiler.internal.safePackageString
 import com.squareup.anvil.compiler.mergeComponentFqName

--- a/compiler/src/test/java/com/squareup/anvil/compiler/dagger/AssistedFactoryGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/dagger/AssistedFactoryGeneratorTest.kt
@@ -255,7 +255,7 @@ public final class AssistedServiceFactory_Impl implements AssistedServiceFactory
       )
       
       interface Base<R: CharSequence, T> {
-        fun create(r :R): T
+        fun create(r : R): T
       }
       
       interface Mid<T> : Base<String, T>


### PR DESCRIPTION
That required moving many utilities around to better places, but we were also able to delete some sketch pieces.