### PR TITLE
Gradle `8.3` and AGP `7.3.1`

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,7 @@
 #
 
 [versions]
-agp = "7.1.0"
+agp = "7.3.1"
 autoService = "1.1.1"
 autoValue = "1.10.1"
 dagger = "2.46.1"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-all.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/integration-tests/mpp/android-module/build.gradle
+++ b/integration-tests/mpp/android-module/build.gradle
@@ -21,8 +21,8 @@ android {
   }
 
   compileOptions {
-    sourceCompatibility JavaVersion.VERSION_1_8
-    targetCompatibility JavaVersion.VERSION_1_8
+    sourceCompatibility JavaVersion.VERSION_11
+    targetCompatibility JavaVersion.VERSION_11
   }
 
   lint {
@@ -37,7 +37,14 @@ android {
 }
 
 kotlin {
-  android()
+
+  // The `android()` target is deprecated in Kotlin 1.9.0+,
+  // but the new `androidTarget()` alternative doesn't exist in KGP 1.8.x.
+  if (kotlin.coreLibrariesVersion < "1.9.0")
+    android()
+  else {
+    androidTarget()
+  }
 
   sourceSets {
     androidMain {

--- a/sample/app/build.gradle
+++ b/sample/app/build.gradle
@@ -22,8 +22,8 @@ android {
   }
 
   compileOptions {
-    sourceCompatibility JavaVersion.VERSION_1_8
-    targetCompatibility JavaVersion.VERSION_1_8
+    sourceCompatibility JavaVersion.VERSION_11
+    targetCompatibility JavaVersion.VERSION_11
   }
 
   lint {

--- a/sample/app/src/main/AndroidManifest.xml
+++ b/sample/app/src/main/AndroidManifest.xml
@@ -3,7 +3,6 @@
 
   <application
       android:name="com.squareup.anvil.sample.App"
-      android:allowBackup="false"
       android:icon="@mipmap/ic_launcher"
       android:label="@string/app_name"
       android:roundIcon="@mipmap/ic_launcher_round"


### PR DESCRIPTION
The AGP update becomes necessary in order to resolve:

```
Could not determine the dependencies of task ':sample:app:testDebugUnitTest'.
> Could not create task ':sample:app:processDebugResources'.
   > Cannot use @TaskAction annotation on method IncrementalTask.taskAction$gradle_core() because interface org.gradle.api.tasks.incremental.IncrementalTaskInputs is not a valid parameter to an action method.
```