### PR TITLE
Make `@ContributesTo` repeatable.

### DIFF
--- a/annotations/src/main/java/com/squareup/anvil/annotations/ContributesTo.kt
+++ b/annotations/src/main/java/com/squareup/anvil/annotations/ContributesTo.kt
@@ -38,6 +38,7 @@ import kotlin.reflect.KClass
  */
 @Target(CLASS)
 @Retention(RUNTIME)
+@Repeatable
 public annotation class ContributesTo(
   /**
    * The scope in which to include this module.

--- a/compiler-utils/src/testFixtures/java/com/squareup/anvil/compiler/internal/testing/AnvilCompilation.kt
+++ b/compiler-utils/src/testFixtures/java/com/squareup/anvil/compiler/internal/testing/AnvilCompilation.kt
@@ -37,9 +37,15 @@ public class AnvilCompilation internal constructor(
     disableComponentMerging: Boolean = false,
     enableExperimentalAnvilApis: Boolean = true,
     codeGenerators: List<CodeGenerator> = emptyList(),
+    enableAnvil: Boolean = true,
   ) = apply {
     checkNotCompiled()
+    check(!anvilConfigured) { "Anvil should not be configured twice." }
+
     anvilConfigured = true
+
+    if (!enableAnvil) return@apply
+
     kotlinCompilation.apply {
       compilerPlugins = listOf(
         AnvilComponentRegistrar().also { it.addCodeGenerators(codeGenerators) }

--- a/compiler/src/main/java/com/squareup/anvil/compiler/ClassScanner.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/ClassScanner.kt
@@ -1,17 +1,18 @@
 package com.squareup.anvil.compiler
 
+import com.squareup.anvil.compiler.GeneratedProperty.ReferenceProperty
+import com.squareup.anvil.compiler.GeneratedProperty.ScopeProperty
+import com.squareup.anvil.compiler.api.AnvilCompilationException
 import com.squareup.anvil.compiler.internal.argumentType
 import com.squareup.anvil.compiler.internal.classDescriptor
 import com.squareup.anvil.compiler.internal.reference.ClassReference
 import com.squareup.anvil.compiler.internal.reference.toClassReference
-import org.jetbrains.kotlin.descriptors.ClassDescriptor
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 import org.jetbrains.kotlin.descriptors.PackageViewDescriptor
 import org.jetbrains.kotlin.descriptors.PropertyDescriptor
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
 import org.jetbrains.kotlin.resolve.scopes.DescriptorKindFilter
-import kotlin.LazyThreadSafetyMode.NONE
 
 internal class ClassScanner {
 
@@ -21,12 +22,18 @@ internal class ClassScanner {
    */
   fun findContributedClasses(
     module: ModuleDescriptor,
-    packageName: String,
     annotation: FqName,
     scope: FqName?
   ): Sequence<ClassReference.Descriptor> {
-    val packageDescriptor = module.getPackage(FqName(packageName))
-    return generateSequence(listOf(packageDescriptor)) { subPackages ->
+    val packageName = when (annotation) {
+      contributesToFqName -> HINT_CONTRIBUTES_PACKAGE_PREFIX
+      contributesBindingFqName -> HINT_BINDING_PACKAGE_PREFIX
+      contributesMultibindingFqName -> HINT_MULTIBINDING_PACKAGE_PREFIX
+      contributesSubcomponentFqName -> HINT_SUBCOMPONENTS_PACKAGE_PREFIX
+      else -> throw AnvilCompilationException(message = "Cannot find hints for $annotation.")
+    }
+
+    return generateSequence(listOf(module.getPackage(FqName(packageName)))) { subPackages ->
       subPackages
         .flatMap { it.subPackages() }
         .ifEmpty { null }
@@ -34,36 +41,34 @@ internal class ClassScanner {
       .flatMap { it.asSequence() }
       .flatMap {
         it.memberScope.getContributedDescriptors(DescriptorKindFilter.VALUES)
-          .asSequence()
       }
       .filterIsInstance<PropertyDescriptor>()
-      .groupBy { property ->
-        // For each contributed hint there are several properties, e.g. the reference itself
-        // and the scope. Group them by their common name without the suffix.
-        val name = property.name.asString()
-        val suffix = propertySuffixes.firstOrNull { name.endsWith(it) } ?: return@groupBy name
-        name.substringBeforeLast(suffix)
-      }
+      .mapNotNull { GeneratedProperty.fromDescriptor(it) }
+      .groupBy { property -> property.baseName }
       .values
       .asSequence()
-      .filter { properties ->
-        // Double check that the number of properties matches how many suffixes we have and how
-        // many properties we expect.
-        properties.size == propertySuffixes.size
+      .mapNotNull { properties ->
+        val reference = properties.filterIsInstance<ReferenceProperty>().singleOrEmpty()
+          ?: throw AnvilCompilationException(
+            message = "Couldn't find the reference for a generated hint: ${properties[0].baseName}."
+          )
+
+        val scopes = properties.filterIsInstance<ScopeProperty>()
+          .ifEmpty {
+            throw AnvilCompilationException(
+              message = "Couldn't find any scope for a generated hint: ${properties[0].baseName}."
+            )
+          }
+          .map { it.descriptor.type.argumentType().classDescriptor().fqNameSafe }
+
+        // Look for the right scope even before resolving the class and resolving all its super
+        // types.
+        if (scope != null && scope !in scopes) return@mapNotNull null
+
+        reference.descriptor.type.argumentType()
+          .classDescriptor()
+          .toClassReference(module)
       }
-      .map { ContributedHint(it) }
-      .let { sequence ->
-        if (scope != null) {
-          sequence
-            .filter { hint ->
-              // The scope must match what we're looking for.
-              hint.scope.fqNameSafe == scope
-            }
-        } else {
-          sequence
-        }
-      }
-      .map { hint -> hint.reference.toClassReference(module) }
       .filter { clazz ->
         // Check that the annotation really is present. It should always be the case, but it's
         // a safetynet in case the generated properties are out of sync.
@@ -78,24 +83,41 @@ private fun PackageViewDescriptor.subPackages(): List<PackageViewDescriptor> = m
   .getContributedDescriptors(DescriptorKindFilter.PACKAGES)
   .filterIsInstance<PackageViewDescriptor>()
 
-private class ContributedHint(properties: List<PropertyDescriptor>) {
-  val reference by lazy(NONE) {
-    properties
-      .bySuffix(REFERENCE_SUFFIX)
-      .toClassDescriptor()
-  }
+private sealed class GeneratedProperty(
+  val descriptor: PropertyDescriptor,
+  val baseName: String
+) {
+  class ReferenceProperty(
+    descriptor: PropertyDescriptor,
+    baseName: String
+  ) : GeneratedProperty(descriptor, baseName)
 
-  val scope by lazy(NONE) {
-    properties
-      .bySuffix(SCOPE_SUFFIX)
-      .toClassDescriptor()
-  }
+  class ScopeProperty(
+    descriptor: PropertyDescriptor,
+    baseName: String
+  ) : GeneratedProperty(descriptor, baseName)
 
-  private fun List<PropertyDescriptor>.bySuffix(suffix: String): PropertyDescriptor = first {
-    it.name.asString()
-      .endsWith(suffix)
-  }
+  companion object {
+    fun fromDescriptor(descriptor: PropertyDescriptor): GeneratedProperty? {
+      // For each contributed hint there are several properties, e.g. the reference itself
+      // and the scopes. Group them by their common name without the suffix.
+      val name = descriptor.name.asString()
 
-  private fun PropertyDescriptor.toClassDescriptor(): ClassDescriptor =
-    type.argumentType().classDescriptor()
+      return when {
+        name.endsWith(REFERENCE_SUFFIX) ->
+          ReferenceProperty(descriptor, name.substringBeforeLast(REFERENCE_SUFFIX))
+        name.contains(SCOPE_SUFFIX) -> {
+          // The old scope hint didn't have a number. Now that there can be multiple scopes
+          // we append a number for all scopes, but we still need to support the old format.
+          val indexString = name.substringAfterLast(SCOPE_SUFFIX)
+          if (indexString.toIntOrNull() != null || indexString.isEmpty()) {
+            ScopeProperty(descriptor, name.substringBeforeLast(SCOPE_SUFFIX))
+          } else {
+            null
+          }
+        }
+        else -> null
+      }
+    }
+  }
 }

--- a/compiler/src/main/java/com/squareup/anvil/compiler/ClassScannerIr.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/ClassScannerIr.kt
@@ -14,14 +14,13 @@ import org.jetbrains.kotlin.name.FqName
 internal fun ClassScanner.findContributedClasses(
   pluginContext: IrPluginContext,
   moduleFragment: IrModuleFragment,
-  packageName: String,
   annotation: FqName,
   scope: ClassReferenceIr?,
   moduleDescriptorFactory: RealAnvilModuleDescriptor.Factory
 ): Sequence<ClassReferenceIr> {
   val module = moduleDescriptorFactory.create(moduleFragment.descriptor)
 
-  return findContributedClasses(module, packageName, annotation, scope?.fqName)
+  return findContributedClasses(module, annotation, scope?.fqName)
     .map {
       pluginContext.requireReferenceClass(it.fqName).toClassReference(pluginContext)
     }

--- a/compiler/src/main/java/com/squareup/anvil/compiler/Utils.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/Utils.kt
@@ -76,7 +76,6 @@ internal const val SUBCOMPONENT_MODULE = "SubcomponentModule"
 
 internal const val REFERENCE_SUFFIX = "_reference"
 internal const val SCOPE_SUFFIX = "_scope"
-internal val propertySuffixes = arrayOf(REFERENCE_SUFFIX, SCOPE_SUFFIX)
 
 internal fun FqName.isAnvilModule(): Boolean {
   val name = asString()
@@ -93,3 +92,30 @@ internal fun <T : ClassReference> ClassId.classReferenceOrNull(
 internal fun ClassDescriptor.shouldIgnore(): Boolean {
   return classId == null || DescriptorUtils.isAnonymousObject(this)
 }
+
+/**
+ * Returns the single element matching the given [predicate], or `null` if element was not found.
+ * Unlike [singleOrNull] this method throws an exception if more than one element is found.
+ */
+internal inline fun <T> Iterable<T>.singleOrEmpty(predicate: (T) -> Boolean): T? {
+  var single: T? = null
+  var found = false
+  for (element in this) {
+    if (predicate(element)) {
+      if (found) throw IllegalArgumentException(
+        "Collection contains more than one matching element."
+      )
+      single = element
+      found = true
+    }
+  }
+  return single
+}
+
+private val truePredicate: (Any?) -> Boolean = { true }
+
+/**
+ * Returns single element, or `null` if the collection is empty. Unlike [singleOrNull] this
+ * method throws an exception if more than one element is found.
+ */
+internal fun <T> Iterable<T>.singleOrEmpty(): T? = singleOrEmpty(truePredicate)

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesSubcomponentHandlerGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesSubcomponentHandlerGenerator.kt
@@ -4,7 +4,6 @@ import com.squareup.anvil.annotations.MergeSubcomponent
 import com.squareup.anvil.compiler.ANVIL_SUBCOMPONENT_SUFFIX
 import com.squareup.anvil.compiler.COMPONENT_PACKAGE_PREFIX
 import com.squareup.anvil.compiler.ClassScanner
-import com.squareup.anvil.compiler.HINT_SUBCOMPONENTS_PACKAGE_PREFIX
 import com.squareup.anvil.compiler.PARENT_COMPONENT
 import com.squareup.anvil.compiler.SUBCOMPONENT_FACTORY
 import com.squareup.anvil.compiler.SUBCOMPONENT_MODULE
@@ -397,7 +396,6 @@ internal class ContributesSubcomponentHandlerGenerator(
     contributions += classScanner
       .findContributedClasses(
         module = module,
-        packageName = HINT_SUBCOMPONENTS_PACKAGE_PREFIX,
         annotation = contributesSubcomponentFqName,
         scope = null
       )

--- a/compiler/src/test/java/com/squareup/anvil/compiler/MergeModulesTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/MergeModulesTest.kt
@@ -281,8 +281,8 @@ class MergeModulesTest {
       assertThat(messages).contains("Source0.kt: (17, 16)")
       assertThat(messages).contains(
         "com.squareup.test.DaggerModule2 with scope kotlin.Any wants to replace " +
-          "com.squareup.test.ContributingInterface with scope kotlin.Unit. The replacement " +
-          "must use the same scope."
+          "com.squareup.test.ContributingInterface, but the replaced class isn't contributed " +
+          "to the same scope."
       )
     }
   }
@@ -317,8 +317,8 @@ class MergeModulesTest {
       assertThat(messages).contains("Source0.kt: (17, 16)")
       assertThat(messages).contains(
         "com.squareup.test.DaggerModule2 with scope kotlin.Any wants to replace " +
-          "com.squareup.test.ContributingInterface with scope kotlin.Unit. The replacement " +
-          "must use the same scope."
+          "com.squareup.test.ContributingInterface, but the replaced class isn't contributed " +
+          "to the same scope."
       )
     }
   }
@@ -413,8 +413,8 @@ class MergeModulesTest {
       assertThat(messages).contains("Source0.kt: (17, 11)")
       assertThat(messages).contains(
         "com.squareup.test.ContributingInterface with scope kotlin.Any wants to replace " +
-          "com.squareup.test.DaggerModule2 with scope kotlin.Unit. The replacement must use " +
-          "the same scope."
+          "com.squareup.test.DaggerModule2, but the replaced class isn't contributed " +
+          "to the same scope."
       )
     }
   }
@@ -449,8 +449,8 @@ class MergeModulesTest {
       assertThat(messages).contains("Source0.kt: (17, 11)")
       assertThat(messages).contains(
         "com.squareup.test.ContributingInterface with scope kotlin.Any wants to replace " +
-          "com.squareup.test.DaggerModule2 with scope kotlin.Unit. The replacement must use " +
-          "the same scope."
+          "com.squareup.test.DaggerModule2, but the replaced class isn't contributed " +
+          "to the same scope."
       )
     }
   }
@@ -510,8 +510,8 @@ class MergeModulesTest {
       assertThat(messages).contains("Source0.kt: (15, 16)")
       assertThat(messages).contains(
         "com.squareup.test.DaggerModule2 with scope kotlin.Any wants to replace " +
-          "com.squareup.test.DaggerModule3 with scope kotlin.Unit. The replacement must use " +
-          "the same scope."
+          "com.squareup.test.DaggerModule3, but the replaced class isn't contributed " +
+          "to the same scope."
       )
     }
   }
@@ -605,8 +605,8 @@ class MergeModulesTest {
       assertThat(messages).contains("Source0.kt: (16, 7)")
       assertThat(messages).contains(
         "com.squareup.test.DaggerModule1 with scope kotlin.Any wants to exclude " +
-          "com.squareup.test.DaggerModule2 with scope kotlin.Unit. The exclusion must " +
-          "use the same scope."
+          "com.squareup.test.DaggerModule2, but the excluded class isn't contributed " +
+          "to the same scope."
       )
     }
   }
@@ -690,8 +690,8 @@ class MergeModulesTest {
       assertThat(messages).contains("Source0.kt: (17, 11)")
       assertThat(messages).contains(
         "com.squareup.test.ComponentInterface with scope kotlin.Any wants to exclude " +
-          "com.squareup.test.ContributingInterface with scope kotlin.Unit. The exclusion " +
-          "must use the same scope."
+          "com.squareup.test.ContributingInterface, but the excluded class isn't contributed " +
+          "to the same scope."
       )
     }
   }
@@ -723,8 +723,8 @@ class MergeModulesTest {
       assertThat(messages).contains("Source0.kt: (17, 11)")
       assertThat(messages).contains(
         "com.squareup.test.ComponentInterface with scope kotlin.Any wants to exclude " +
-          "com.squareup.test.ContributingInterface with scope kotlin.Unit. The exclusion " +
-          "must use the same scope."
+          "com.squareup.test.ContributingInterface, but the excluded class isn't contributed " +
+          "to the same scope."
       )
     }
   }
@@ -910,6 +910,108 @@ class MergeModulesTest {
 
       assertThat(daggerModule3.daggerModule.includes.withoutAnvilModule())
         .containsExactly(daggerModule1.kotlin)
+    }
+  }
+
+  @Test fun `modules contributed to multiple scopes are merged`() {
+    assumeIrBackend()
+
+    compile(
+      """
+      package com.squareup.test
+      
+      import com.squareup.anvil.annotations.compat.MergeModules
+      import com.squareup.anvil.annotations.ContributesTo
+      
+      @ContributesTo(Any::class)
+      @ContributesTo(Unit::class)
+      @dagger.Module
+      abstract class DaggerModule3
+      
+      @ContributesTo(Any::class)
+      @dagger.Module
+      abstract class DaggerModule4
+      
+      @MergeModules(Any::class)
+      class DaggerModule1
+      
+      @MergeModules(Unit::class)
+      class DaggerModule2
+      """
+    ) {
+      assertThat(daggerModule1.daggerModule.includes.withoutAnvilModule())
+        .containsExactly(daggerModule3.kotlin, daggerModule4.kotlin)
+
+      assertThat(daggerModule2.daggerModule.includes.withoutAnvilModule())
+        .containsExactly(daggerModule3.kotlin)
+    }
+  }
+
+  @Test fun `modules contributed to multiple scopes can be replaced`() {
+    assumeIrBackend()
+
+    compile(
+      """
+      package com.squareup.test
+      
+      import com.squareup.anvil.annotations.compat.MergeModules
+      import com.squareup.anvil.annotations.ContributesTo
+      
+      @ContributesTo(Any::class)
+      @ContributesTo(Unit::class)
+      @dagger.Module
+      abstract class DaggerModule3
+      
+      @ContributesTo(Any::class, replaces = [DaggerModule3::class])
+      @dagger.Module
+      abstract class DaggerModule4
+      
+      @MergeModules(Any::class)
+      class DaggerModule1
+      
+      @MergeModules(Unit::class)
+      class DaggerModule2
+      """
+    ) {
+      assertThat(daggerModule1.daggerModule.includes.withoutAnvilModule())
+        .containsExactly(daggerModule4.kotlin)
+
+      assertThat(daggerModule2.daggerModule.includes.withoutAnvilModule())
+        .containsExactly(daggerModule3.kotlin)
+    }
+  }
+
+  @Test fun `modules contributed to multiple scopes can be excluded in one scope`() {
+    assumeIrBackend()
+
+    compile(
+      """
+      package com.squareup.test
+      
+      import com.squareup.anvil.annotations.compat.MergeModules
+      import com.squareup.anvil.annotations.ContributesTo
+      
+      @ContributesTo(Any::class)
+      @ContributesTo(Unit::class)
+      @dagger.Module
+      abstract class DaggerModule3
+      
+      @ContributesTo(Any::class)
+      @dagger.Module
+      abstract class DaggerModule4
+      
+      @MergeModules(Any::class, exclude = [DaggerModule3::class])
+      class DaggerModule1
+      
+      @MergeModules(Unit::class)
+      class DaggerModule2
+      """
+    ) {
+      assertThat(daggerModule1.daggerModule.includes.withoutAnvilModule())
+        .containsExactly(daggerModule4.kotlin)
+
+      assertThat(daggerModule2.daggerModule.includes.withoutAnvilModule())
+        .containsExactly(daggerModule3.kotlin)
     }
   }
 }

--- a/compiler/src/test/java/com/squareup/anvil/compiler/ModuleMergerTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/ModuleMergerTest.kt
@@ -3,13 +3,14 @@ package com.squareup.anvil.compiler
 import com.google.common.truth.Truth.assertThat
 import com.squareup.anvil.annotations.MergeComponent
 import com.squareup.anvil.annotations.MergeSubcomponent
+import com.squareup.anvil.compiler.internal.testing.AnvilCompilation
 import com.squareup.anvil.compiler.internal.testing.AnyDaggerComponent
 import com.squareup.anvil.compiler.internal.testing.anyDaggerComponent
 import com.squareup.anvil.compiler.internal.testing.daggerComponent
 import com.squareup.anvil.compiler.internal.testing.daggerModule
 import com.squareup.anvil.compiler.internal.testing.daggerSubcomponent
 import com.squareup.anvil.compiler.internal.testing.withoutAnvilModule
-import com.tschuchort.compiletesting.KotlinCompilation.ExitCode
+import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.OK
 import dagger.Component
 import dagger.Subcomponent
 import org.junit.Assume.assumeTrue
@@ -129,7 +130,6 @@ class ModuleMergerTest(
       """
     ) {
       assertThat(exitCode).isError()
-      // Position to the class.
       assertThat(messages).contains("Source0.kt: (7, 11)")
     }
   }
@@ -220,7 +220,6 @@ class ModuleMergerTest(
       """
     ) {
       assertThat(exitCode).isError()
-      // Position to the class.
       assertThat(messages).contains("Source0.kt: (7, 16)")
     }
   }
@@ -343,12 +342,11 @@ class ModuleMergerTest(
       """
     ) {
       assertThat(exitCode).isError()
-      // Position to the class.
       assertThat(messages).contains("Source0.kt: (17, 16)")
       assertThat(messages).contains(
         "com.squareup.test.DaggerModule1 with scope kotlin.Any wants to replace " +
-          "com.squareup.test.ContributingInterface with scope kotlin.Unit. The replacement " +
-          "must use the same scope."
+          "com.squareup.test.ContributingInterface, but the replaced class isn't contributed " +
+          "to the same scope."
       )
     }
   }
@@ -379,12 +377,11 @@ class ModuleMergerTest(
       """
     ) {
       assertThat(exitCode).isError()
-      // Position to the class.
       assertThat(messages).contains("Source0.kt: (17, 16)")
       assertThat(messages).contains(
         "com.squareup.test.DaggerModule1 with scope kotlin.Any wants to replace " +
-          "com.squareup.test.ContributingInterface with scope kotlin.Unit. The replacement " +
-          "must use the same scope."
+          "com.squareup.test.ContributingInterface, but the replaced class isn't contributed " +
+          "to the same scope."
       )
     }
   }
