### PR TITLE
Update FqName detection to fix validation of extension function bindings with qualifiers

### DIFF
--- a/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/PsiUtils.kt
+++ b/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/PsiUtils.kt
@@ -15,6 +15,7 @@ import org.jetbrains.kotlin.psi.KtAnnotationEntry
 import org.jetbrains.kotlin.psi.KtClassLiteralExpression
 import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.psi.KtConstructorCalleeExpression
+import org.jetbrains.kotlin.psi.KtDeclarationModifierList
 import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtFunctionType
@@ -123,6 +124,14 @@ public fun PsiElement.requireFqName(
           return children[0].requireFqName(module)
         } catch (e: AnvilCompilationException) {
           // Fallback to the text representation.
+          text
+        }
+      } else if (children.size == 2 && children[0] is KtDeclarationModifierList) {
+        // This could be a case of a KtUserType with a modifier like `@receiver:Qualifier`
+        try {
+          return children[1].requireFqName(module)
+        } catch (e: AnvilCompilationException) {
+          // Fallback to text
           text
         }
       } else {

--- a/compiler/src/test/java/com/squareup/anvil/compiler/dagger/BindsMethodValidatorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/dagger/BindsMethodValidatorTest.kt
@@ -225,8 +225,62 @@ class BindsMethodValidatorTest(
       import javax.inject.Singleton
 
       @Component(modules = [BarModule::class])
-      @Singleton
       interface ComponentInterface {
+        fun bar(): Bar
+      }
+      """,
+      previousCompilationResult = moduleResult,
+      enableDagger = true,
+    ) {
+      assertThat(exitCode).isEqualTo(OK)
+    }
+  }
+
+  @Test
+  fun `an extension function binding with a qualifier is valid`() {
+    val moduleResult = compile(
+      """
+      package com.squareup.test
+ 
+      import dagger.Binds
+      import dagger.Module
+      import dagger.Provides
+      import javax.inject.Inject
+      import javax.inject.Qualifier
+
+      @Qualifier
+      annotation class Marker
+
+      class Foo : Bar
+      interface Bar
+
+      @Module
+      abstract class BarModule {
+
+        @Marker
+        @Binds
+        abstract fun @receiver:Marker Foo.bindsBar(): Bar
+
+        companion object {
+            @Provides 
+            @Marker
+            fun providesFoo(): Foo = Foo()
+        }
+      }
+      """
+    ) {
+      assertThat(exitCode).isEqualTo(OK)
+    }
+
+    compile(
+      """
+      package com.squareup.test
+
+      import dagger.Component
+
+      @Component(modules = [BarModule::class])
+      interface ComponentInterface {
+        @Marker
         fun bar(): Bar
       }
       """,


### PR DESCRIPTION
Currently when something like @receiver:Qualifier is used on an extension function, the FqName utils don't have any cases to handle it and try to resolve the combined string of `@receiver:Qualifier ReceivingType` which results in us not finding the FqName for `ReceivingType`