### PR TITLE
replace the Dokka Gradle plugin with Dokkatoo

### DIFF
--- a/build-logic/build.gradle
+++ b/build-logic/build.gradle
@@ -31,6 +31,7 @@ dependencies {
   compileOnly(gradleApi())
   implementation libs.ktlintRaw
   implementation libs.kgx
+  implementation libs.dokkatoo.plugin
   implementation libs.kotlinpoet
   implementation libs.kotlin.dokka
   implementation libs.kotlin.gradlePlugin

--- a/compiler/build.gradle
+++ b/compiler/build.gradle
@@ -52,11 +52,6 @@ dependencies {
   testImplementation libs.truth
 }
 
-// Fixes:
-// Reason: Task ':compiler:dokkaHtml' uses this output of task ':compiler:kaptKotlin'
-// without declaring an explicit or implicit dependency.
-tasks.named("dokkaHtml") { mustRunAfter("kaptKotlin") }
-
 tasks.withType(KotlinCompile).configureEach {
   compilerOptions {
     // The flag is needed because we extend an interface that uses @JvmDefault and the Kotlin

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,6 +18,7 @@ autoValue = "1.10.4"
 buildconfig = "4.1.2"
 dagger = "2.46.1"
 dokka = "1.9.10"
+dokkatoo = "2.0.0"
 espresso = "3.5.1"
 gradlePublish = "1.2.1"
 kct = "0.3.1"
@@ -48,6 +49,7 @@ config-generateDaggerFactoriesWithAnvil = "true"
 agp-application = { id = "com.android.application", version.ref = "agp" }
 agp-library = { id = "com.android.library", version.ref = "agp" }
 buildconfig = { id = "com.github.gmazzo.buildconfig", version.ref = "buildconfig" }
+dokkatoo = { id = "dev.adamko.dokkatoo", version.ref = "dokkatoo" }
 gradlePublish = { id = "com.gradle.plugin-publish", version.ref = "gradlePublish" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
@@ -77,6 +79,8 @@ auto-value-processor = { module = "com.google.auto.value:auto-value", version.re
 
 dagger2 = { module = "com.google.dagger:dagger", version.ref = "dagger" }
 dagger2-compiler = { module = "com.google.dagger:dagger-compiler", version.ref = "dagger" }
+
+dokkatoo-plugin = { module = "dev.adamko.dokkatoo:dokkatoo-plugin", version.ref = "dokkatoo" }
 
 gradlePublishRaw = { module = "com.gradle.publish:plugin-publish-plugin", version.ref = "gradlePublish" }
 


### PR DESCRIPTION
https://github.com/adamko-dev/dokkatoo

It's slowly being upstreamed into Dokka.  It still uses Dokka to generate the actual docs, but does so using much better Gradle logic.