### PR TITLE
Improve the error message for failed binding validations when the parameter and return type do not match

### DIFF
--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/BindsMethodValidator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/BindsMethodValidator.kt
@@ -7,6 +7,7 @@ import com.squareup.anvil.compiler.codegen.PrivateCodeGenerator
 import com.squareup.anvil.compiler.daggerBindsFqName
 import com.squareup.anvil.compiler.daggerModuleFqName
 import com.squareup.anvil.compiler.internal.reference.AnvilCompilationExceptionFunctionReference
+import com.squareup.anvil.compiler.internal.reference.ClassReference
 import com.squareup.anvil.compiler.internal.reference.FunctionReference
 import com.squareup.anvil.compiler.internal.reference.allSuperTypeClassReferences
 import com.squareup.anvil.compiler.internal.reference.classAndInnerClassReferences
@@ -75,28 +76,43 @@ internal class BindsMethodValidator : PrivateCodeGenerator() {
     )
 
     if (!function.parameterMatchesReturnType() && !function.receiverMatchesReturnType()) {
+      val returnType = function.returnType().asClassReference().shortName
+      val paramSuperTypes = (function.parameterSuperTypes() ?: function.receiverSuperTypes())!!
+        .map { it.shortName }
+        .toList()
+
       throw AnvilCompilationExceptionFunctionReference(
-        message = "@Binds methods' parameter type must be assignable to the return type",
+        message = "@Binds methods' parameter type must be assignable to the return type. " +
+          "Expected return type of $returnType but impl parameter of type " +
+          "${paramSuperTypes.first()} only has the following supertypes: $paramSuperTypes",
         functionReference = function
       )
     }
   }
 
   private fun FunctionReference.Psi.parameterMatchesReturnType(): Boolean {
-    return parameters.singleOrNull()
-      ?.type()
-      ?.asClassReference()
-      ?.allSuperTypeClassReferences(includeSelf = true)
+    return parameterSuperTypes()
       ?.contains(returnType().asClassReference())
       ?: false
   }
 
+  private fun FunctionReference.Psi.parameterSuperTypes(): Sequence<ClassReference>? {
+    return parameters.singleOrNull()
+      ?.type()
+      ?.asClassReference()
+      ?.allSuperTypeClassReferences(includeSelf = true)
+  }
+
   private fun FunctionReference.Psi.receiverMatchesReturnType(): Boolean {
+    return receiverSuperTypes()
+      ?.contains(returnType().asClassReference())
+      ?: false
+  }
+
+  private fun FunctionReference.Psi.receiverSuperTypes(): Sequence<ClassReference>? {
     return function.receiverTypeReference
       ?.toTypeReference(declaringClass)
       ?.asClassReference()
       ?.allSuperTypeClassReferences(includeSelf = true)
-      ?.contains(returnType().asClassReference())
-      ?: false
   }
 }

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/BindsMethodValidator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/BindsMethodValidator.kt
@@ -81,10 +81,15 @@ internal class BindsMethodValidator : PrivateCodeGenerator() {
         .map { it.shortName }
         .toList()
 
+      val superTypesMessage = if (paramSuperTypes.size == 1) {
+        "has no supertypes."
+      } else {
+        "only has the following supertypes: ${paramSuperTypes.drop(1)}"
+      }
       throw AnvilCompilationExceptionFunctionReference(
         message = "@Binds methods' parameter type must be assignable to the return type. " +
-          "Expected return type of $returnType but impl parameter of type " +
-          "${paramSuperTypes.first()} only has the following supertypes: $paramSuperTypes",
+          "Expected binding of type $returnType but impl parameter of type " +
+          "${paramSuperTypes.first()} $superTypesMessage",
         functionReference = function
       )
     }

--- a/compiler/src/test/java/com/squareup/anvil/compiler/dagger/BindsMethodValidatorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/dagger/BindsMethodValidatorTest.kt
@@ -37,7 +37,9 @@ class BindsMethodValidatorTest(
       import dagger.Module
       import javax.inject.Inject
 
-      class Foo @Inject constructor()
+      interface Lorem
+      open class Ipsum
+      class Foo @Inject constructor() : Ipsum(), Lorem
       interface Bar
 
       @Module
@@ -51,6 +53,12 @@ class BindsMethodValidatorTest(
       assertThat(messages).contains(
         "@Binds methods' parameter type must be assignable to the return type"
       )
+      if (!useDagger) {
+        assertThat(messages).contains(
+          "Expected return type of Bar but impl parameter of type Foo only has the following " +
+            "supertypes: [Foo, Ipsum, Lorem]"
+        )
+      }
     }
   }
 

--- a/compiler/src/test/java/com/squareup/anvil/compiler/dagger/BindsMethodValidatorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/dagger/BindsMethodValidatorTest.kt
@@ -55,8 +55,40 @@ class BindsMethodValidatorTest(
       )
       if (!useDagger) {
         assertThat(messages).contains(
-          "Expected return type of Bar but impl parameter of type Foo only has the following " +
-            "supertypes: [Foo, Ipsum, Lorem]"
+          "Expected binding of type Bar but impl parameter of type Foo only has the following " +
+            "supertypes: [Ipsum, Lorem]"
+        )
+      }
+    }
+  }
+
+  @Test
+  fun `a binding with an incompatible parameter type with no supertypes fails to compile`() {
+    compile(
+      """
+      package com.squareup.test
+ 
+      import dagger.Binds
+      import dagger.Module
+      import javax.inject.Inject
+
+      class Foo @Inject constructor()
+      interface Bar
+
+      @Module
+      abstract class BarModule {
+        @Binds
+        abstract fun bindsBar(impl: Foo): Bar
+      }
+      """
+    ) {
+      assertThat(exitCode).isError()
+      assertThat(messages).contains(
+        "@Binds methods' parameter type must be assignable to the return type"
+      )
+      if (!useDagger) {
+        assertThat(messages).contains(
+          "Expected binding of type Bar but impl parameter of type Foo has no supertypes."
         )
       }
     }


### PR DESCRIPTION
This should make it more obvious why a given binding failed without needing to check the generated code.