### PR TITLE
Support resolving a class's super type's generic type

### DIFF
--- a/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/reference/ClassReference.kt
+++ b/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/reference/ClassReference.kt
@@ -395,6 +395,26 @@ public fun ClassReference.allSuperTypeClassReferences(
     .distinct()
 }
 
+/**
+ * Resolves the concrete type for a super type's generic types.
+ *
+ * e.g. this will find [Int] when passing [parameterIndex] of 1 in the following example:
+ * ```
+ * interface SuperClass<T, R>
+ *
+ * interface ImplementingClass : SuperClass<String, Int>
+ * ```
+ *
+ * @param parameterIndex: The index of the super type parameter to resolve.
+ */
+@ExperimentalAnvilApi
+public fun Psi.resolveSuperTypeGenericTypeReference(
+  superClass: ClassReference,
+  parameterIndex: Int = 0
+): TypeReference.Psi? {
+  return resolveGenericTypeReference(this, superClass, parameterIndex = parameterIndex)
+}
+
 @ExperimentalAnvilApi
 @Suppress("FunctionName")
 public fun AnvilCompilationExceptionClassReference(

--- a/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/reference/TypeReference.kt
+++ b/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/reference/TypeReference.kt
@@ -422,17 +422,22 @@ public fun AnvilCompilationExceptionTypReference(
   }
 }
 
-private fun resolveGenericTypeReference(
+internal fun resolveGenericTypeReference(
   implementingClass: ClassReference.Psi,
   declaringClass: ClassReference,
-  parameterName: String
+  parameterName: String? = null,
+  parameterIndex: Int = 0
 ): Psi? {
   // If the class/interface declaring the generic is the receiver class,
   // then the generic hasn't been set to a concrete type and can't be resolved.
   if (implementingClass == declaringClass) return null
 
   // Used to determine which parameter to look at in a KtTypeArgumentList.
-  val indexOfType = declaringClass.indexOfTypeParameter(parameterName)
+  val indexOfType = if (parameterName != null) {
+    declaringClass.indexOfTypeParameter(parameterName)
+  } else {
+    parameterIndex
+  }
 
   // Find where the supertype is actually declared by matching the FqName of the
   // SuperTypeListEntry to the type which declares the generic we're trying to resolve.


### PR DESCRIPTION
This resolves #583. We have a private utility method for finding this info currently, but it previously has only been used for resolving types on things like methods and fields. It may make sense to try and incorporate this with `TypeParameterReference` somehow but this felt like a good first step to at least support the functionality.