### PR TITLE
Revert publishing changes from build modernization to address local publish…

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -30,7 +30,7 @@ Snapshot releases are automatically created whenever a commit to the `main` bran
 
 Depending on the version in the `gradle.properties` file it will be either a production or snapshot release.
 ```
-./gradlew clean publish --no-daemon --no-parallel --no-build-cache && cd gradle-plugin && ./gradlew clean publish publishPlugins --no-daemon --no-parallel --no-build-cache && cd ..
+./gradlew clean publish --no-daemon --no-parallel --no-build-cache && cd gradle-plugin && ./gradlew clean publish --no-daemon --no-parallel --no-build-cache && cd ..
 ```
 
 # Installing in Maven Local

--- a/annotations/build.gradle
+++ b/annotations/build.gradle
@@ -1,7 +1,7 @@
 plugins {
   alias(libs.plugins.kotlin.jvm)
-  alias(libs.plugins.mavenPublish)
 }
+apply from: rootProject.file('publishing.gradle')
 
 kotlin {
   explicitApi()

--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,11 @@
 import com.squareup.anvil.benchmark.CreateBenchmarkProjectTask
-import com.vanniktech.maven.publish.SonatypeHost
 import org.gradle.api.internal.project.DefaultProject
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 buildscript {
   dependencies {
+    classpath libs.mavenPublishRaw
     classpath("com.squareup.anvil:gradle-plugin:${findProperty("VERSION_NAME")}",)
   }
 }
@@ -18,7 +18,6 @@ plugins {
   alias(libs.plugins.kotlin.kapt) apply false
   alias(libs.plugins.kotlin.dokka) apply false
   alias(libs.plugins.kotlin.multiplatform) apply false
-  alias(libs.plugins.mavenPublish) apply false
   alias(libs.plugins.gradlePublish) apply false
   alias(libs.plugins.ktlint) apply false
 }
@@ -130,14 +129,6 @@ subprojects {
   // is good enough for now.
   if (configureOnDemandEnabled) {
     (it as DefaultProject).evaluate()
-  }
-
-  plugins.withId("com.vanniktech.maven.publish") {
-    apply plugin: 'org.jetbrains.dokka'
-    mavenPublishing {
-      publishToMavenCentral(SonatypeHost.S01)
-      signAllPublications()
-    }
   }
 }
 

--- a/compiler-api/build.gradle
+++ b/compiler-api/build.gradle
@@ -1,7 +1,7 @@
 plugins {
   alias(libs.plugins.kotlin.jvm)
-  alias(libs.plugins.mavenPublish)
 }
+apply from: rootProject.file('publishing.gradle')
 
 kotlin {
   explicitApi()

--- a/compiler-utils/build.gradle
+++ b/compiler-utils/build.gradle
@@ -2,9 +2,9 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
   alias(libs.plugins.kotlin.jvm)
-  alias(libs.plugins.mavenPublish)
   id 'java-test-fixtures'
 }
+apply from: rootProject.file('publishing.gradle')
 
 kotlin {
   explicitApi()

--- a/compiler/build.gradle
+++ b/compiler/build.gradle
@@ -3,8 +3,8 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.kotlin.kapt)
-  alias(libs.plugins.mavenPublish)
 }
+apply from: rootProject.file('publishing.gradle')
 
 apply from: project.file('generate_build_properties.gradle')
 

