### PR TITLE
Delete deprecated functions

### DIFF
--- a/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/reference/AnnotationArgumentReference.kt
+++ b/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/reference/AnnotationArgumentReference.kt
@@ -29,6 +29,7 @@ public sealed class AnnotationArgumentReference {
 
   public abstract val annotation: AnnotationReference
   public abstract val name: String?
+  public abstract val resolvedName: String
 
   public val module: AnvilModuleDescriptor get() = annotation.module
 
@@ -39,7 +40,8 @@ public sealed class AnnotationArgumentReference {
   public fun <T : Any> value(): T = value as T
 
   override fun toString(): String {
-    return "${AnnotationArgumentReference::class.simpleName}(name=$name, value=$value)"
+    return "${AnnotationArgumentReference::class.simpleName}(name=$name, value=$value, " +
+      "resolvedName=$resolvedName)"
   }
 
   override fun equals(other: Any?): Boolean {
@@ -48,13 +50,15 @@ public sealed class AnnotationArgumentReference {
 
     if (name != other.name) return false
     if (value != other.value) return false
+    if (resolvedName != other.resolvedName) return false
 
     return true
   }
 
   override fun hashCode(): Int {
-    var result = name?.hashCode() ?: 0
+    var result = name.hashCode()
     result = 31 * result + value.hashCode()
+    result = 31 * result + resolvedName.hashCode()
     return result
   }
 
@@ -62,6 +66,7 @@ public sealed class AnnotationArgumentReference {
     public val argument: KtValueArgument,
     override val annotation: AnnotationReference.Psi,
     override val name: String?,
+    override val resolvedName: String
   ) : AnnotationArgumentReference() {
     protected override val value: Any by lazy(NONE) {
       fun fail(): Nothing {
@@ -89,7 +94,8 @@ public sealed class AnnotationArgumentReference {
   public class Descriptor internal constructor(
     public val argument: ConstantValue<*>,
     override val annotation: AnnotationReference.Descriptor,
-    override val name: String
+    override val name: String,
+    override val resolvedName: String = name
   ) : AnnotationArgumentReference() {
 
     protected override val value: Any by lazy(NONE) {
@@ -114,17 +120,34 @@ public sealed class AnnotationArgumentReference {
 
 @ExperimentalAnvilApi
 public fun KtValueArgument.toAnnotationArgumentReference(
-  annotationReference: AnnotationReference.Psi
+  annotationReference: AnnotationReference.Psi,
+  indexOfArgument: Int
 ): Psi {
   val children = children
   val name = (children.firstOrNull() as? KtValueArgumentName)?.asName?.asString()
 
-  return Psi(this, annotationReference, name)
+  // If no name is specified, then look up the name in the annotation class.
+  val resolvedName = name ?: annotationReference.classReference
+    .constructors
+    .single()
+    .parameters[indexOfArgument]
+    .name
+
+  return Psi(
+    argument = this,
+    annotation = annotationReference,
+    name = name,
+    resolvedName = resolvedName
+  )
 }
 
 @ExperimentalAnvilApi
 public fun Pair<Name, ConstantValue<*>>.toAnnotationArgumentReference(
   annotationReference: AnnotationReference.Descriptor
 ): Descriptor {
-  return Descriptor(this.second, annotationReference, this.first.asString())
+  return Descriptor(
+    argument = second,
+    annotation = annotationReference,
+    name = first.asString()
+  )
 }

--- a/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/reference/AnnotationReference.kt
+++ b/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/reference/AnnotationReference.kt
@@ -18,7 +18,6 @@ import com.squareup.anvil.compiler.internal.mergeSubcomponentFqName
 import com.squareup.anvil.compiler.internal.qualifierFqName
 import com.squareup.anvil.compiler.internal.reference.AnnotationReference.Descriptor
 import com.squareup.anvil.compiler.internal.reference.AnnotationReference.Psi
-import com.squareup.anvil.compiler.internal.requireClass
 import com.squareup.anvil.compiler.internal.requireFqName
 import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.MemberName
@@ -29,6 +28,7 @@ import org.jetbrains.kotlin.psi.KtAnnotationEntry
 import org.jetbrains.kotlin.psi.KtValueArgument
 import org.jetbrains.kotlin.resolve.constants.EnumValue
 import org.jetbrains.kotlin.resolve.constants.KClassValue
+import org.jetbrains.kotlin.resolve.descriptorUtil.annotationClass
 import kotlin.LazyThreadSafetyMode.NONE
 
 private const val DEFAULT_SCOPE_INDEX = 0
@@ -212,9 +212,13 @@ public fun AnnotationDescriptor.toAnnotationReference(
   declaringClass: ClassReference.Descriptor?,
   module: ModuleDescriptor
 ): Descriptor {
+  val annotationClass = annotationClass ?: throw AnvilCompilationException(
+    message = "Couldn't find the annotation class for $fqName",
+  )
+
   return Descriptor(
     annotation = this,
-    classReference = requireClass().toClassReference(module),
+    classReference = annotationClass.toClassReference(module),
     declaringClass = declaringClass
   )
 }

--- a/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/reference/AnnotationReference.kt
+++ b/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/reference/AnnotationReference.kt
@@ -114,7 +114,9 @@ public sealed class AnnotationReference {
     override val arguments: List<AnnotationArgumentReference.Psi> by lazy(NONE) {
       annotation.valueArguments
         .filterIsInstance<KtValueArgument>()
-        .map { it.toAnnotationArgumentReference(this) }
+        .mapIndexed { index, argument ->
+          argument.toAnnotationArgumentReference(this, index)
+        }
     }
 
     private val defaultScope by lazy(NONE) { computeScope(DEFAULT_SCOPE_INDEX) }

--- a/compiler/src/main/java/com/squareup/anvil/compiler/AnvilComponentRegistrar.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/AnvilComponentRegistrar.kt
@@ -74,7 +74,7 @@ class AnvilComponentRegistrar : ComponentRegistrar {
 
       IrGenerationExtension.registerExtension(
         project,
-        ModuleMergerIr(scanner)
+        ModuleMergerIr(scanner, moduleDescriptorFactory)
       )
     }
   }

--- a/compiler/src/main/java/com/squareup/anvil/compiler/ClassScannerIr.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/ClassScannerIr.kt
@@ -1,10 +1,10 @@
 package com.squareup.anvil.compiler
 
+import com.squareup.anvil.compiler.codegen.reference.RealAnvilModuleDescriptor
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
 import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
 import org.jetbrains.kotlin.name.FqName
-import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
 
 /**
  * Returns a sequence of contributed classes from the dependency graph. Note that the result
@@ -15,10 +15,13 @@ internal fun ClassScanner.findContributedClasses(
   moduleFragment: IrModuleFragment,
   packageName: String,
   annotation: FqName,
-  scope: FqName?
+  scope: FqName?,
+  moduleDescriptorFactory: RealAnvilModuleDescriptor.Factory
 ): Sequence<IrClassSymbol> {
-  return findContributedClasses(moduleFragment.descriptor, packageName, annotation, scope)
+  val module = moduleDescriptorFactory.create(moduleFragment.descriptor)
+
+  return findContributedClasses(module, packageName, annotation, scope)
     .map {
-      pluginContext.requireReferenceClass(it.fqNameSafe)
+      pluginContext.requireReferenceClass(it.fqName)
     }
 }

--- a/compiler/src/main/java/com/squareup/anvil/compiler/ModuleMergerIr.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/ModuleMergerIr.kt
@@ -3,6 +3,7 @@ package com.squareup.anvil.compiler
 import com.squareup.anvil.annotations.ContributesTo
 import com.squareup.anvil.compiler.api.AnvilCompilationException
 import com.squareup.anvil.compiler.codegen.generatedAnvilSubcomponent
+import com.squareup.anvil.compiler.codegen.reference.RealAnvilModuleDescriptor
 import com.squareup.anvil.compiler.internal.safePackageString
 import dagger.Module
 import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
@@ -29,7 +30,8 @@ import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.types.Variance.INVARIANT
 
 internal class ModuleMergerIr(
-  private val classScanner: ClassScanner
+  private val classScanner: ClassScanner,
+  private val moduleDescriptorFactory: RealAnvilModuleDescriptor.Factory
 ) : IrGenerationExtension {
   override fun generate(
     moduleFragment: IrModuleFragment,
@@ -74,7 +76,8 @@ internal class ModuleMergerIr(
         moduleFragment = moduleFragment,
         packageName = HINT_CONTRIBUTES_PACKAGE_PREFIX,
         annotation = contributesToFqName,
-        scope = scope
+        scope = scope,
+        moduleDescriptorFactory = moduleDescriptorFactory
       )
       .filter {
         // We generate a Dagger module for each merged component. We use Anvil itself to
@@ -189,7 +192,8 @@ internal class ModuleMergerIr(
           moduleFragment = moduleFragment,
           packageName = hintPackagePrefix,
           annotation = annotationFqName,
-          scope = scope
+          scope = scope,
+          moduleDescriptorFactory = moduleDescriptorFactory
         )
         .flatMap { classSymbol ->
           val annotation = classSymbol.owner.annotation(annotationFqName)
@@ -349,7 +353,8 @@ internal class ModuleMergerIr(
         moduleFragment = moduleFragment,
         packageName = HINT_SUBCOMPONENTS_PACKAGE_PREFIX,
         annotation = contributesSubcomponentFqName,
-        scope = null
+        scope = null,
+        moduleDescriptorFactory = moduleDescriptorFactory
       )
       .filter {
         it.owner.annotation(contributesSubcomponentFqName).parentScope() == scope

--- a/compiler/src/main/java/com/squareup/anvil/compiler/Utils.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/Utils.kt
@@ -22,10 +22,8 @@ import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.internal.DoubleCheck
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
-import org.jetbrains.kotlin.descriptors.annotations.AnnotationDescriptor
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.FqName
-import org.jetbrains.kotlin.resolve.descriptorUtil.annotationClass
 import javax.inject.Inject
 import javax.inject.Provider
 import javax.inject.Qualifier
@@ -80,15 +78,6 @@ internal val propertySuffixes = arrayOf(REFERENCE_SUFFIX, SCOPE_SUFFIX)
 internal fun FqName.isAnvilModule(): Boolean {
   val name = asString()
   return name.startsWith(MODULE_PACKAGE_PREFIX) && name.endsWith(ANVIL_MODULE_SUFFIX)
-}
-
-@Suppress("DeprecatedCallableAddReplaceWith")
-@Deprecated(
-  "Don't rely on descriptors and make the code agnostic to the underlying implementation. " +
-    "See [AnnotationReference#isMapKey]"
-)
-internal fun AnnotationDescriptor.isMapKey(): Boolean {
-  return annotationClass?.annotations?.hasAnnotation(mapKeyFqName) ?: false
 }
 
 @Suppress("UNCHECKED_CAST")

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/BindingModuleGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/BindingModuleGenerator.kt
@@ -26,7 +26,6 @@ import com.squareup.anvil.compiler.internal.reference.asClassName
 import com.squareup.anvil.compiler.internal.reference.classAndInnerClassReferences
 import com.squareup.anvil.compiler.internal.reference.generateClassName
 import com.squareup.anvil.compiler.internal.reference.isAnnotatedWith
-import com.squareup.anvil.compiler.internal.reference.scopeOrNull
 import com.squareup.anvil.compiler.internal.reference.toClassReference
 import com.squareup.anvil.compiler.internal.requireFqName
 import com.squareup.anvil.compiler.internal.safePackageString
@@ -231,7 +230,11 @@ internal class BindingModuleGenerator(
           .filterNot { it.fqName in replacedBindings }
           .filterNot { it.fqName in bindingsReplacedInDaggerModules }
           .filterNot { it.fqName in excludedNames }
-          .filter { scope == it.scopeOrNull(annotationFqName) }
+          .filter { clazz ->
+            clazz.annotations
+              .find(annotationName = annotationFqName, scopeName = scope)
+              .isNotEmpty()
+          }
           .map { clazz ->
             clazz.annotations
               .filter { it.fqName == annotationFqName }

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesSubcomponentHandlerGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesSubcomponentHandlerGenerator.kt
@@ -25,7 +25,6 @@ import com.squareup.anvil.compiler.internal.reference.Visibility.PUBLIC
 import com.squareup.anvil.compiler.internal.reference.asClassName
 import com.squareup.anvil.compiler.internal.reference.classAndInnerClassReferences
 import com.squareup.anvil.compiler.internal.reference.isAnnotatedWith
-import com.squareup.anvil.compiler.internal.reference.toClassReference
 import com.squareup.anvil.compiler.internal.safePackageString
 import com.squareup.anvil.compiler.mergeComponentFqName
 import com.squareup.anvil.compiler.mergeInterfacesFqName
@@ -403,12 +402,10 @@ internal class ContributesSubcomponentHandlerGenerator(
         annotation = contributesSubcomponentFqName,
         scope = null
       )
-      .map { descriptor ->
-        val annotation = descriptor.toClassReference(module)
-          .annotations
-          .single { it.fqName == contributesSubcomponentFqName }
-
-        Contribution(annotation)
+      .map { clazz ->
+        Contribution(
+          annotation = clazz.annotations.single { it.fqName == contributesSubcomponentFqName }
+        )
       }
 
     // Find all replaced subcomponents from precompiled dependencies.

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/DaggerGenerationUtils.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/DaggerGenerationUtils.kt
@@ -13,14 +13,15 @@ import com.squareup.anvil.compiler.internal.capitalize
 import com.squareup.anvil.compiler.internal.classDescriptorOrNull
 import com.squareup.anvil.compiler.internal.findAnnotation
 import com.squareup.anvil.compiler.internal.fqNameOrNull
-import com.squareup.anvil.compiler.internal.generateClassName
 import com.squareup.anvil.compiler.internal.hasAnnotation
 import com.squareup.anvil.compiler.internal.isNullable
 import com.squareup.anvil.compiler.internal.reference.ClassReference
 import com.squareup.anvil.compiler.internal.reference.ClassReference.Descriptor
 import com.squareup.anvil.compiler.internal.reference.ClassReference.Psi
 import com.squareup.anvil.compiler.internal.reference.allSuperTypeClassReferences
+import com.squareup.anvil.compiler.internal.reference.generateClassName
 import com.squareup.anvil.compiler.internal.reference.toAnnotationReference
+import com.squareup.anvil.compiler.internal.reference.toClassReference
 import com.squareup.anvil.compiler.internal.requireFqName
 import com.squareup.anvil.compiler.internal.requireTypeName
 import com.squareup.anvil.compiler.internal.requireTypeReference
@@ -229,6 +230,8 @@ private fun KtTypeElement.singleTypeArgument(): KtTypeReference {
 
 // TODO
 //  Include methods: https://github.com/square/anvil/issues/339
+
+// TODO: Use ClassReference
 internal fun KtClassOrObject.injectedMembers(module: ModuleDescriptor) = children
   .asSequence()
   .filterIsInstance<KtClassBody>()
@@ -505,7 +508,9 @@ private fun KtProperty.toMemberInjectParameter(
   val packageName = containingClass.containingKtFile.packageFqName.asString()
 
   // TODO: remove deprecated function call
-  val memberInjectorClassName = "${containingClass.generateClassName()}_MembersInjector"
+  val memberInjectorClassName =
+    "${containingClass.toClassReference(module).generateClassName().relativeClassName}" +
+      "_MembersInjector"
   val memberInjectorClass = ClassName(packageName, memberInjectorClassName)
 
   val qualifierAnnotations = annotationEntries

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/MembersInjectorGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/MembersInjectorGenerator.kt
@@ -9,7 +9,6 @@ import com.squareup.anvil.compiler.codegen.PrivateCodeGenerator
 import com.squareup.anvil.compiler.internal.asClassName
 import com.squareup.anvil.compiler.internal.buildFile
 import com.squareup.anvil.compiler.internal.capitalize
-import com.squareup.anvil.compiler.internal.isGenericClass
 import com.squareup.anvil.compiler.internal.reference.ClassReference
 import com.squareup.anvil.compiler.internal.reference.asClassName
 import com.squareup.anvil.compiler.internal.reference.classAndInnerClassReferences
@@ -77,7 +76,7 @@ internal class MembersInjectorGenerator : PrivateCodeGenerator() {
 
     val classType = clazz.asClassName()
       .let {
-        if (clazz.clazz.isGenericClass()) {
+        if (clazz.isGenericClass()) {
           it.parameterizedBy(List(size = clazz.clazz.typeParameters.size) { STAR })
         } else {
           it

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/reference/RealAnvilModuleDescriptor.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/reference/RealAnvilModuleDescriptor.kt
@@ -1,5 +1,6 @@
 package com.squareup.anvil.compiler.codegen.reference
 
+import com.squareup.anvil.compiler.api.AnvilCompilationException
 import com.squareup.anvil.compiler.codegen.reference.RealAnvilModuleDescriptor.ClassReferenceCacheKey.Companion.toClassReferenceCacheKey
 import com.squareup.anvil.compiler.codegen.reference.RealAnvilModuleDescriptor.ClassReferenceCacheKey.Type.DESCRIPTOR
 import com.squareup.anvil.compiler.codegen.reference.RealAnvilModuleDescriptor.ClassReferenceCacheKey.Type.PSI
@@ -8,9 +9,7 @@ import com.squareup.anvil.compiler.internal.reference.AnvilModuleDescriptor
 import com.squareup.anvil.compiler.internal.reference.ClassReference
 import com.squareup.anvil.compiler.internal.reference.ClassReference.Descriptor
 import com.squareup.anvil.compiler.internal.reference.ClassReference.Psi
-import com.squareup.anvil.compiler.internal.requireClassId
 import com.squareup.anvil.compiler.internal.requireFqName
-import com.squareup.anvil.compiler.internal.toClassId
 import org.jetbrains.kotlin.descriptors.ClassDescriptor
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 import org.jetbrains.kotlin.descriptors.findTypeAliasAcrossModuleDependencies
@@ -20,6 +19,8 @@ import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.psiUtil.parentsWithSelf
+import org.jetbrains.kotlin.resolve.descriptorUtil.classId
 import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
 
 class RealAnvilModuleDescriptor private constructor(
@@ -91,7 +92,12 @@ class RealAnvilModuleDescriptor private constructor(
 
   override fun getClassReference(descriptor: ClassDescriptor): Descriptor {
     return classReferenceCache.getOrPut(descriptor.toClassReferenceCacheKey()) {
-      Descriptor(descriptor, descriptor.requireClassId(), this)
+      val classId = descriptor.classId ?: throw AnvilCompilationException(
+        classDescriptor = descriptor,
+        message = "Couldn't find the classId for $fqNameSafe. Are we stuck in a loop while " +
+          "resolving super types?"
+      )
+      Descriptor(descriptor, classId, this)
     } as Descriptor
   }
 
@@ -152,4 +158,13 @@ private fun KtFile.classesAndInnerClasses(): List<KtClassOrObject> {
       }
       .ifEmpty { null }
   }.flatten().toList()
+}
+
+private fun KtClassOrObject.toClassId(): ClassId {
+  val className = parentsWithSelf.filterIsInstance<KtClassOrObject>()
+    .toList()
+    .reversed()
+    .joinToString(separator = ".") { it.nameAsSafeName.asString() }
+
+  return ClassId(containingKtFile.packageFqName, FqName(className), false)
 }

--- a/compiler/src/test/java/com/squareup/anvil/compiler/InterfaceMergerTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/InterfaceMergerTest.kt
@@ -491,11 +491,9 @@ class InterfaceMergerTest(
       }
       """
     ) {
-      assertThat(exitCode).isEqualTo(INTERNAL_ERROR)
-      // Position to the class.
+      assertThat(exitCode).isError()
       assertThat(messages).contains(
-        "org.jetbrains.kotlin.util.KotlinFrontEndException: " +
-          "Exception while analyzing expression at (8,18)"
+        "Couldn't find the classId for <root>. Are we stuck in a loop while resolving super types?"
       )
     }
   }

--- a/compiler/src/test/java/com/squareup/anvil/compiler/ModuleMergerTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/ModuleMergerTest.kt
@@ -996,7 +996,9 @@ class ModuleMergerTest(
       """
     ) {
       assertThat(exitCode).isError()
-      assertThat(messages).contains("File being compiled: (10,18)")
+      assertThat(messages).contains(
+        "Couldn't find the classId for <root>. Are we stuck in a loop while resolving super types?"
+      )
     }
   }
 

--- a/compiler/src/test/java/com/squareup/anvil/compiler/internal/reference/ClassReferenceTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/internal/reference/ClassReferenceTest.kt
@@ -2,7 +2,6 @@ package com.squareup.anvil.compiler.internal.reference
 
 import com.google.common.truth.Truth.assertThat
 import com.squareup.anvil.compiler.compile
-import com.squareup.anvil.compiler.internal.classDescriptor
 import com.squareup.anvil.compiler.internal.fqName
 import com.squareup.anvil.compiler.internal.testing.simpleCodeGenerator
 import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.OK
@@ -294,7 +293,7 @@ class ClassReferenceTest {
       is ClassReference.Descriptor -> this
       is ClassReference.Psi -> {
         // Force using the descriptor.
-        fqName.classDescriptor(module).toClassReference(module)
+        module.resolveFqNameOrNull(fqName)!!.toClassReference(module)
           .also { descriptorReference ->
             assertThat(descriptorReference).isInstanceOf(ClassReference.Descriptor::class.java)
 


### PR DESCRIPTION
* Add the option to get the name of an annotation argument.
* Clean up the utilities within `ClassReference`.
* Remove several unused or deprecated functions, clean up TODOs and use our reference implementations more broadly.