@@ -475,12 +472,11 @@ class ModuleMergerTest(
       """
     ) {
       assertThat(exitCode).isError()
-      // Position to the class.
       assertThat(messages).contains("Source0.kt: (17, 11)")
       assertThat(messages).contains(
         "com.squareup.test.ContributingInterface with scope kotlin.Any wants to replace " +
-          "com.squareup.test.DaggerModule1 with scope kotlin.Unit. The replacement must use " +
-          "the same scope."
+          "com.squareup.test.DaggerModule1, but the replaced class isn't contributed " +
+          "to the same scope."
       )
     }
   }
@@ -511,12 +507,11 @@ class ModuleMergerTest(
       """
     ) {
       assertThat(exitCode).isError()
-      // Position to the class.
       assertThat(messages).contains("Source0.kt: (17, 11)")
       assertThat(messages).contains(
         "com.squareup.test.ContributingInterface with scope kotlin.Any wants to replace " +
-          "com.squareup.test.DaggerModule1 with scope kotlin.Unit. The replacement must use " +
-          "the same scope."
+          "com.squareup.test.DaggerModule1, but the replaced class isn't contributed " +
+          "to the same scope."
       )
     }
   }
@@ -543,7 +538,6 @@ class ModuleMergerTest(
       """
     ) {
       assertThat(exitCode).isError()
-      // Position to the class.
       assertThat(messages).contains("Source0.kt: (13, 16)")
     }
   }
@@ -572,12 +566,11 @@ class ModuleMergerTest(
       """
     ) {
       assertThat(exitCode).isError()
-      // Position to the class.
       assertThat(messages).contains("Source0.kt: (15, 16)")
       assertThat(messages).contains(
         "com.squareup.test.DaggerModule2 with scope kotlin.Any wants to replace " +
-          "com.squareup.test.DaggerModule1 with scope kotlin.Unit. The replacement must " +
-          "use the same scope."
+          "com.squareup.test.DaggerModule1, but the replaced class isn't contributed " +
+          "to the same scope."
       )
     }
   }