--- a/gradle-plugin/build.gradle
+++ b/gradle-plugin/build.gradle
@@ -1,17 +1,28 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+buildscript {
+  repositories {
+    google()
+    gradlePluginPortal()
+    mavenCentral()
+  }
 
-plugins {
-  id 'java-gradle-plugin'
-  alias(libs.plugins.kotlin.jvm)
-  alias(libs.plugins.kotlin.dokka)
-  alias(libs.plugins.gradlePublish)
-  alias(libs.plugins.mavenPublish)
-  alias(libs.plugins.ktlint)
+  dependencies {
+    classpath libs.kotlin.dokka
+    classpath libs.kotlin.gradlePlugin
+    classpath libs.mavenPublishRaw
+    classpath libs.gradlePublishRaw
+    classpath libs.ktlintRaw
+  }
 }
 
 apply from: rootProject.file('copy_properties.gradle')
+
+apply plugin: 'java-gradle-plugin'
+apply plugin: 'org.jetbrains.kotlin.jvm'
+apply plugin: 'com.gradle.plugin-publish'
+apply plugin: 'org.jlleitschuh.gradle.ktlint'
+
 apply from: rootProject.file('generate_build_properties.gradle')
+apply from: rootProject.file('../publishing.gradle')
 
 // Pull from the GROUP property and assign to the project
 group = GROUP
@@ -44,9 +55,9 @@ tasks.withType(JavaCompile).configureEach {
   options.release.set(8)
 }
 
-tasks.withType(KotlinCompile).configureEach {
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
   compilerOptions {
-    jvmTarget.set(JvmTarget.JVM_1_8)
+    jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8)
 
     // Because Gradle hardcodes Kotlin versions we have warnings during compilation.
     allWarningsAsErrors = false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,8 +13,11 @@ autoService = "1.0.1"
 autoValue = "1.10"
 dagger = "2.39.1"
 espresso = "3.5.1"
+gradlePublish = "0.15.0"
 kotlin = "1.8.0"
 ktlint = "0.41.0"
+ktlintPlugin = "10.2.0"
+mavenPublish = "0.18.0"
 
 #
 # Configs that we can override in CI. Not exactly "versions" but useful to repurpose it here.
@@ -30,14 +33,14 @@ config-useIr = "true"
 [plugins]
 agp-application = { id = "com.android.application", version.ref = "agp" }
 agp-library = { id = "com.android.library", version.ref = "agp" }
-gradlePublish = { id = "com.gradle.plugin-publish", version = "0.15.0" }
+gradlePublish = { id = "com.gradle.plugin-publish", version.ref = "gradlePublish" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-dokka = { id = "org.jetbrains.dokka", version = "1.7.20" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
-ktlint = { id = "org.jlleitschuh.gradle.ktlint", version = "10.2.0" }
-mavenPublish = { id = "com.vanniktech.maven.publish", version = "0.22.0" }
+ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlintPlugin" }
+mavenPublish = { id = "com.vanniktech.maven.publish", version.ref = "mavenPublish" }
 
 [libraries]
 androidx-appcompat = "androidx.appcompat:appcompat:1.1.0"
@@ -59,6 +62,8 @@ auto-value-processor = { module = "com.google.auto.value:auto-value", version.re
 dagger2 = { module = "com.google.dagger:dagger", version.ref = "dagger" }
 dagger2-compiler = { module = "com.google.dagger:dagger-compiler", version.ref = "dagger" }
 
+gradlePublishRaw = { module = "com.gradle.publish:plugin-publish-plugin", version.ref = "gradlePublish" }
+
 inject = "javax.inject:javax.inject:1"
 jsr250 = "javax.annotation:jsr250-api:1.0"
 junit = "junit:junit:4.13"
@@ -74,5 +79,9 @@ kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref =
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }
 
 kotlinpoet = "com.squareup:kotlinpoet:1.12.0"
+
+ktlintRaw = { module = "org.jlleitschuh.gradle:ktlint-gradle", version.ref = "ktlintPlugin" }
+
+mavenPublishRaw = { module = "com.vanniktech:gradle-maven-publish-plugin", version.ref = "mavenPublish" }
 
 truth = "com.google.truth:truth:1.1.3"

--- a/publishing.gradle
+++ b/publishing.gradle
@@ -1,0 +1,8 @@
+apply plugin: 'com.vanniktech.maven.publish'
+apply plugin: 'org.jetbrains.dokka'
+
+plugins.withId("com.vanniktech.maven.publish") {
+  mavenPublish {
+    sonatypeHost = "S01"
+  }
+}


### PR DESCRIPTION
…ing failure

There is currently a failure with plugin versioning when publishing manually that appears to be related to ordering/timing issues in the current set-up, around our application of `copy_properties.gradle` in particular. There are also other changes in the new version of the publishing plugin that we should look at more closely and possibly update for, such as --no-parallel no longer being needed.

For now this is to get us back to the previous baseline and we can separately look at updating the publishing logic in isolation.