### PR TITLE
Ignore classes without a classId when merging interfaces and modules

### DIFF
--- a/compiler/src/main/java/com/squareup/anvil/compiler/InterfaceMerger.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/InterfaceMerger.kt
@@ -14,7 +14,6 @@ import com.squareup.anvil.compiler.internal.reference.toClassReference
 import org.jetbrains.kotlin.descriptors.ClassDescriptor
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 import org.jetbrains.kotlin.name.Name
-import org.jetbrains.kotlin.resolve.DescriptorUtils
 import org.jetbrains.kotlin.resolve.descriptorUtil.module
 import org.jetbrains.kotlin.resolve.extensions.SyntheticResolveExtension
 import org.jetbrains.kotlin.types.KotlinType
@@ -31,9 +30,7 @@ internal class InterfaceMerger(
     thisDescriptor: ClassDescriptor,
     supertypes: MutableList<KotlinType>
   ) {
-    // If we're evaluating an anonymous inner class, it cannot merge anything and will cause
-    // a failure if we try to resolve its [ClassId]
-    if (DescriptorUtils.isAnonymousObject(thisDescriptor)) return
+    if (thisDescriptor.shouldIgnore()) return
 
     val module = moduleDescriptorFactory.create(thisDescriptor.module)
     val mergeAnnotatedClass = thisDescriptor.toClassReference(module)

--- a/compiler/src/main/java/com/squareup/anvil/compiler/IrUtils.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/IrUtils.kt
@@ -14,6 +14,7 @@ import org.jetbrains.kotlin.ir.types.classifierOrNull
 import org.jetbrains.kotlin.ir.types.typeOrNull
 import org.jetbrains.kotlin.ir.util.classId
 import org.jetbrains.kotlin.ir.util.fqNameWhenAvailable
+import org.jetbrains.kotlin.ir.util.isAnonymousObject
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.FqName
 
@@ -52,3 +53,9 @@ internal val IrDeclarationWithName.fqName: FqName
   )
 
 internal val IrClassSymbol.fqName: FqName get() = owner.fqName
+
+// If we're evaluating an anonymous inner class, it cannot merge anything and will cause
+// a failure if we try to resolve its [ClassId]
+internal fun IrClass.shouldIgnore(): Boolean {
+  return classId == null || isAnonymousObject
+}

--- a/compiler/src/main/java/com/squareup/anvil/compiler/ModuleMerger.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/ModuleMerger.kt
@@ -27,7 +27,6 @@ import org.jetbrains.kotlin.codegen.extensions.ExpressionCodegenExtension
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
-import org.jetbrains.kotlin.resolve.DescriptorUtils
 import org.jetbrains.kotlin.resolve.constants.ArrayValue
 import org.jetbrains.kotlin.resolve.constants.ConstantValue
 import org.jetbrains.kotlin.resolve.descriptorUtil.module
@@ -47,9 +46,7 @@ internal class ModuleMerger(
 ) : ExpressionCodegenExtension {
 
   override fun generateClassSyntheticParts(codegen: ImplementationBodyCodegen) {
-    // If we're evaluating an anonymous inner class, it cannot merge anything and will cause
-    // a failure if we try to resolve its [ClassId]
-    if (DescriptorUtils.isAnonymousObject(codegen.descriptor)) return
+    if (codegen.descriptor.shouldIgnore()) return
 
     val module = moduleDescriptorFactory.create(codegen.descriptor.module)
     val clazz = codegen.descriptor.toClassReference(module)

--- a/compiler/src/main/java/com/squareup/anvil/compiler/ModuleMergerIr.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/ModuleMergerIr.kt
@@ -23,7 +23,6 @@ import org.jetbrains.kotlin.ir.expressions.impl.IrVarargImpl
 import org.jetbrains.kotlin.ir.types.defaultType
 import org.jetbrains.kotlin.ir.types.impl.IrDynamicTypeImpl
 import org.jetbrains.kotlin.ir.util.defaultType
-import org.jetbrains.kotlin.ir.util.isAnonymousObject
 import org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
@@ -40,9 +39,7 @@ internal class ModuleMergerIr(
     moduleFragment.transform(
       object : IrElementTransformerVoid() {
         override fun visitClass(declaration: IrClass): IrStatement {
-          // If we're evaluating an anonymous inner class, it cannot merge anything and will cause
-          // a failure if we try to resolve its [ClassId]
-          if (declaration.isAnonymousObject) return super.visitClass(declaration)
+          if (declaration.shouldIgnore()) return super.visitClass(declaration)
 
           val declarationReference = declaration.symbol.toClassReference(pluginContext)
           val annotationContext = AnnotationContext.create(declarationReference)

--- a/compiler/src/main/java/com/squareup/anvil/compiler/Utils.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/Utils.kt
@@ -21,9 +21,12 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.internal.DoubleCheck
+import org.jetbrains.kotlin.descriptors.ClassDescriptor
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.resolve.DescriptorUtils
+import org.jetbrains.kotlin.resolve.descriptorUtil.classId
 import javax.inject.Inject
 import javax.inject.Provider
 import javax.inject.Qualifier
@@ -84,3 +87,9 @@ internal fun FqName.isAnvilModule(): Boolean {
 internal fun <T : ClassReference> ClassId.classReferenceOrNull(
   module: ModuleDescriptor
 ): T? = asSingleFqName().toClassReferenceOrNull(module) as T?
+
+// If we're evaluating an anonymous inner class, it cannot merge anything and will cause
+// a failure if we try to resolve its [ClassId]
+internal fun ClassDescriptor.shouldIgnore(): Boolean {
+  return classId == null || DescriptorUtils.isAnonymousObject(this)
+}


### PR DESCRIPTION
Co-authored by @vRallev 