### PR TITLE
Allow contributing multiple bindings with the same scope.

### DIFF
--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/BindingModuleGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/BindingModuleGenerator.kt
@@ -309,7 +309,7 @@ private fun List<ContributedBinding>.findHighestPriorityBinding(): ContributedBi
   if (bindings.size > 1) {
     throw AnvilCompilationException(
       "There are multiple contributed bindings with the same bound type. The bound type is " +
-        "${bindings[0].boundTypeClassName}. The contributed binding classes are: " +
+        "${bindings[0].boundType.fqName}. The contributed binding classes are: " +
         bindings.joinToString(
           prefix = "[",
           postfix = "]"
@@ -326,11 +326,14 @@ private fun ContributedBinding.toGeneratedMethod(
 
   val isMapMultibinding = mapKeys.isNotEmpty()
 
+  val methodNameSubString = contributedClass.fqName.pathSegments()
+    .map { it.asString() }
+    .plus(boundType.shortName)
+
   return if (contributedClass.isObject()) {
     ProviderMethod(
       FunSpec.builder(
-        name = contributedClass.fqName.asString()
-          .split(".")
+        name = methodNameSubString
           .joinToString(
             separator = "",
             prefix = "provide",
@@ -348,15 +351,14 @@ private fun ContributedBinding.toGeneratedMethod(
         }
         .addAnnotations(qualifiers)
         .addAnnotations(mapKeys)
-        .returns(boundTypeClassName)
+        .returns(boundType.asClassName())
         .addStatement("return %T", contributedClass.asClassName())
         .build()
     )
   } else {
     BindingMethod(
       FunSpec.builder(
-        name = contributedClass.fqName.asString()
-          .split(".")
+        name = methodNameSubString
           .joinToString(
             separator = "",
             prefix = "bind",
@@ -379,7 +381,7 @@ private fun ContributedBinding.toGeneratedMethod(
           name = contributedClass.shortName.decapitalize(),
           type = contributedClass.asClassName()
         )
-        .returns(boundTypeClassName)
+        .returns(boundType.asClassName())
         .build()
     )
   }

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributedBinding.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributedBinding.kt
@@ -7,9 +7,7 @@ import com.squareup.anvil.compiler.internal.reference.ClassReference
 import com.squareup.anvil.compiler.internal.reference.ClassReference.Descriptor
 import com.squareup.anvil.compiler.internal.reference.ClassReference.Psi
 import com.squareup.anvil.compiler.internal.reference.allSuperTypeClassReferences
-import com.squareup.anvil.compiler.internal.reference.asClassName
 import com.squareup.kotlinpoet.AnnotationSpec
-import com.squareup.kotlinpoet.TypeName
 import org.jetbrains.kotlin.types.KotlinType
 import kotlin.LazyThreadSafetyMode.NONE
 
@@ -17,7 +15,7 @@ internal data class ContributedBinding(
   val contributedClass: ClassReference,
   val mapKeys: List<AnnotationSpec>,
   val qualifiers: List<AnnotationSpec>,
-  val boundTypeClassName: TypeName,
+  val boundType: ClassReference,
   val priority: Priority,
   val qualifiersKeyLazy: Lazy<String>
 )
@@ -44,7 +42,7 @@ internal fun AnnotationReference.toContributedBinding(
     contributedClass = declaringClass(),
     mapKeys = mapKeys,
     qualifiers = qualifiers,
-    boundTypeClassName = boundType.asClassName(),
+    boundType = boundType,
     priority = priority(),
     qualifiersKeyLazy = declaringClass().qualifiersKeyLazy(boundType, ignoreQualifier)
   )

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesBindingGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesBindingGenerator.kt
@@ -61,7 +61,8 @@ internal class ContributesBindingGenerator : CodeGenerator {
 
         val scopes = clazz.annotations
           .find(contributesBindingFqName)
-          .also { it.checkNoDuplicateScope(contributeAnnotation = true) }
+          .also { it.checkNoDuplicateScopeAndBoundType() }
+          .distinctBy { it.scope() }
           // Give it a stable sort.
           .sortedBy { it.scope() }
           .map { it.scope().asClassName() }

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesMultibindingGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesMultibindingGenerator.kt
@@ -62,7 +62,8 @@ internal class ContributesMultibindingGenerator : CodeGenerator {
 
         val scopes = clazz.annotations
           .find(contributesMultibindingFqName)
-          .also { it.checkNoDuplicateScope(contributeAnnotation = true) }
+          .also { it.checkNoDuplicateScopeAndBoundType() }
+          .distinctBy { it.scope() }
           // Give it a stable sort.
           .sortedBy { it.scope() }
           .map { it.scope().asClassName() }

--- a/compiler/src/test/java/com/squareup/anvil/compiler/TestUtils.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/TestUtils.kt
@@ -46,6 +46,12 @@ internal val Result.innerInterface: Class<*>
 internal val Result.parentInterface: Class<*>
   get() = classLoader.loadClass("com.squareup.test.ParentInterface")
 
+internal val Result.parentInterface1: Class<*>
+  get() = classLoader.loadClass("com.squareup.test.ParentInterface1")
+
+internal val Result.parentInterface2: Class<*>
+  get() = classLoader.loadClass("com.squareup.test.ParentInterface2")
+
 internal val Result.componentInterface: Class<*>
   get() = classLoader.loadClass("com.squareup.test.ComponentInterface")
 

--- a/compiler/src/test/java/com/squareup/anvil/compiler/codegen/BindingModuleMultibindingSetTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/codegen/BindingModuleMultibindingSetTest.kt
@@ -16,6 +16,8 @@ import com.squareup.anvil.compiler.internal.testing.isAbstract
 import com.squareup.anvil.compiler.isError
 import com.squareup.anvil.compiler.isFullTestRun
 import com.squareup.anvil.compiler.parentInterface
+import com.squareup.anvil.compiler.parentInterface1
+import com.squareup.anvil.compiler.parentInterface2
 import com.squareup.anvil.compiler.secondContributingInterface
 import com.squareup.anvil.compiler.subcomponentInterface
 import dagger.Binds
@@ -403,7 +405,7 @@ class BindingModuleMultibindingSetTest(
     }
   }
 
-  @Test fun `multiple contribution can have different bound types`() {
+  @Test fun `multiple contributions can have different bound types`() {
     assumeIrBackend()
 
     compile(
@@ -428,8 +430,7 @@ class BindingModuleMultibindingSetTest(
       """
     ) {
       with(componentInterface.anvilModule.declaredMethods.single()) {
-        assertThat(returnType)
-          .isEqualTo(classLoader.loadClass("com.squareup.test.ParentInterface1"))
+        assertThat(returnType).isEqualTo(parentInterface1)
         assertThat(parameterTypes.toList()).containsExactly(contributingInterface)
         assertThat(isAbstract).isTrue()
         assertThat(isAnnotationPresent(Binds::class.java)).isTrue()
@@ -437,13 +438,81 @@ class BindingModuleMultibindingSetTest(
       }
 
       with(subcomponentInterface.anvilModule.declaredMethods.single()) {
-        assertThat(returnType)
-          .isEqualTo(classLoader.loadClass("com.squareup.test.ParentInterface2"))
+        assertThat(returnType).isEqualTo(parentInterface2)
         assertThat(parameterTypes.toList()).containsExactly(contributingInterface)
         assertThat(isAbstract).isTrue()
         assertThat(isAnnotationPresent(Binds::class.java)).isTrue()
         assertThat(isAnnotationPresent(IntoSet::class.java)).isTrue()
       }
+    }
+  }
+
+  @Test fun `multiple contributions can have the same scope but different bound types`() {
+    assumeIrBackend()
+
+    compile(
+      """
+      package com.squareup.test
+
+      import com.squareup.anvil.annotations.ContributesMultibinding
+      $import
+      
+      interface ParentInterface1
+      interface ParentInterface2
+
+      @ContributesMultibinding(Any::class, boundType = ParentInterface1::class)
+      @ContributesMultibinding(Any::class, boundType = ParentInterface2::class)
+      class ContributingInterface : ParentInterface1, ParentInterface2
+
+      $annotation(Any::class)
+      interface ComponentInterface
+      """
+    ) {
+      val methods = componentInterface.anvilModule.declaredMethods.sortedBy { it.name }
+      assertThat(methods).hasSize(2)
+
+      with(methods[0]) {
+        assertThat(returnType).isEqualTo(parentInterface1)
+        assertThat(parameterTypes.toList()).containsExactly(contributingInterface)
+        assertThat(isAbstract).isTrue()
+        assertThat(isAnnotationPresent(Binds::class.java)).isTrue()
+      }
+      with(methods[1]) {
+        assertThat(returnType).isEqualTo(parentInterface2)
+        assertThat(parameterTypes.toList()).containsExactly(contributingInterface)
+        assertThat(isAbstract).isTrue()
+        assertThat(isAnnotationPresent(Binds::class.java)).isTrue()
+      }
+    }
+  }
+
+  @Test fun `multiple contributions to the same scope can be replaced at once`() {
+    assumeIrBackend()
+
+    compile(
+      """
+      package com.squareup.test
+
+      import com.squareup.anvil.annotations.ContributesMultibinding
+      import com.squareup.anvil.annotations.ContributesTo
+      $import
+      
+      interface ParentInterface1
+      interface ParentInterface2
+
+      @ContributesMultibinding(Any::class, boundType = ParentInterface1::class)
+      @ContributesMultibinding(Any::class, boundType = ParentInterface2::class)
+      class ContributingInterface : ParentInterface1, ParentInterface2
+
+      @ContributesTo(Any::class, replaces = [ContributingInterface::class])
+      @dagger.Module
+      abstract class DaggerModule1
+
+      $annotation(Any::class)
+      interface ComponentInterface
+      """
+    ) {
+      assertThat(componentInterface.anvilModule.declaredMethods).isEmpty()
     }
   }
 

--- a/compiler/src/test/java/com/squareup/anvil/compiler/codegen/ContributesMultibindingGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/codegen/ContributesMultibindingGeneratorTest.kt
@@ -476,7 +476,7 @@ class ContributesMultibindingGeneratorTest {
     }
   }
 
-  @Test fun `multiple annotations with the same scope aren't allowed`() {
+  @Test fun `multiple annotations with the same scope and bound type aren't allowed`() {
     assumeIrBackend()
 
     compile(
@@ -496,10 +496,36 @@ class ContributesMultibindingGeneratorTest {
     ) {
       assertThat(exitCode).isError()
       assertThat(messages).contains(
-        "com.squareup.test.ContributingInterface contributes multiple times to the same scope: " +
-          "[Any, Unit]. Contributing multiple times to the same scope is forbidden and all " +
-          "scopes must be distinct."
+        "com.squareup.test.ContributingInterface contributes multiple times to the same scope " +
+          "using the same bound type: [ParentInterface]. Contributing multiple times to the " +
+          "same scope with the same bound type is forbidden and all scope - bound type " +
+          "combinations must be distinct."
       )
+    }
+  }
+
+  @Test fun `multiple annotations with the same scope and different bound type are allowed`() {
+    assumeIrBackend()
+
+    compile(
+      """
+      package com.squareup.test
+
+      import com.squareup.anvil.annotations.ContributesMultibinding
+
+      interface ParentInterface1
+      interface ParentInterface2
+
+      @ContributesMultibinding(Any::class, boundType = ParentInterface1::class)
+      @ContributesMultibinding(Any::class, boundType = ParentInterface2::class)
+      @ContributesMultibinding(Unit::class, boundType = ParentInterface1::class)
+      @ContributesMultibinding(Unit::class, boundType = ParentInterface2::class)
+      class ContributingInterface : ParentInterface1, ParentInterface2
+      """
+    ) {
+      assertThat(contributingInterface.hintMultibinding?.java).isEqualTo(contributingInterface)
+      assertThat(contributingInterface.hintMultibindingScopes)
+        .containsExactly(Any::class, Unit::class)
     }
   }
 }

--- a/compiler/src/test/java/com/squareup/anvil/compiler/dagger/ProvidesMethodFactoryGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/dagger/ProvidesMethodFactoryGeneratorTest.kt
@@ -2388,7 +2388,7 @@ public final class DaggerComponentInterface implements ComponentInterface {
       """
     ) {
       val factoryClass = componentInterface.anvilModule
-        .moduleFactoryClass("provideComSquareupTestContributingObject")
+        .moduleFactoryClass("provideComSquareupTestContributingObjectParentInterface")
 
       val constructor = factoryClass.declaredConstructors.single()
       assertThat(constructor.parameterTypes.toList()).isEmpty()
@@ -2400,7 +2400,7 @@ public final class DaggerComponentInterface implements ComponentInterface {
       assertThat(factoryInstance::class.java).isEqualTo(factoryClass)
 
       val providedContributingObject = staticMethods
-        .single { it.name == "provideComSquareupTestContributingObject" }
+        .single { it.name == "provideComSquareupTestContributingObjectParentInterface" }
         .invoke(null)
 
       assertThat(providedContributingObject).isSameInstanceAs(factoryInstance.get())


### PR DESCRIPTION
Allow contributing multiple bindings with the same scope as long as they have a different bound type. Contributing multiple bindings with the same scope and same bound type is an error.