### PR TITLE
Fix duplicate generated binding method names.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Fixed
 
+- Fix duplicate generated binding method names. If a class contributes multiple bindings and the bound types have the same short name, then Anvil would generate methods with duplicate names that clash in the end.
+
 ### Security
 
 ### Custom Code Generator

--- a/compiler/src/test/java/com/squareup/anvil/compiler/dagger/ProvidesMethodFactoryGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/dagger/ProvidesMethodFactoryGeneratorTest.kt
@@ -2420,7 +2420,7 @@ public final class DaggerComponentInterface implements ComponentInterface {
       """
     ) {
       val factoryClass = componentInterface.anvilModule
-        .moduleFactoryClass("provideComSquareupTestContributingObjectParentInterface")
+        .moduleFactoryClass("provideParentInterface")
 
       val constructor = factoryClass.declaredConstructors.single()
       assertThat(constructor.parameterTypes.toList()).isEmpty()
@@ -2432,7 +2432,7 @@ public final class DaggerComponentInterface implements ComponentInterface {
       assertThat(factoryInstance::class.java).isEqualTo(factoryClass)
 
       val providedContributingObject = staticMethods
-        .single { it.name == "provideComSquareupTestContributingObjectParentInterface" }
+        .single { it.name == "provideParentInterface" }
         .invoke(null)
 
       assertThat(providedContributingObject).isSameInstanceAs(factoryInstance.get())


### PR DESCRIPTION
If a class contributes multiple bindings and the bound types have the same short name, then Anvil would generate methods with duplicate names that clash in the end.