### PR TITLE
Shared output directory

### DIFF
--- a/gradle-plugin/src/main/java/com/squareup/anvil/plugin/AnvilPlugin.kt
+++ b/gradle-plugin/src/main/java/com/squareup/anvil/plugin/AnvilPlugin.kt
@@ -293,6 +293,12 @@ internal open class AnvilPlugin : KotlinCompilerPluginSupportPlugin {
         variant.project.configurations.getByName(variant.compilerPluginClasspathName)
       )
       task.incrementalSignal.set(incrementalSignal)
+      task.outputFile.set(
+        File(
+          variant.project.buildDir,
+          "not-existing-file-because-gradle-needs-an-output-$compileTaskName"
+        )
+      )
     }
 
     compileTaskProvider.configure {

--- a/gradle-plugin/src/main/java/com/squareup/anvil/plugin/DisableIncrementalCompilationTask.kt
+++ b/gradle-plugin/src/main/java/com/squareup/anvil/plugin/DisableIncrementalCompilationTask.kt
@@ -23,7 +23,7 @@ internal abstract class DisableIncrementalCompilationTask : DefaultTask() {
 
   @Suppress("unused")
   @get:OutputFile @get:Optional
-  val someFile = File(project.buildDir, "not-existing-file-because-gradle-needs-an-output")
+  abstract val outputFile: Property<File>
 
   @get:Internal
   abstract val incrementalSignal: Property<IncrementalSignal>


### PR DESCRIPTION
Don't share the output directory for the `DisableIncrementalCompilationTask`, if there are multiple Kotlin compilation tasks for the same module.

Fixes #602