### PR TITLE
When resolving `FqName`s check the inner class hierarchy for the right reference.

### DIFF
--- a/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/PsiUtils.kt
+++ b/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/PsiUtils.kt
@@ -267,6 +267,12 @@ public fun PsiElement.requireFqName(
   findClassReferenceInSuperTypes(classReference, importPaths, module)
     ?.let { return it.fqName }
 
+  // Check if it's an inner class in the hierarchy.
+  parents.filterIsInstance<KtClassOrObject>()
+    .map { FqName("${it.requireFqName()}.$classReference") }
+    .firstOrNull { it.canResolveFqName(module) }
+    ?.let { return it }
+
   // Check if it's a named import.
   containingKtFile.importDirectives
     .firstOrNull { classReference == it.importPath?.importedName?.asString() }

--- a/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/reference/TypeReference.kt
+++ b/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/reference/TypeReference.kt
@@ -214,13 +214,20 @@ public sealed class TypeReference {
       fun KtTypeElement.requireTypeName(): TypeName {
         return when (this) {
           is KtUserType -> {
-            val className = fqNameOrNull(module)?.asClassName(module)
-              ?: if (isTypeParameter()) {
+            val className = try {
+              requireFqName(module).asClassName(module)
+            } catch (e: Exception) {
+              if (isTypeParameter()) {
                 val bounds = findExtendsBound().map { it.asClassName(module) }
                 return TypeVariableName(text, bounds)
               } else {
-                throw AnvilCompilationException("Couldn't resolve fqName.", element = this)
+                throw AnvilCompilationException(
+                  message = "Couldn't resolve fqName.",
+                  element = this,
+                  cause = e
+                )
               }
+            }
 
             val typeArgumentList = typeArgumentList
             if (typeArgumentList != null) {

--- a/compiler/src/test/java/com/squareup/anvil/compiler/dagger/InjectConstructorFactoryGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/dagger/InjectConstructorFactoryGeneratorTest.kt
@@ -23,7 +23,6 @@ import org.junit.runners.Parameterized.Parameters
 import java.io.File
 import javax.inject.Provider
 
-@Suppress("UNCHECKED_CAST")
 @RunWith(Parameterized::class)
 class InjectConstructorFactoryGeneratorTest(
   private val useDagger: Boolean
@@ -233,6 +232,7 @@ public final class InjectClass_Factory implements Factory<InjectClass> {
 }
      */
 
+    @Suppress("EqualsOrHashCode")
     compile(
       """
       package com.squareup.test
@@ -336,6 +336,7 @@ public final class InjectClass_Factory implements Factory<InjectClass> {
 }
      */
 
+    @Suppress("EqualsOrHashCode")
     compile(
       """
       package com.squareup.test
@@ -426,6 +427,7 @@ public final class InjectClass_Factory implements Factory<InjectClass> {
 }
      */
 
+    @Suppress("EqualsOrHashCode")
     compile(
       """
       package com.squareup.test
@@ -890,6 +892,7 @@ public final class InjectClass_Factory implements Factory<InjectClass> {
 }
      */
 
+    @Suppress("ClassName")
     compile(
       """
       package com.squareup.test
@@ -1451,6 +1454,7 @@ public final class InjectClass_Factory implements Factory<InjectClass> {
 }
      */
 
+    @Suppress("ClassName")
     compile(
       """
       package com.squareup.test
@@ -1640,6 +1644,7 @@ public final class MyClass_Factory implements Factory<MyClass> {
 }
      */
 
+    @Suppress("ClassName")
     compile(
       """
       package com.squareup.test
@@ -2022,7 +2027,7 @@ public final class InjectClass_Factory<T> implements Factory<InjectClass<T>> {
       package com.squareup.test
       
       import javax.inject.Inject
-      import javax.inject.Provider;
+      import javax.inject.Provider
       
       class InjectClass<T> @Inject constructor(prov: Provider<T>)
       """
@@ -2135,7 +2140,7 @@ public final class InjectClass_Factory implements Factory<InjectClass> {
       package com.squareup.test
       
       import javax.inject.Inject
-      import javax.inject.Provider;
+      import javax.inject.Provider
       
       class InjectClass @Inject constructor(
         map: Map<Class<out CharSequence>, @JvmSuppressWildcards Provider<String>>
@@ -2664,6 +2669,33 @@ public final class InjectClass_Factory implements Factory<InjectClass> {
     ) {
       val constructor = injectClass.factoryClass().declaredConstructors.single()
       assertThat(constructor.parameterTypes.toList()).hasSize(8)
+    }
+  }
+
+  @Test fun `nested inner classes are supported`() {
+    compile(
+      """
+      package com.squareup.test
+
+      import kotlin.LazyThreadSafetyMode.NONE
+      import kotlin.LazyThreadSafetyMode.SYNCHRONIZED 
+      import kotlin.reflect.KClass      
+      import javax.inject.Inject
+      import javax.inject.Named
+      import javax.inject.Qualifier
+      
+      class A {
+        class Factory @Inject constructor(
+          private val innerClassFactory: Achild.Factory
+        )
+      
+        class Achild {
+          class Factory
+        }
+      }
+      """
+    ) {
+      assertThat(classLoader.loadClass("com.squareup.test.A\$Achild\$Factory")).isNotNull()
     }
   }
 


### PR DESCRIPTION
Fixes #617 