### PR TITLE
Remove output deletion that breaks incremental compilation

### DIFF
--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/CodeGenerationExtension.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/CodeGenerationExtension.kt
@@ -70,13 +70,6 @@ internal class CodeGenerationExtension(
 
     val anvilContext = commandLineOptions.toAnvilContext(anvilModule)
 
-    codeGenDir.listFiles()
-      ?.forEach {
-        check(it.deleteRecursively()) {
-          "Could not clean file: $it"
-        }
-      }
-
     val generatedFiles = mutableMapOf<String, GeneratedFile>()
 
     val (privateCodeGenerators, nonPrivateCodeGenerators) =


### PR DESCRIPTION
With @RBusarow fix (here: https://github.com/square/anvil/issues/693#issuecomment-1744013947) adding the anvil src gen directory to the task outputs for `KotlinCompile` fixes the incremental compilation. 

Now the compiler plugin doesn't need to wipe the output directory since this will end up deleting all of anvil's generated output. This happens because the anvil compiler is invoked first with the list of changed files. This would leave only the changed files with generated outputs. However, the plugin is then invoked again with an empty list of files and then wipes the output directory with no files generated. I'm not sure _why_ the final invocation is getting passed an empty list as IC mechanisms/Compiler Plugins are new for me

## Steps to reproduce

```bash
gw clean :sample:library:assemble
```
_Observing that **all** anvil generated code is present_

Then changing _any file_ in `:sample:library` and compile again 

```bash
gw :sample:library:assemble
```

Now there won't be any output in the anvil `src-gen-{sourceSet}`.

## Solution

If we remove the deletion code here
```kotlin
codeGenDir.listFiles()
      ?.forEach {
        check(it.deleteRecursively()) {
          "Could not clean file: $it"
        }
      }
```

then rerun the steps above we'll see that all the outputs changed accordingly and aren't deleted. Additionally you could try deleting files, or converting `RealFatherProvider` from an `object` to an injectable constructor class, then vice versa. This should result in the output updating each time. 