### PR TITLE
replace the symlinked `gradle.properties` with manually-loaded Properties

### DIFF
--- a/gradle-plugin-build-logic/build.gradle
+++ b/gradle-plugin-build-logic/build.gradle
@@ -7,3 +7,15 @@ java {
     languageVersion.set(JavaLanguageVersion.of(11))
   }
 }
+
+// The :gradle-plugin project needs the `GROUP` and `VERSION_NAME` values
+// from the main build's `gradle.properties`.  We can't just use a symlink because Windows exists.
+// https://github.com/square/anvil/pull/763#discussion_r1379563691
+Properties mainBuildProperties = new Properties().tap { props ->
+  file("../gradle.properties").withInputStream { stream ->
+    props.load(stream)
+  }
+}
+mainBuildProperties.each { key, value ->
+  ext[key.toString()] = value
+}

--- a/gradle-plugin-build-logic/gradle.properties
+++ b/gradle-plugin-build-logic/gradle.properties
@@ -1,1 +1,0 @@
-../gradle.properties


### PR DESCRIPTION
The symlinked properties file caused issues with syncing in Windows.

https://github.com/square/anvil/pull/763#discussion_r1379563691