### PR TITLE
Allow contributing bindings with generic supertypes

### DIFF
--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/BindingModuleGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/BindingModuleGenerator.kt
@@ -28,6 +28,8 @@ import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier.ABSTRACT
+import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import com.squareup.kotlinpoet.STAR
 import com.squareup.kotlinpoet.TypeSpec
 import dagger.Binds
 import dagger.Module
@@ -354,6 +356,15 @@ private fun ContributedBinding.toGeneratedMethod(
     }
   }
 
+  val boundTypeWithStarGenerics = boundType.asClassName()
+    .let {
+      if (boundType.typeParameters.isEmpty()) {
+        it
+      } else {
+        it.parameterizedBy(boundType.typeParameters.map { STAR })
+      }
+    }
+
   return if (contributedClass.isObject()) {
     ProviderMethod(
       spec = FunSpec.builder(name = "provide$methodNameSuffix")
@@ -366,7 +377,7 @@ private fun ContributedBinding.toGeneratedMethod(
         }
         .addAnnotations(qualifiers)
         .addAnnotations(mapKeys)
-        .returns(boundType.asClassName())
+        .returns(boundTypeWithStarGenerics)
         .addStatement("return %T", contributedClass.asClassName())
         .build(),
       contributedClass = contributedClass,
@@ -389,7 +400,7 @@ private fun ContributedBinding.toGeneratedMethod(
           name = contributedClass.shortName.decapitalize(),
           type = contributedClass.asClassName()
         )
-        .returns(boundType.asClassName())
+        .returns(boundTypeWithStarGenerics)
         .build(),
       contributedClass = contributedClass,
       boundType = boundType

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/ProvidesMethodFactoryGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/ProvidesMethodFactoryGenerator.kt
@@ -79,7 +79,7 @@ internal class ProvidesMethodFactoryGenerator : PrivateCodeGenerator() {
           .asSequence()
           .flatMap { it.properties }
           .filter { property ->
-            // Must be '@get:Provides'.
+            // Must be '@get:"Provides"'.
             property.annotations.singleOrNull {
               it.fqName == daggerProvidesFqName
             }?.annotation?.useSiteTarget?.text == "get"

--- a/compiler/src/test/java/com/squareup/anvil/compiler/codegen/BindingModuleGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/codegen/BindingModuleGeneratorTest.kt
@@ -14,13 +14,13 @@ import com.squareup.anvil.compiler.internal.testing.AnyDaggerComponent
 import com.squareup.anvil.compiler.internal.testing.anyDaggerComponent
 import com.squareup.anvil.compiler.internal.testing.daggerModule
 import com.squareup.anvil.compiler.internal.testing.isAbstract
-import com.squareup.anvil.compiler.isError
 import com.squareup.anvil.compiler.isFullTestRun
 import com.squareup.anvil.compiler.parentInterface
 import com.squareup.anvil.compiler.parentInterface1
 import com.squareup.anvil.compiler.parentInterface2
 import com.squareup.anvil.compiler.secondContributingInterface
 import com.squareup.anvil.compiler.subcomponentInterface
+import com.tschuchort.compiletesting.KotlinCompilation.ExitCode
 import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.OK
 import dagger.Binds
 import dagger.Provides
@@ -28,6 +28,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 import org.junit.runners.Parameterized.Parameters
+import java.io.File
 import kotlin.reflect.KClass
 
 @RunWith(Parameterized::class)
@@ -373,7 +374,7 @@ class BindingModuleGeneratorTest(
     }
   }
 
-  @Test fun `the contributed binding class must not have a generic type parameter`() {
+  @Test fun `the Dagger binding method with star type is generated for generic type parameters`() {
     compile(
       """
       package com.squareup.test
@@ -393,19 +394,25 @@ class BindingModuleGeneratorTest(
       interface ComponentInterface
       """
     ) {
-      assertThat(exitCode).isError()
+      assertThat(exitCode).isEqualTo(ExitCode.OK)
 
-      assertThat(messages).contains("Source0.kt:6:11")
-      assertThat(messages).contains(
-        "Class com.squareup.test.ContributingInterface binds com.squareup.test.ParentInterface, " +
-          "but the bound type contains type parameter(s) <T, S>. Type parameters in bindings " +
-          "are not supported. This binding needs to be contributed in a Dagger module manually."
-      )
+      // Because of type erasure, we cannot check through the type system that generated type
+      // is the right one. Instead, we can check generated string.
+
+      val generatedModuleFile = File(outputDirectory.parent, "build/anvil")
+        .walk()
+        .single { it.isFile && it.name == "ComponentInterface.kt" }
+
+      assertThat(generatedModuleFile.readText().replace(Regex("\\s"), ""))
+        .contains(
+          "bindParentInterface(contributingInterface: ContributingInterface):" +
+            "ParentInterface<*, *>"
+        )
     }
   }
 
   @Test
-  fun `the contributed binding class must not have a generic type parameter with super type chain`() {
+  fun `the Dagger binding method with star type is generated for a super type chain`() {
     compile(
       """
       package com.squareup.test
@@ -425,15 +432,20 @@ class BindingModuleGeneratorTest(
       interface ComponentInterface
       """
     ) {
-      assertThat(exitCode).isError()
+      assertThat(exitCode).isEqualTo(ExitCode.OK)
 
-      assertThat(messages).contains("Source0.kt:6:11")
-      assertThat(messages).contains(
-        "Class com.squareup.test.ContributingInterface binds com.squareup.test.ParentInterface, " +
-          "but the bound type contains type parameter(s) <OutputT>. Type parameters in " +
-          "bindings are not supported. This binding needs to be contributed in a Dagger module " +
-          "manually."
-      )
+      // Because of type erasure, we cannot check through the type system that generated type
+      // is the right one. Instead, we can check generated string.
+
+      val generatedModuleFile = File(outputDirectory.parent, "build/anvil")
+        .walk()
+        .single { it.isFile && it.name == "ComponentInterface.kt" }
+
+      assertThat(generatedModuleFile.readText().replace(Regex("\\s"), ""))
+        .contains(
+          "bindParentInterface(contributingInterface:ContributingInterface):" +
+            "ParentInterface<*>"
+        )
     }
   }
 


### PR DESCRIPTION
Instead of giving up, whenever user attempts to `@Contributes(Multi)Binding` on a generic parent interface, it will just bind to a variant of the parent interface with generic parameters filled as stars. 

It does not cover all use cases, but it covers more use cases than the old solution. And user can still use regular Module to achieve the rest of the use cases, so this seems like a win win in my book.

This fixes #694.