### PR TITLE
Handle back-ticked package names when resolving FqNames

### DIFF
--- a/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/PsiUtils.kt
+++ b/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/PsiUtils.kt
@@ -90,7 +90,10 @@ public fun PsiElement.requireFqName(
       // If the qualifier exists, then it may refer to the package and the referencedName refers to
       // the class name, e.g. a KtUserType "abc.def.GenericType<String>" has three children: a
       // qualifier "abc.def", the referencedName "GenericType" and the KtTypeArgumentList.
-      val qualifierText = qualifier?.text
+      // It's also possible for the qualifier text to be a back-tick-wrapped package such as
+      // com.squareup.`impl`, so we remove any backticks since they will cause issues with resolving
+      // the FqName.
+      val qualifierText = qualifier?.text?.replace("`", "")
       // Prefer `referencedName` instead of just `text` even if this is just a simple name without a
       // qualifier, because `referencedName` will automatically remove any wrapping backticks, and
       // backticks must be removed before resolving with an FqName via ModuleDescriptor.

--- a/compiler/src/test/java/com/squareup/anvil/compiler/dagger/BindsMethodValidatorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/dagger/BindsMethodValidatorTest.kt
@@ -237,6 +237,52 @@ class BindsMethodValidatorTest(
   }
 
   @Test
+  fun `a binding for a back-ticked-package type is valid`() {
+    val moduleResult = compile(
+      """
+      package com.squareup.`impl`
+
+      interface Bar
+      """,
+      """
+      package com.squareup.test
+ 
+      import dagger.Binds
+      import dagger.Module
+      import javax.inject.Inject
+
+      class Foo @Inject constructor() : com.squareup.`impl`.Bar
+
+      @Module
+      abstract class BarModule {
+        @Binds
+        abstract fun bindsBar(foo: Foo): com.squareup.`impl`.Bar
+      }
+      """,
+    ) {
+      assertThat(exitCode).isEqualTo(OK)
+    }
+
+    compile(
+      """
+      package com.squareup.test
+
+      import dagger.Component
+      import javax.inject.Singleton
+
+      @Component(modules = [BarModule::class])
+      interface ComponentInterface {
+        fun bar(): com.squareup.`impl`.Bar
+      }
+      """,
+      previousCompilationResult = moduleResult,
+      enableDagger = true,
+    ) {
+      assertThat(exitCode).isEqualTo(OK)
+    }
+  }
+
+  @Test
   fun `an extension function binding with a qualifier is valid`() {
     val moduleResult = compile(
       """


### PR DESCRIPTION
This fixes validation of binding methods for types with back-ticked packages. Without this fix, the FqName cannot be found. In the test example, `Foo` would not have any super types found, and trying to resolve + get a reference for the binding method return type would result in an exception.