@@ -672,12 +665,11 @@ class ModuleMergerTest(
       """
     ) {
       assertThat(exitCode).isError()
-      // Position to the class.
       assertThat(messages).contains("Source0.kt: (20, 11)")
       assertThat(messages).contains(
         "com.squareup.test.ComponentInterface with scope kotlin.Any wants to exclude " +
-          "com.squareup.test.DaggerModule1 with scope kotlin.Unit. The exclusion must use " +
-          "the same scope."
+          "com.squareup.test.DaggerModule1, but the excluded class isn't contributed " +
+          "to the same scope."
       )
     }
   }
@@ -822,12 +814,11 @@ class ModuleMergerTest(
       """
     ) {
       assertThat(exitCode).isError()
-      // Position to the class.
       assertThat(messages).contains("Source0.kt: (17, 11)")
       assertThat(messages).contains(
         "com.squareup.test.ComponentInterface with scope kotlin.Any wants to exclude " +
-          "com.squareup.test.ContributingInterface with scope kotlin.Unit. The exclusion " +
-          "must use the same scope."
+          "com.squareup.test.ContributingInterface, but the excluded class isn't contributed " +
+          "to the same scope."
       )
     }
   }
@@ -855,12 +846,11 @@ class ModuleMergerTest(
       """
     ) {
       assertThat(exitCode).isError()
-      // Position to the class.
       assertThat(messages).contains("Source0.kt: (17, 11)")
       assertThat(messages).contains(
         "com.squareup.test.ComponentInterface with scope kotlin.Any wants to exclude " +
-          "com.squareup.test.ContributingInterface with scope kotlin.Unit. The exclusion " +
-          "must use the same scope."
+          "com.squareup.test.ContributingInterface, but the excluded class isn't contributed " +
+          "to the same scope."
       )
     }
   }
@@ -952,7 +942,6 @@ class ModuleMergerTest(
         """
       ) {
         assertThat(exitCode).isError()
-        // Position to the class.
         assertThat(messages).contains("Source0.kt: (8, ")
       }
     }
