### PR TITLE
Fix inconsistency between Dagger and Anvil for generated factory names…

### DIFF
--- a/compiler-utils/src/testFixtures/java/com/squareup/anvil/compiler/internal/testing/AnvilCompilation.kt
+++ b/compiler-utils/src/testFixtures/java/com/squareup/anvil/compiler/internal/testing/AnvilCompilation.kt
@@ -219,7 +219,8 @@ public fun compileAnvil(
   enableExperimentalAnvilApis: Boolean = true,
   previousCompilationResult: Result? = null,
   codeGenerators: List<CodeGenerator> = emptyList(),
-  block: Result.() -> Unit = { }
+  moduleName: String? = null,
+  block: Result.() -> Unit = { },
 ): Result {
   return AnvilCompilation()
     .apply {
@@ -228,6 +229,9 @@ public fun compileAnvil(
         this.messageOutputStream = messageOutputStream
         if (workingDir != null) {
           this.workingDir = workingDir
+        }
+        if (moduleName != null) {
+          this.moduleName = moduleName
         }
       }
 

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/ProvidesMethodFactoryGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/ProvidesMethodFactoryGenerator.kt
@@ -333,7 +333,8 @@ internal class ProvidesMethodFactoryGenerator : PrivateCodeGenerator() {
   }
 
   private fun ModuleDescriptor.mangledNameSuffix(): String {
-    val name = name.asString()
+    // We replace - with _ to maintain interoperability with Dagger's expected generated identifiers
+    val name = name.asString().replace('-', '_')
     return if (name.startsWith('<') && name.endsWith('>')) {
       name.substring(1, name.length - 1)
     } else {


### PR DESCRIPTION
… involving a dash-separated module name

Fixes #653