### PR TITLE
Bump KotlinPoet to 1.13.0 and fix bug uncovered by new TypeName equal…

### DIFF
--- a/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/KotlinPoetUtils.kt
+++ b/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/KotlinPoetUtils.kt
@@ -25,7 +25,7 @@ import java.io.ByteArrayOutputStream
 public fun ClassDescriptor.asClassName(): ClassName =
   ClassName(
     packageName = parents.filterIsInstance<PackageFragmentDescriptor>().first()
-      .fqName.safePackageString(),
+      .fqName.safePackageString(dotSuffix = false),
     simpleNames = parentsWithSelf.filterIsInstance<ClassDescriptor>()
       .map { it.name.asString() }
       .toList()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -77,7 +77,7 @@ kotlin-metadata = "org.jetbrains.kotlinx:kotlinx-metadata-jvm:0.5.0"
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }
 
-kotlinpoet = "com.squareup:kotlinpoet:1.12.0"
+kotlinpoet = "com.squareup:kotlinpoet:1.13.0"
 
 ktlintRaw = { module = "org.jlleitschuh.gradle:ktlint-gradle", version.ref = "ktlintPlugin" }
 


### PR DESCRIPTION
…s/hashCode changes.

KotlinPoet 1.13.0 includes fixes to how equals and hashCode are implemented for the various TypeName impls and ClassName itself (see https://github.com/square/kotlinpoet/pull/1477). After upgrading to the new version, it revealed a bug in our KotlinPoet utils where some instantiations of ClassName would include a dot suffix for the provided packageName.

What this looked like in practice was that for @Assisted parameters, the @AssistedFactory function would sometimes create a parameter ClassName with an internal packagename like 'kotlin.reflect.', while the @AssistedInject constructor parameter would get created with a ClassName using internal packagename like 'kotlin.reflect'. Notice how one had a '.' suffix included and the other did not. This resulted in the parameters' hashcodes and the subsequently-derived keys being different.

This use-case is covered by AssistedFactoryGeneratorTest#`the factory function may be provided by a generic super type from another module`