### PR TITLE
Update AnvilMergeAnnotationDetector for ksp

### DIFF
--- a/compiler-utils/src/testFixtures/java/com/squareup/anvil/compiler/internal/testing/AnvilCompilation.kt
+++ b/compiler-utils/src/testFixtures/java/com/squareup/anvil/compiler/internal/testing/AnvilCompilation.kt
@@ -115,6 +115,7 @@ public class AnvilCompilation internal constructor(
           kspWithCompilation = true
           kspArgs["generate-dagger-factories"] = generateDaggerFactories.toString()
           kspArgs["generate-dagger-factories-only"] = generateDaggerFactoriesOnly.toString()
+          kspArgs["disable-component-merging"] = disableComponentMerging.toString()
         }
       }
 

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/AnvilMergeAnnotationDetectorCheck.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/AnvilMergeAnnotationDetectorCheck.kt
@@ -70,7 +70,8 @@ internal object AnvilMergeAnnotationDetectorCheck : AnvilApplicabilityChecker {
       val clazz = projectFiles
         .classAndInnerClassReferences(module)
         .firstOrNull {
-          clazz -> ANNOTATIONS_TO_CHECK.any { clazz.isAnnotatedWith(it) }
+          clazz ->
+          ANNOTATIONS_TO_CHECK.any { clazz.isAnnotatedWith(it) }
         }
 
       if (clazz != null) {

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/AnvilMergeAnnotationDetectorCheck.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/AnvilMergeAnnotationDetectorCheck.kt
@@ -1,9 +1,17 @@
 package com.squareup.anvil.compiler.codegen.dagger
 
 import com.google.auto.service.AutoService
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
+import com.google.devtools.ksp.processing.SymbolProcessorProvider
+import com.google.devtools.ksp.symbol.KSAnnotated
+import com.squareup.anvil.compiler.api.AnvilApplicabilityChecker
 import com.squareup.anvil.compiler.api.AnvilContext
 import com.squareup.anvil.compiler.api.CodeGenerator
 import com.squareup.anvil.compiler.codegen.PrivateCodeGenerator
+import com.squareup.anvil.compiler.codegen.ksp.AnvilSymbolProcessor
+import com.squareup.anvil.compiler.codegen.ksp.AnvilSymbolProcessorProvider
+import com.squareup.anvil.compiler.codegen.ksp.KspAnvilException
 import com.squareup.anvil.compiler.internal.reference.AnvilCompilationExceptionClassReference
 import com.squareup.anvil.compiler.internal.reference.classAndInnerClassReferences
 import com.squareup.anvil.compiler.mergeComponentFqName
@@ -14,32 +22,59 @@ import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 import org.jetbrains.kotlin.psi.KtFile
 import java.io.File
 
-@AutoService(CodeGenerator::class)
-internal class AnvilMergeAnnotationDetectorCheck : PrivateCodeGenerator() {
-
+internal object AnvilMergeAnnotationDetectorCheck : AnvilApplicabilityChecker {
+  private const val MESSAGE = "This Gradle module is configured to ONLY generate code with " +
+    "the `disableComponentMerging` flag. However, this module contains code that " +
+    "uses Anvil @Merge* annotations. That's not supported."
+  private val ANNOTATIONS_TO_CHECK = setOf(
+    mergeComponentFqName,
+    mergeSubcomponentFqName,
+    mergeInterfacesFqName,
+    mergeModulesFqName
+  )
   override fun isApplicable(context: AnvilContext): Boolean = context.disableComponentMerging
 
-  override fun generateCodePrivate(
-    codeGenDir: File,
-    module: ModuleDescriptor,
-    projectFiles: Collection<KtFile>
-  ) {
-    val clazz = projectFiles
-      .classAndInnerClassReferences(module)
-      .firstOrNull {
-        it.isAnnotatedWith(mergeComponentFqName) ||
-          it.isAnnotatedWith(mergeSubcomponentFqName) ||
-          it.isAnnotatedWith(mergeInterfacesFqName) ||
-          it.isAnnotatedWith(mergeModulesFqName)
-      }
+  internal class KspGenerator(
+    override val env: SymbolProcessorEnvironment,
+  ) : AnvilSymbolProcessor() {
+    @AutoService(SymbolProcessorProvider::class)
+    class Provider : AnvilSymbolProcessorProvider(AnvilMergeAnnotationDetectorCheck, ::KspGenerator)
 
-    if (clazz != null) {
-      throw AnvilCompilationExceptionClassReference(
-        message = "This Gradle module is configured to ONLY generate code with " +
-          "the `disableComponentMerging` flag. However, this module contains code that " +
-          "uses Anvil @Merge* annotations. That's not supported.",
-        classReference = clazz
+    override fun processChecked(resolver: Resolver): List<KSAnnotated> {
+      val clazz = ANNOTATIONS_TO_CHECK.flatMap { resolver.getSymbolsWithAnnotation(it.asString()) }
+        .firstOrNull()
+        ?: return emptyList()
+
+      throw KspAnvilException(
+        message = MESSAGE,
+        node = clazz
       )
+    }
+  }
+
+  @AutoService(CodeGenerator::class)
+  internal class EmbeddedGenerator : PrivateCodeGenerator() {
+
+    override fun isApplicable(context: AnvilContext) =
+      AnvilMergeAnnotationDetectorCheck.isApplicable(context)
+
+    override fun generateCodePrivate(
+      codeGenDir: File,
+      module: ModuleDescriptor,
+      projectFiles: Collection<KtFile>
+    ) {
+      val clazz = projectFiles
+        .classAndInnerClassReferences(module)
+        .firstOrNull {
+          clazz -> ANNOTATIONS_TO_CHECK.any { clazz.isAnnotatedWith(it) }
+        }
+
+      if (clazz != null) {
+        throw AnvilCompilationExceptionClassReference(
+          message = MESSAGE,
+          classReference = clazz
+        )
+      }
     }
   }
 }

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/AnvilMergeAnnotationDetectorCheck.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/AnvilMergeAnnotationDetectorCheck.kt
@@ -42,6 +42,7 @@ internal object AnvilMergeAnnotationDetectorCheck : AnvilApplicabilityChecker {
 
     override fun processChecked(resolver: Resolver): List<KSAnnotated> {
       val clazz = ANNOTATIONS_TO_CHECK
+        .asSequence()
         .flatMap {
           resolver.getSymbolsWithAnnotation(it.asString())
         }

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/AnvilMergeAnnotationDetectorCheck.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/AnvilMergeAnnotationDetectorCheck.kt
@@ -32,7 +32,7 @@ internal object AnvilMergeAnnotationDetectorCheck : AnvilApplicabilityChecker {
     mergeInterfacesFqName,
     mergeModulesFqName
   )
-  override fun isApplicable(context: AnvilContext): Boolean = context.disableComponentMerging
+  override fun isApplicable(context: AnvilContext) = context.disableComponentMerging
 
   internal class KspGenerator(
     override val env: SymbolProcessorEnvironment,
@@ -41,7 +41,10 @@ internal object AnvilMergeAnnotationDetectorCheck : AnvilApplicabilityChecker {
     class Provider : AnvilSymbolProcessorProvider(AnvilMergeAnnotationDetectorCheck, ::KspGenerator)
 
     override fun processChecked(resolver: Resolver): List<KSAnnotated> {
-      val clazz = ANNOTATIONS_TO_CHECK.flatMap { resolver.getSymbolsWithAnnotation(it.asString()) }
+      val clazz = ANNOTATIONS_TO_CHECK
+        .flatMap {
+          resolver.getSymbolsWithAnnotation(it.asString())
+        }
         .firstOrNull()
         ?: return emptyList()
 

--- a/compiler/src/test/java/com/squareup/anvil/compiler/dagger/AnvilMergeAnnotationDetectorCheckTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/dagger/AnvilMergeAnnotationDetectorCheckTest.kt
@@ -124,7 +124,7 @@ class AnvilMergeAnnotationDetectorCheckTest(
 
   private fun JvmCompilationResult.assertError() {
     assertThat(exitCode).isError()
-    assertThat(messages).contains("Source0.kt:6:7")
+    assertThat(messages).contains("Source0.kt:6")
     assertThat(messages).contains(
       "This Gradle module is configured to ONLY generate code with the " +
         "`disableComponentMerging` flag. However, this module contains code that uses " +

--- a/compiler/src/test/java/com/squareup/anvil/compiler/dagger/AnvilMergeAnnotationDetectorCheckTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/dagger/AnvilMergeAnnotationDetectorCheckTest.kt
@@ -2,14 +2,28 @@ package com.squareup.anvil.compiler.dagger
 
 import com.google.common.truth.Truth.assertThat
 import com.squareup.anvil.compiler.WARNINGS_AS_ERRORS
+import com.squareup.anvil.compiler.api.CodeGenerator
+import com.squareup.anvil.compiler.internal.testing.AnvilCompilationMode
 import com.squareup.anvil.compiler.internal.testing.compileAnvil
 import com.squareup.anvil.compiler.isError
 import com.tschuchort.compiletesting.JvmCompilationResult
 import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.OK
 import org.intellij.lang.annotations.Language
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
 
-class AnvilMergeAnnotationDetectorCheckTest {
+@RunWith(Parameterized::class)
+class AnvilMergeAnnotationDetectorCheckTest(
+  private val mode: AnvilCompilationMode
+) {
+
+  companion object {
+    @Parameterized.Parameters(name = "{0}")
+    @JvmStatic fun modes(): Collection<Any> {
+      return listOf(AnvilCompilationMode.Embedded(), AnvilCompilationMode.Ksp())
+    }
+  }
 
   @Test fun `@ContributesTo is allowed`() {
     compile(
@@ -21,7 +35,8 @@ class AnvilMergeAnnotationDetectorCheckTest {
       @Module
       @com.squareup.anvil.annotations.ContributesTo(Any::class)
       object AnyClass
-      """
+      """,
+      mode = mode
     ) {
       assertThat(exitCode).isEqualTo(OK)
     }
@@ -36,7 +51,8 @@ class AnvilMergeAnnotationDetectorCheckTest {
       
       @com.squareup.anvil.annotations.ContributesBinding(Any::class)
       class AnyClass : BaseType
-      """
+      """,
+      mode = mode
     ) {
       assertThat(exitCode).isEqualTo(OK)
     }
@@ -51,7 +67,8 @@ class AnvilMergeAnnotationDetectorCheckTest {
       
       @com.squareup.anvil.annotations.MergeComponent(Any::class)
       class AnyClass
-      """
+      """,
+      mode = mode
     ) {
       assertError()
     }
@@ -66,7 +83,8 @@ class AnvilMergeAnnotationDetectorCheckTest {
       
       @com.squareup.anvil.annotations.MergeSubcomponent(Any::class)
       class AnyClass
-      """
+      """,
+      mode = mode
     ) {
       assertError()
     }
@@ -81,7 +99,8 @@ class AnvilMergeAnnotationDetectorCheckTest {
       
       @com.squareup.anvil.annotations.compat.MergeModules(Any::class)
       class AnyClass
-      """
+      """,
+      mode = mode
     ) {
       assertError()
     }
@@ -96,7 +115,8 @@ class AnvilMergeAnnotationDetectorCheckTest {
       
       @com.squareup.anvil.annotations.compat.MergeInterfaces(Any::class)
       class AnyClass
-      """
+      """,
+      mode = mode
     ) {
       assertError()
     }
@@ -114,11 +134,14 @@ class AnvilMergeAnnotationDetectorCheckTest {
 
   private fun compile(
     @Language("kotlin") vararg sources: String,
+    codeGenerators: List<CodeGenerator> = emptyList(),
+    mode: AnvilCompilationMode = AnvilCompilationMode.Embedded(codeGenerators),
     block: JvmCompilationResult.() -> Unit = { }
   ): JvmCompilationResult = compileAnvil(
     sources = sources,
     disableComponentMerging = true,
     allWarningsAsErrors = WARNINGS_AS_ERRORS,
-    block = block
+    block = block,
+    mode = mode
   )
 }


### PR DESCRIPTION
This PR adds KSP support for `AnvilMergeAnnotationDetector`

- The changes to `AnvilMergeAnnotationDetector` follows the same pattern already used in AnvilAnnotationDetectorCheck. 
- Added `kspArgs["disable-component-merging"]` to `AnvilCompilation.kt` when mode=KSP, this is to resolve an issue where the annotations `@merge<component/subcompnent/module/Interface>` where being ignored.
- The corresponding test class was updated to handle KSP and the current system by making the expected errors a bit more generic. Specifically, the error message includes "Source0.kt:6" for KSP whereas it is "Source0.kt:6:7" for the current implementation.