### PR TITLE
fix provides method names with an 'is-' prefix which is part of a longer word

### DIFF
--- a/compiler/src/main/java/com/squareup/anvil/compiler/Utils.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/Utils.kt
@@ -59,6 +59,8 @@ internal val publishedApiFqName = PublishedApi::class.fqName
 
 internal val daggerDoubleCheckFqNameString = DoubleCheck::class.java.canonicalName
 
+internal val isWordPrefixRegex = "^is([^a-z].*)".toRegex()
+
 internal const val HINT_CONTRIBUTES_PACKAGE_PREFIX = "anvil.hint.merge"
 internal const val HINT_BINDING_PACKAGE_PREFIX = "anvil.hint.binding"
 internal const val HINT_MULTIBINDING_PACKAGE_PREFIX = "anvil.hint.multibinding"

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/ProvidesMethodFactoryGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/ProvidesMethodFactoryGenerator.kt
@@ -24,6 +24,7 @@ import com.squareup.anvil.compiler.internal.reference.classAndInnerClassReferenc
 import com.squareup.anvil.compiler.internal.reference.generateClassName
 import com.squareup.anvil.compiler.internal.safePackageString
 import com.squareup.anvil.compiler.internal.withJvmSuppressWildcardsIfNeeded
+import com.squareup.anvil.compiler.isWordPrefixRegex
 import com.squareup.anvil.compiler.publishedApiFqName
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FileSpec
@@ -117,7 +118,9 @@ internal class ProvidesMethodFactoryGenerator : PrivateCodeGenerator() {
 
     val isProperty = declaration.isProperty
     val declarationName = declaration.fqName.shortName().asString()
-    val useGetPrefix = isProperty && !declarationName.startsWith("is")
+    // omit the `get-` prefix for property names starting with the *word* `is`, like `isProperty`,
+    // but not for names which just start with those letters, like `issues`.
+    val useGetPrefix = isProperty && !isWordPrefixRegex.matches(declarationName)
 
     val isMangled = !isProperty &&
       declaration.visibility == INTERNAL &&

--- a/compiler/src/test/java/com/squareup/anvil/compiler/dagger/ProvidesMethodFactoryGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/dagger/ProvidesMethodFactoryGeneratorTest.kt
@@ -3320,7 +3320,7 @@ public final class DaggerModule1_ProvideFunctionFactory implements Factory<Set<S
     }
   }
 
-  @Test fun `a provides method with 'is' as prefix is supported`() {
+  @Test fun `a provides method with the word 'is' as prefix is supported`() {
     compile(
       """
       package com.squareup.test
@@ -3351,6 +3351,82 @@ public final class DaggerModule1_ProvideFunctionFactory implements Factory<Set<S
       assertThat(factoryInstance::class.java).isEqualTo(factoryClass)
 
       val providedFactory = staticMethods.single { it.name == "isValidCache" }
+        .invoke(null, module) as Any
+
+      assertThat((factoryInstance as Factory<*>).get()).isSameInstanceAs(providedFactory)
+    }
+  }
+
+  @Test
+  fun `a provides method with starting with 'is_' is supported`() {
+    compile(
+      """
+      package com.squareup.test
+      
+      import dagger.Module
+      import dagger.Provides
+      import javax.inject.Singleton
+      
+      @Module
+      class DaggerModule1 {
+        @get:Provides
+        val is_valid_cache: BooleanArray = booleanArrayOf(false)
+      }
+      """
+    ) {
+      val factoryClass = daggerModule1.moduleFactoryClass("is_valid_cache")
+
+      val constructor = factoryClass.declaredConstructors.single()
+      assertThat(constructor.parameterTypes.toList()).containsExactly(daggerModule1)
+
+      val staticMethods = factoryClass.declaredMethods.filter { it.isStatic }
+      assertThat(staticMethods).hasSize(2)
+
+      val module = daggerModule1.createInstance()
+
+      val factoryInstance = staticMethods.single { it.name == "create" }
+        .invoke(null, module)
+      assertThat(factoryInstance::class.java).isEqualTo(factoryClass)
+
+      val providedFactory = staticMethods.single { it.name == "is_valid_cache" }
+        .invoke(null, module) as Any
+
+      assertThat((factoryInstance as Factory<*>).get()).isSameInstanceAs(providedFactory)
+    }
+  }
+
+  @Test
+  fun `a provides method with starting with 'is' but not as a word is supported`() {
+    compile(
+      """
+      package com.squareup.test
+      
+      import dagger.Module
+      import dagger.Provides
+      import javax.inject.Singleton
+      
+      @Module
+      class DaggerModule1 {
+        @get:Provides
+        val issues: List<String> = listOf("a")
+      }
+      """
+    ) {
+      val factoryClass = daggerModule1.moduleFactoryClass("getIssues")
+
+      val constructor = factoryClass.declaredConstructors.single()
+      assertThat(constructor.parameterTypes.toList()).containsExactly(daggerModule1)
+
+      val staticMethods = factoryClass.declaredMethods.filter { it.isStatic }
+      assertThat(staticMethods).hasSize(2)
+
+      val module = daggerModule1.createInstance()
+
+      val factoryInstance = staticMethods.single { it.name == "create" }
+        .invoke(null, module)
+      assertThat(factoryInstance::class.java).isEqualTo(factoryClass)
+
+      val providedFactory = staticMethods.single { it.name == "getIssues" }
         .invoke(null, module) as Any
 
       assertThat((factoryInstance as Factory<*>).get()).isSameInstanceAs(providedFactory)


### PR DESCRIPTION
The kotlin/java interop only omits "get-" if the `is` prefix is the _word_ "is", like `isAndroid` or `is_android`.

There's no special case for `isandroid`, `issues`, etc.