@@ -1128,9 +1117,6 @@ class ModuleMergerTest(
     }
   }
 
-  private val Class<*>.anyDaggerComponent: AnyDaggerComponent
-    get() = anyDaggerComponent(annotationClass)
-
   @Test fun `locally defined classes without a classId are skipped over when merging modules`() {
     assumeTrue(USE_IR)
 
@@ -1173,7 +1159,243 @@ class ModuleMergerTest(
       interface ComponentInterface
       """
     ) {
-      assertThat(exitCode).isEqualTo(ExitCode.OK)
+      assertThat(exitCode).isEqualTo(OK)
     }
   }
+
+  @Test fun `modules contributed to multiple scopes are merged`() {
+    assumeIrBackend()
+
+    compile(
+      """
+      package com.squareup.test
+      
+      import com.squareup.anvil.annotations.ContributesTo
+      $import
+      
+      @ContributesTo(Any::class)
+      @ContributesTo(Unit::class)
+      @dagger.Module
+      abstract class DaggerModule1
+      
+      @ContributesTo(Any::class)
+      @dagger.Module
+      abstract class DaggerModule2
+      
+      $annotation(Any::class)
+      interface ComponentInterface
+      
+      $annotation(Unit::class)
+      interface SubcomponentInterface
+      """
+    ) {
+      assertThat(componentInterface.anyDaggerComponent.modules.withoutAnvilModule())
+        .containsExactly(daggerModule1.kotlin, daggerModule2.kotlin)
+
+      assertThat(subcomponentInterface.anyDaggerComponent.modules.withoutAnvilModule())
+        .containsExactly(daggerModule1.kotlin)
+    }
+  }
+
+  @Test fun `modules contributed to multiple scopes are merged with multiple compilations`() {
+    assumeIrBackend()
+
+    val firstResult = compile(
+      """
+      package com.squareup.test
+      
+      import com.squareup.anvil.annotations.ContributesTo
+      import dagger.Module
+        
+      @ContributesTo(Any::class)
+      @ContributesTo(Unit::class)
+      @Module
+      abstract class DaggerModule1
+      """
+    ) {
+      assertThat(exitCode).isEqualTo(OK)
+    }
+
+    compile(
+      """
+      package com.squareup.test
+      
+      import com.squareup.anvil.annotations.ContributesTo
+      $import
+      
+      @ContributesTo(Any::class)
+      @dagger.Module
+      abstract class DaggerModule2
+      
+      $annotation(Any::class)
+      interface ComponentInterface
+      
+      $annotation(Unit::class)
+      interface SubcomponentInterface
+      """,
+      previousCompilationResult = firstResult
+    ) {
+      assertThat(componentInterface.anyDaggerComponent.modules.withoutAnvilModule())
+        .containsExactly(daggerModule1.kotlin, daggerModule2.kotlin)
+
+      assertThat(subcomponentInterface.anyDaggerComponent.modules.withoutAnvilModule())
+        .containsExactly(daggerModule1.kotlin)
+    }
+  }
+
+  @Test fun `modules contributed to multiple scopes can be replaced`() {
+    assumeIrBackend()
+
+    compile(
+      """
+      package com.squareup.test
+      
+      import com.squareup.anvil.annotations.ContributesTo
+      $import
+      
+      @ContributesTo(Any::class)
+      @ContributesTo(Unit::class)
+      @dagger.Module
+      abstract class DaggerModule1
+      
+      @ContributesTo(Any::class, replaces = [DaggerModule1::class])
+      @dagger.Module
+      abstract class DaggerModule2
+      
+      $annotation(Any::class)
+      interface ComponentInterface
+      
+      $annotation(Unit::class)
+      interface SubcomponentInterface
+      """
+    ) {
+      assertThat(componentInterface.anyDaggerComponent.modules.withoutAnvilModule())
+        .containsExactly(daggerModule2.kotlin)
+
+      assertThat(subcomponentInterface.anyDaggerComponent.modules.withoutAnvilModule())
+        .containsExactly(daggerModule1.kotlin)
+    }
+  }
+
+  @Test
+  fun `replaced module contributed to multiple scopes must use the same scope`() {
+    assumeIrBackend()
+
+    compile(
+      """
+      package com.squareup.test
+      
+      import com.squareup.anvil.annotations.ContributesTo
+      $import
+      
+      @ContributesTo(Any::class)
+      @ContributesTo(Unit::class)
+      @dagger.Module
+      abstract class DaggerModule1
+      
+      @ContributesTo(Int::class, replaces = [DaggerModule1::class])
+      @dagger.Module
+      abstract class DaggerModule2
+      
+      $annotation(Any::class)
+      interface ComponentInterface
+      
+      $annotation(Unit::class)
+      interface SubcomponentInterface1
+      
+      $annotation(Int::class)
+      interface SubcomponentInterface2
+      """
+    ) {
+      assertThat(exitCode).isError()
+      assertThat(messages).contains(
+        "com.squareup.test.DaggerModule2 with scope kotlin.Int wants to replace " +
+          "com.squareup.test.DaggerModule1, but the replaced class isn't contributed to the " +
+          "same scope."
+      )
+    }
+  }
+
+  @Test fun `modules contributed to multiple scopes can be excluded in one scope`() {
+    assumeIrBackend()
+
+    compile(
+      """
+      package com.squareup.test
+      
+      import com.squareup.anvil.annotations.ContributesTo
+      $import
+      
+      @ContributesTo(Any::class)
+      @ContributesTo(Unit::class)
+      @dagger.Module
+      abstract class DaggerModule1
+      
+      @ContributesTo(Any::class)
+      @dagger.Module
+      abstract class DaggerModule2
+      
+      $annotation(Any::class, exclude = [DaggerModule1::class])
+      interface ComponentInterface
+      
+      $annotation(Unit::class)
+      interface SubcomponentInterface
+      """
+    ) {
+      assertThat(componentInterface.anyDaggerComponent.modules.withoutAnvilModule())
+        .containsExactly(daggerModule2.kotlin)
+
+      assertThat(subcomponentInterface.anyDaggerComponent.modules.withoutAnvilModule())
+        .containsExactly(daggerModule1.kotlin)
+    }
+  }
+
+  @Test fun `contributed modules in the old format are picked up`() {
+    val result = AnvilCompilation()
+      .useIR(USE_IR)
+      .configureAnvil(enableAnvil = false)
+      .compile(
+        """
+        package com.squareup.test
+      
+        import com.squareup.anvil.annotations.ContributesTo
+        import dagger.Module
+        
+        @ContributesTo(Any::class)
+        @Module
+        abstract class DaggerModule1  
+        """,
+        """
+        package anvil.hint.merge.com.squareup.test
+
+        import com.squareup.test.DaggerModule1
+        import kotlin.reflect.KClass
+        
+        public val com_squareup_test_DaggerModule1_reference: KClass<DaggerModule1> = DaggerModule1::class
+        
+        // Note that the number is missing after the scope. 
+        public val com_squareup_test_DaggerModule1_scope: KClass<Any> = Any::class
+        """.trimIndent()
+      ) {
+        assertThat(exitCode).isEqualTo(OK)
+      }
+
+    compile(
+      """
+      package com.squareup.test
+      
+      $import
+      
+      $annotation(Any::class)
+      interface ComponentInterface
+      """,
+      previousCompilationResult = result
+    ) {
+      assertThat(componentInterface.anyDaggerComponent.modules.withoutAnvilModule())
+        .containsExactly(daggerModule1.kotlin)
+    }
+  }
+
+  private val Class<*>.anyDaggerComponent: AnyDaggerComponent
+    get() = anyDaggerComponent(annotationClass)
 }

--- a/compiler/src/test/java/com/squareup/anvil/compiler/codegen/ContributesSubcomponentHandlerGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/codegen/ContributesSubcomponentHandlerGeneratorTest.kt
@@ -869,8 +869,8 @@ class ContributesSubcomponentHandlerGeneratorTest {
       assertThat(exitCode).isError()
       assertThat(messages).contains(
         "com.squareup.test.ComponentInterface with scope kotlin.Any wants to exclude " +
-          "com.squareup.test.SubcomponentInterface with scope kotlin.Int. The exclusion " +
-          "must use the same scope."
+          "com.squareup.test.SubcomponentInterface, but the excluded class isn't contributed " +
+          "to the same scope."
       )
     }
   }

--- a/compiler/src/test/java/com/squareup/anvil/compiler/codegen/ContributesToGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/codegen/ContributesToGeneratorTest.kt
@@ -1,18 +1,22 @@
 package com.squareup.anvil.compiler.codegen
 
 import com.google.common.truth.Truth.assertThat
+import com.squareup.anvil.compiler.assumeIrBackend
 import com.squareup.anvil.compiler.compile
 import com.squareup.anvil.compiler.componentInterface
 import com.squareup.anvil.compiler.contributingInterface
 import com.squareup.anvil.compiler.daggerModule1
+import com.squareup.anvil.compiler.daggerModule2
 import com.squareup.anvil.compiler.hintContributes
 import com.squareup.anvil.compiler.hintContributesScope
+import com.squareup.anvil.compiler.hintContributesScopes
 import com.squareup.anvil.compiler.innerInterface
 import com.squareup.anvil.compiler.innerModule
 import com.squareup.anvil.compiler.isError
 import org.junit.Test
 import java.io.File
 
+@Suppress("RemoveRedundantQualifierName")
 class ContributesToGeneratorTest {
 
   @Test fun `there is no hint for merge annotations`() {
@@ -65,6 +69,123 @@ class ContributesToGeneratorTest {
         .single { it.isFile && it.extension == "kt" }
 
       assertThat(generatedFile.name).isEqualTo("DaggerModule1.kt")
+    }
+  }
+
+  @Test fun `there are multiple hints for contributed Dagger modules`() {
+    assumeIrBackend()
+
+    compile(
+      """
+      package com.squareup.test
+
+      import com.squareup.anvil.annotations.ContributesTo
+      import dagger.Module
+
+      @ContributesTo(Any::class)
+      @ContributesTo(Unit::class)
+      @Module
+      abstract class DaggerModule1
+      """
+    ) {
+      assertThat(daggerModule1.hintContributes?.java).isEqualTo(daggerModule1)
+      assertThat(daggerModule1.hintContributesScopes).containsExactly(Any::class, Unit::class)
+    }
+  }
+
+  @Test fun `the scopes for multiple contributions have a stable sort`() {
+    assumeIrBackend()
+
+    compile(
+      """
+      package com.squareup.test
+
+      import com.squareup.anvil.annotations.ContributesTo
+      import dagger.Module
+
+      @ContributesTo(Any::class)
+      @ContributesTo(Unit::class)
+      @Module
+      abstract class DaggerModule1
+
+      @ContributesTo(Unit::class)
+      @ContributesTo(Any::class)
+      @Module
+      abstract class DaggerModule2
+      """
+    ) {
+      assertThat(daggerModule1.hintContributesScopes)
+        .containsExactly(Any::class, Unit::class)
+        .inOrder()
+      assertThat(daggerModule2.hintContributesScopes)
+        .containsExactly(Any::class, Unit::class)
+        .inOrder()
+    }
+  }
+
+  @Test fun `there are multiple hints for contributed Dagger modules with fully qualified names`() {
+    assumeIrBackend()
+
+    compile(
+      """
+      package com.squareup.test
+
+      import com.squareup.anvil.annotations.ContributesTo
+
+      @ContributesTo(Any::class)
+      @com.squareup.anvil.annotations.ContributesTo(Unit::class)
+      @dagger.Module
+      abstract class DaggerModule1
+      """
+    ) {
+      assertThat(daggerModule1.hintContributes?.java).isEqualTo(daggerModule1)
+      assertThat(daggerModule1.hintContributesScopes).containsExactly(Any::class, Unit::class)
+    }
+  }
+
+  @Test fun `there are multiple hints for contributed Dagger modules with star imports`() {
+    assumeIrBackend()
+
+    compile(
+      """
+      package com.squareup.test
+
+      import com.squareup.anvil.annotations.*
+
+      @ContributesTo(Any::class)
+      @com.squareup.anvil.annotations.ContributesTo(Unit::class)
+      @dagger.Module
+      abstract class DaggerModule1
+      """
+    ) {
+      assertThat(daggerModule1.hintContributes?.java).isEqualTo(daggerModule1)
+      assertThat(daggerModule1.hintContributesScopes).containsExactly(Any::class, Unit::class)
+    }
+  }
+
+  @Test fun `multiple annotations with the same scope aren't allowed`() {
+    assumeIrBackend()
+
+    compile(
+      """
+      package com.squareup.test
+
+      import com.squareup.anvil.annotations.ContributesTo
+
+      @ContributesTo(Any::class)
+      @ContributesTo(Any::class, replaces = [Int::class])
+      @ContributesTo(Unit::class)
+      @ContributesTo(Unit::class, replaces = [Int::class])
+      @dagger.Module
+      abstract class DaggerModule1
+      """
+    ) {
+      assertThat(exitCode).isError()
+      assertThat(messages).contains(
+        "com.squareup.test.DaggerModule1 contributes multiple times to the same scope: " +
+          "[Any, Unit]. Contributing multiple times to the same scope is forbidden and all " +
+          "scopes must be distinct."
+      )
     }
   }
 

--- a/docs/INTERNALS.md
+++ b/docs/INTERNALS.md
@@ -111,14 +111,18 @@ view, but it increased total build time by 20%. Using hints reduced the overhead
 
 A hint is a pointer to the class that is being contributed and implemented by a property.
 For performance reasons and faster filtering without resolving all contributed types we
-additionally create a property for the scope:
+additionally create properties for the scopes. Note that Anvil annotations can be repeatable. We
+only need one reference property to point to the contributed class, but we need multiple scope
+properties for each contribution to a specific scope:
 
 ```kotlin
 package anvil.hint.binding.com.squareup.anvil.test
 
 val com_squareup_anvil_test_AppBinding_reference: KClass<AppBinding> = AppBinding::class
 
-val com_squareup_anvil_test_AppBinding_scope: KClass<AppScope> = AppScope::class
+val com_squareup_anvil_test_AppBinding_scope_1: KClass<AppScope> = AppScope::class
+
+val com_squareup_anvil_test_AppBinding_scope_2: KClass<AppScope> = OtherScope::class
 ```
 
 With that hint we can query all top-level properties within the `anvil.hint.*` package. Our

--- a/integration-tests/library/src/main/java/com/squareup/anvil/test/RepeatableContributions.kt
+++ b/integration-tests/library/src/main/java/com/squareup/anvil/test/RepeatableContributions.kt
@@ -1,0 +1,21 @@
+package com.squareup.anvil.test
+
+import com.squareup.anvil.annotations.ContributesTo
+import dagger.Module
+import dagger.Provides
+
+public abstract class RepeatedScope1 private constructor()
+public abstract class RepeatedScope2 private constructor()
+
+@ContributesTo(RepeatedScope1::class)
+@ContributesTo(RepeatedScope2::class)
+public interface RepeatedInterface {
+  public fun string(): String
+}
+
+@ContributesTo(RepeatedScope1::class)
+@ContributesTo(RepeatedScope2::class)
+@Module
+public object RepeatedModule {
+  @Provides public fun provideString(): String = "Hello"
+}

--- a/integration-tests/tests/src/test/java/com/squareup/anvil/test/RepeatedContributionsTest.kt
+++ b/integration-tests/tests/src/test/java/com/squareup/anvil/test/RepeatedContributionsTest.kt
@@ -1,0 +1,63 @@
+package com.squareup.anvil.test
+
+import com.google.common.truth.Truth.assertThat
+import com.squareup.anvil.annotations.ContributesTo
+import com.squareup.anvil.annotations.MergeComponent
+import com.squareup.anvil.annotations.MergeSubcomponent
+import com.squareup.anvil.compiler.internal.testing.extends
+import com.squareup.anvil.compiler.internal.testing.withoutAnvilModule
+import dagger.Component
+import dagger.Module
+import dagger.Provides
+import dagger.Subcomponent
+import org.junit.Test
+
+class RepeatedContributionsTest {
+
+  @Test fun `repeated contributions are merged properly`() {
+    val componentAnnotation = RepeatedComponent1::class.java
+      .getAnnotation(Component::class.java)!!
+    assertThat(componentAnnotation.modules.withoutAnvilModule())
+      .containsExactly(RepeatedModule::class, RepeatedModuleInt::class)
+
+    assertThat(RepeatedComponent1::class extends RepeatedInterface::class).isTrue()
+    assertThat(RepeatedComponent1::class extends RepeatedInterfaceInt::class).isTrue()
+
+    val component = DaggerRepeatedContributionsTest_RepeatedComponent1.create()
+    assertThat((component as RepeatedInterface).string()).isEqualTo("Hello")
+    assertThat((component as RepeatedInterfaceInt).integer()).isEqualTo(5)
+
+    val subcomponentAnnotation = RepeatedComponent2::class.java
+      .getAnnotation(Subcomponent::class.java)!!
+    assertThat(subcomponentAnnotation.modules.withoutAnvilModule())
+      .containsExactly(RepeatedModule::class, RepeatedModuleInt::class)
+
+    assertThat(RepeatedComponent2::class extends RepeatedInterface::class).isTrue()
+    assertThat(RepeatedComponent2::class extends RepeatedInterfaceInt::class).isTrue()
+
+    val subcomponent = component.subcomponent()
+    assertThat((subcomponent as RepeatedInterface).string()).isEqualTo("Hello")
+    assertThat((subcomponent as RepeatedInterfaceInt).integer()).isEqualTo(5)
+  }
+
+  @MergeComponent(RepeatedScope1::class)
+  interface RepeatedComponent1 {
+    fun subcomponent(): RepeatedComponent2
+  }
+
+  @MergeSubcomponent(RepeatedScope2::class)
+  interface RepeatedComponent2
+
+  @ContributesTo(RepeatedScope1::class)
+  @ContributesTo(RepeatedScope2::class)
+  interface RepeatedInterfaceInt {
+    fun integer(): Int
+  }
+
+  @ContributesTo(RepeatedScope1::class)
+  @ContributesTo(RepeatedScope2::class)
+  @Module
+  object RepeatedModuleInt {
+    @Provides fun provideInteger(): Int = 5
+  }
+}


### PR DESCRIPTION
While you now can have multiple `@ContributesTo` annotations for Dagger modules and component interfaces, they all must have a different scope (contributing to the same scope twice is redundant).