### PR TITLE
Improve CI times of the Windows job.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs :
       # Expressions in Github actions are limited. If there would be an if expression, then we
       # wouldn't need to duplicate the next step and depending on the OS enable / disable them.
       - name : Test on Windows
-        run : ./gradlew.bat assemble test --no-build-cache --no-daemon --stacktrace
+        run : ./gradlew.bat assemble test --no-build-cache --no-daemon --stacktrace "-Psquare.fullTestRun=false"
 
       - name : Upload Test Results
         uses : actions/upload-artifact@v2

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -31,10 +31,6 @@ ext {
   fullTestRun = (project.hasProperty('square.fullTestRun') ?
       project.getProperty('square.fullTestRun') : 'true').toBoolean()
 
-  if (ci && !fullTestRun) {
-    throw GradleException("Don't disable fullTestRun in CI!")
-  }
-
   // TODO: Remove when we remove the old backend.
   // TODO Repeatable: After cleaning up all deprecated methods remove the `&& false`.
   makeWarningsErrors = ci && (kotlinVersion.startsWith('1.5') || kotlinUseIR) && false


### PR DESCRIPTION
Don't run the entire test suite for the Windows job, because we don't need to and it's the slowest of all jobs. The job only makes sure that we don't have any incompatibilities and therefore skipping the Dagger tests is fine.