### PR TITLE
Resolve Gradle configurations cache issues

### DIFF
--- a/compiler/generate_build_properties.gradle
+++ b/compiler/generate_build_properties.gradle
@@ -4,12 +4,17 @@ sourceSets {
   test.java.srcDirs += "$buildDir/$generatedDirPath"
 }
 
-def generateBuildProperties = project.tasks.register('generateBuildProperties') {
-  File buildPropertiesFile = new File(new File(project.buildDir, generatedDirPath), 'BuildProperties.kt')
+def warningsAsErrors = rootProject.ext.warningsAsErrors
 
-  inputs.property 'fullTestRun', libs.versions.config.fullTestRun.get()
+def generateBuildProperties = project.tasks.register('generateBuildProperties') {
+  File buildPropertiesFile = layout.buildDirectory.file(generatedDirPath + '/BuildProperties.kt')
+      .get().asFile
+
+  def fullTestRun = libs.versions.config.fullTestRun.get()
+
+  inputs.property 'fullTestRun', fullTestRun
   inputs.property 'kotlinVersion', libs.versions.kotlin.get()
-  inputs.property 'warningsAsErrors', rootProject.ext.warningsAsErrors
+  inputs.property 'warningsAsErrors', warningsAsErrors
 
   outputs.file buildPropertiesFile
 
@@ -18,9 +23,9 @@ def generateBuildProperties = project.tasks.register('generateBuildProperties') 
     buildPropertiesFile.write """\
       package com.squareup.anvil.compiler
 
-      internal const val WARNINGS_AS_ERRORS = ${rootProject.ext.warningsAsErrors}
+      internal const val WARNINGS_AS_ERRORS = $warningsAsErrors
      
-      internal const val FULL_TEST_RUN = ${rootProject.ext.fullTestRun}
+      internal const val FULL_TEST_RUN = $fullTestRun
     """.stripIndent()
   }
 }

--- a/gradle-plugin/generate_build_properties.gradle
+++ b/gradle-plugin/generate_build_properties.gradle
@@ -9,11 +9,11 @@ sourceSets {
 }
 
 def generateBuildProperties = project.tasks.register('generateBuildProperties') {
-  def version = project.findProperty('VERSION_NAME')
-  def group = project.findProperty('GROUP')
+  def version = getProperty('VERSION_NAME').toString()
+  def group = getProperty('GROUP').toString()
 
-  File buildPropertiesFile =
-      new File(new File(project.buildDir, generatedDirPath), 'BuildProperties.kt')
+  File buildPropertiesFile = layout.buildDirectory.file(generatedDirPath + '/BuildProperties.kt')
+      .get().asFile
 
   inputs.property 'version', version
   inputs.property 'group', group
@@ -51,7 +51,8 @@ afterEvaluate {
       tasks.named(taskName).configure {
         it.dependsOn(generateBuildProperties)
       }
-    } catch (UnknownTaskException ignored) { }
+    } catch (UnknownTaskException ignored) {
+    }
   }
 
   // javaSourcesJar is registered even later. Gradle is love.

--- a/integration-tests/tests/build.gradle
+++ b/integration-tests/tests/build.gradle
@@ -23,23 +23,3 @@ dependencies {
 
   kaptTest libs.dagger2.compiler
 }
-
-// Okay, this check is sketchy here. But this module serves as integration test so it's not too
-// terrible. What would be worse is setting up integration tests in the Gradle plugin itself,
-// because it requires so much code and might not represent the real world usage.
-gradle.taskGraph.afterTask { Task task ->
-  if (task.project != project) return
-
-  task.inputs.properties.each { key, value ->
-    if (key.contains('com.squareup.anvil.compiler.src-gen-dir')) {
-      boolean isAbsolute = new File(value.toString()).isAbsolute()
-      if (isAbsolute) {
-        throw new GradleException(
-            "The workaround for absolute paths in the Anvil Gradle plugin is broken. Key: $key, " +
-                "value: $value, task: $task. For more context see " +
-                "https://github.com/square/anvil/issues/65"
-        )
-      }
-    }
-  }
-}


### PR DESCRIPTION
- Update our 'generateBuildProperties' tasks to be configuration cache compatible
- Remove an old task check around absolute file paths. The use of 'afterTask' causes failures when configuration cache is used, and Gradle's recommended replacement does not cleanly replace the deprecated method since it no longer provides access to the 'Task' instance. Based on previous comments around intention to remove this check, we should be fine without this.