### PR TITLE
Apply KtLint to the unpublished modules

### DIFF
--- a/build-logic/src/main/kotlin/com/squareup/anvil/KtlintConventionPlugin.kt
+++ b/build-logic/src/main/kotlin/com/squareup/anvil/KtlintConventionPlugin.kt
@@ -13,7 +13,8 @@ open class KtlintConventionPlugin : Plugin<Project> {
     target.plugins.apply(KtlintPlugin::class.java)
 
     target.extensions.configure(KtlintExtension::class.java) { ktlint ->
-      ktlint.version.set(target.libsCatalog.version("ktlint"))
+
+      ktlint.version.set(target.provider { target.libsCatalog.version("ktlint") })
       ktlint.verbose.set(true)
     }
   }

--- a/build-logic/src/main/kotlin/com/squareup/anvil/RootPlugin.kt
+++ b/build-logic/src/main/kotlin/com/squareup/anvil/RootPlugin.kt
@@ -10,6 +10,14 @@ open class RootPlugin : Plugin<Project> {
   override fun apply(target: Project) {
     target.plugins.apply(BenchmarkPlugin::class.java)
     target.plugins.apply(KtlintConventionPlugin::class.java)
+
+    // TODO (rbusarow) delete when all non-library projects have their own convention plugin
+    //   That should be when this lands: https://github.com/square/anvil/pull/789
+    target.subprojects { sub ->
+      sub.plugins.withId("build-init") {
+        sub.plugins.apply(KtlintConventionPlugin::class.java)
+      }
+    }
   }
 }
 

--- a/integration-tests/code-generator-tests/src/test/java/com/squareup/anvil/test/GeneratedCodeTest.kt
+++ b/integration-tests/code-generator-tests/src/test/java/com/squareup/anvil/test/GeneratedCodeTest.kt
@@ -101,18 +101,18 @@ class GeneratedCodeTest {
   class ContributedBindingClass @Inject constructor(
     // Keep the fully qualified name, otherwise the one specific error from
     // https://github.com/square/anvil/issues/310 can't be reproduced.
-    val binding: generated.test.com.squareup.anvil.test.Binding
+    val binding: generated.test.com.squareup.anvil.test.Binding,
   )
 
   class AssistedClass @Inject constructor(
     // Keep the fully qualified name, otherwise the one specific error from
     // https://github.com/square/anvil/issues/326 can't be reproduced.
-    val sampleAssistedFactory: generated.test.com.squareup.anvil.test.SampleAssistedFactory
+    val sampleAssistedFactory: generated.test.com.squareup.anvil.test.SampleAssistedFactory,
   )
 
   class OtherClass @Inject constructor(
     // Keep the fully qualified name, otherwise the one specific error from
     // https://github.com/square/anvil/issues/283 can't be reproduced.
-    val injectClass: generated.test.com.squareup.anvil.test.InjectClass
+    val injectClass: generated.test.com.squareup.anvil.test.InjectClass,
   )
 }

--- a/integration-tests/code-generator/src/main/java/com/squareup/anvil/test/TestCodeGenerator.kt
+++ b/integration-tests/code-generator/src/main/java/com/squareup/anvil/test/TestCodeGenerator.kt
@@ -29,7 +29,7 @@ class TestCodeGenerator : CodeGenerator {
   override fun generateCode(
     codeGenDir: File,
     module: ModuleDescriptor,
-    projectFiles: Collection<KtFile>
+    projectFiles: Collection<KtFile>,
   ): Collection<GeneratedFile> {
     return projectFiles
       .classAndInnerClassReferences(module)
@@ -135,43 +135,43 @@ class TestCodeGenerator : CodeGenerator {
             codeGenDir = codeGenDir,
             packageName = generatedPackage,
             fileName = "GeneratedClass",
-            content = generatedClass
+            content = generatedClass,
           ),
           createGeneratedFile(
             codeGenDir = codeGenDir,
             packageName = generatedPackage,
             fileName = "ContributedInterface",
-            content = contributedInterface
+            content = contributedInterface,
           ),
           createGeneratedFile(
             codeGenDir = codeGenDir,
             packageName = generatedPackage,
             fileName = "ContributedModule",
-            content = contributedModule
+            content = contributedModule,
           ),
           createGeneratedFile(
             codeGenDir = codeGenDir,
             packageName = generatedPackage,
             fileName = "ContributedBinding",
-            content = contributedBinding
+            content = contributedBinding,
           ),
           createGeneratedFile(
             codeGenDir = codeGenDir,
             packageName = generatedPackage,
             fileName = "InjectClass",
-            content = injectClass
+            content = injectClass,
           ),
           createGeneratedFile(
             codeGenDir = codeGenDir,
             packageName = generatedPackage,
             fileName = "AssistedInject",
-            content = assistedInject
+            content = assistedInject,
           ),
           createGeneratedFile(
             codeGenDir = codeGenDir,
             packageName = generatedPackage,
             fileName = "ContributedSubcomponent",
-            content = contributedSubcomponent
+            content = contributedSubcomponent,
           ),
         )
       }
@@ -195,10 +195,10 @@ class TestCodeGenerator : CodeGenerator {
                 codeGenDir = codeGenDir,
                 packageName = generatedPackage,
                 fileName = "GeneratedFunctionClass",
-                content = generatedClass
+                content = generatedClass,
               ),
             )
-          }
+          },
       )
       .plus(
         projectFiles
@@ -220,10 +220,10 @@ class TestCodeGenerator : CodeGenerator {
                 codeGenDir = codeGenDir,
                 packageName = generatedPackage,
                 fileName = "GeneratedPropertyClass",
-                content = generatedClass
+                content = generatedClass,
               ),
             )
-          }
+          },
       )
       .toList()
   }

--- a/integration-tests/code-generator/src/main/java/com/squareup/anvil/test/TestWithKaptCodeGenerator.kt
+++ b/integration-tests/code-generator/src/main/java/com/squareup/anvil/test/TestWithKaptCodeGenerator.kt
@@ -25,7 +25,7 @@ class TestWithKaptCodeGenerator : CodeGenerator {
   override fun generateCode(
     codeGenDir: File,
     module: ModuleDescriptor,
-    projectFiles: Collection<KtFile>
+    projectFiles: Collection<KtFile>,
   ): Collection<GeneratedFile> {
     return projectFiles
       .classAndInnerClassReferences(module)
@@ -49,7 +49,7 @@ class TestWithKaptCodeGenerator : CodeGenerator {
             codeGenDir = codeGenDir,
             packageName = generatedPackage,
             fileName = "mergedComponent",
-            content = mergedComponent
+            content = mergedComponent,
           ),
         )
       }

--- a/integration-tests/code-generator/src/test/java/com/squareup/anvil/test/TestCodeGeneratorTest.kt
+++ b/integration-tests/code-generator/src/test/java/com/squareup/anvil/test/TestCodeGeneratorTest.kt
@@ -21,10 +21,10 @@ class TestCodeGeneratorTest {
       package com.squareup.anvil.test
 
       annotation class Trigger
-      """
+      """,
     ) {
       assertThat(
-        classLoader.loadClass("generated.test.com.squareup.test.GeneratedClass").createInstance()
+        classLoader.loadClass("generated.test.com.squareup.test.GeneratedClass").createInstance(),
       ).isNotNull()
     }
   }

--- a/integration-tests/library/src/main/java/com/squareup/anvil/test/AssistedService.kt
+++ b/integration-tests/library/src/main/java/com/squareup/anvil/test/AssistedService.kt
@@ -18,7 +18,7 @@ public interface AssistedService {
 
 public class AssistedServiceImpl @AssistedInject constructor(
   public val integer: Int,
-  @Assisted public override val string: String
+  @Assisted public override val string: String,
 ) : AssistedService {
 
   @AssistedFactory

--- a/integration-tests/library/src/main/java/com/squareup/anvil/test/Bindings.kt
+++ b/integration-tests/library/src/main/java/com/squareup/anvil/test/Bindings.kt
@@ -11,11 +11,11 @@ public interface MiddleType : ParentType
 
 @ContributesBinding(
   scope = AppScope::class,
-  boundType = ParentType::class
+  boundType = ParentType::class,
 )
 @ContributesMultibinding(
   scope = AppScope::class,
-  boundType = ParentType::class
+  boundType = ParentType::class,
 )
 public class AppBinding @Inject constructor() : MiddleType
 

--- a/integration-tests/library/src/main/java/com/squareup/anvil/test/ContributedSubcomponent.kt
+++ b/integration-tests/library/src/main/java/com/squareup/anvil/test/ContributedSubcomponent.kt
@@ -11,7 +11,7 @@ import javax.inject.Singleton
 
 @ContributesSubcomponent(
   scope = ContributedSubcomponent.Scope::class,
-  parentScope = ContributedSubcomponent.ParentScope::class
+  parentScope = ContributedSubcomponent.ParentScope::class,
 )
 @Singleton
 public interface ContributedSubcomponent {
@@ -25,7 +25,8 @@ public interface ContributedSubcomponent {
   @ContributesTo(ContributedSubcomponent.Scope::class)
   @Module
   public object SubcomponentModule {
-    @Provides @Singleton public fun provideInteger(): Int = 3
+    @Provides @Singleton
+    public fun provideInteger(): Int = 3
   }
 
   public abstract class Scope
@@ -34,7 +35,7 @@ public interface ContributedSubcomponent {
 
 @ContributesSubcomponent(
   scope = ContributedSubcomponentFactory.Scope::class,
-  parentScope = ContributedSubcomponentFactory.ParentScope::class
+  parentScope = ContributedSubcomponentFactory.ParentScope::class,
 )
 public interface ContributedSubcomponentFactory {
   public fun integer(): Int
@@ -47,7 +48,7 @@ public interface ContributedSubcomponentFactory {
   @ContributesSubcomponent.Factory
   public interface Factory {
     public fun createComponent(
-      @BindsInstance integer: Int
+      @BindsInstance integer: Int,
     ): ContributedSubcomponentFactory
   }
 

--- a/integration-tests/library/src/main/java/com/squareup/anvil/test/Modules.kt
+++ b/integration-tests/library/src/main/java/com/squareup/anvil/test/Modules.kt
@@ -12,7 +12,9 @@ public abstract class AppModule1
 @Module
 @ContributesTo(AppScope::class)
 public object AppModule2 {
-  @Provides @Singleton public fun provideFunction(): (String) -> Int = { it.length }
+  @Provides @Singleton
+  public fun provideFunction(): (String) -> Int = { it.length }
+
   @Provides internal fun provideType(): CharSequence = "Hello"
 }
 

--- a/integration-tests/library/src/main/java/com/squareup/anvil/test/PriorityBindings.kt
+++ b/integration-tests/library/src/main/java/com/squareup/anvil/test/PriorityBindings.kt
@@ -7,7 +7,7 @@ public interface PriorityBinding
 
 @ContributesBinding(
   scope = AppScope::class,
-  priority = HIGH
+  priority = HIGH,
 )
 public object PriorityBindingHigh : PriorityBinding
 

--- a/integration-tests/tests/src/test/java/com/squareup/anvil/test/AssistedInjectionTest.kt
+++ b/integration-tests/tests/src/test/java/com/squareup/anvil/test/AssistedInjectionTest.kt
@@ -27,7 +27,7 @@ internal class AssistedInjectionTest {
 
   @MergeComponent(
     scope = AssistedScope::class,
-    modules = [DaggerModule::class]
+    modules = [DaggerModule::class],
   )
   interface AppComponent {
     fun serviceFactory(): AssistedService.Factory

--- a/integration-tests/tests/src/test/java/com/squareup/anvil/test/MergeComponentTest.kt
+++ b/integration-tests/tests/src/test/java/com/squareup/anvil/test/MergeComponentTest.kt
@@ -61,11 +61,11 @@ internal class MergeComponentTest {
       WrappedBindingKey("1"),
       WrappedMapBinding1,
       WrappedBindingKey("3"),
-      WrappedMapBinding3
+      WrappedMapBinding3,
     )
     assertThat(appComponent.mapBindingsWrappedNamed()).containsExactly(
       WrappedBindingKey("2"),
-      WrappedMapBinding2
+      WrappedMapBinding2,
     )
   }
 
@@ -84,18 +84,25 @@ internal class MergeComponentTest {
     fun charSequence(): CharSequence
     fun parentTypes(): Set<ParentType>
     fun mapBindings(): Map<String, ParentType>
-    @Named("abc") fun mapBindingsNamed(): Map<String, ParentType>
+
+    @Named("abc")
+    fun mapBindingsNamed(): Map<String, ParentType>
     fun mapBindingsWrapped(): Map<WrappedBindingKey, ParentType>
-    @Named("def") fun mapBindingsWrappedNamed(): Map<WrappedBindingKey, ParentType>
+
+    @Named("def")
+    fun mapBindingsWrappedNamed(): Map<WrappedBindingKey, ParentType>
     fun priorityBinding(): PriorityBinding
   }
 
   @MergeSubcomponent(SubScope::class)
   interface SubComponent {
-    @Named("middle") fun middleType(): MiddleType
+    @Named("middle")
+    fun middleType(): MiddleType
     fun parentType(): ParentType
 
     fun middleTypes(): Set<MiddleType>
-    @Named("middle") fun middleTypesNamed(): Set<MiddleType>
+
+    @Named("middle")
+    fun middleTypesNamed(): Set<MiddleType>
   }
 }

--- a/integration-tests/tests/src/test/java/com/squareup/anvil/test/MergeModulesTest.kt
+++ b/integration-tests/tests/src/test/java/com/squareup/anvil/test/MergeModulesTest.kt
@@ -58,7 +58,8 @@ internal class MergeModulesTest {
 
   @Subcomponent(modules = [CompositeSubModule::class])
   interface SubComponent {
-    @Named("middle") fun middleType(): MiddleType
+    @Named("middle")
+    fun middleType(): MiddleType
     fun parentType(): ParentType
     fun middleTypes(): Set<MiddleType>
   }

--- a/sample/app/src/androidTest/java/com/squareup/anvil/sample/FakeFatherProvider.kt
+++ b/sample/app/src/androidTest/java/com/squareup/anvil/sample/FakeFatherProvider.kt
@@ -7,7 +7,7 @@ import com.squareup.scopes.AppScope
 
 @ContributesBinding(
   scope = AppScope::class,
-  replaces = [RealFatherProvider::class]
+  replaces = [RealFatherProvider::class],
 )
 object FakeFatherProvider : FatherProvider {
   override fun father(god: God): String = "(No Father)"

--- a/sample/app/src/androidTest/java/com/squareup/anvil/sample/TestRunner.kt
+++ b/sample/app/src/androidTest/java/com/squareup/anvil/sample/TestRunner.kt
@@ -10,6 +10,6 @@ class TestRunner : AndroidJUnitRunner() {
   override fun newApplication(
     cl: ClassLoader,
     className: String,
-    context: Context
+    context: Context,
   ): Application = Instrumentation.newApplication(TestApp::class.java, context)
 }

--- a/sample/app/src/main/java/com/squareup/anvil/sample/RandomModule.kt
+++ b/sample/app/src/main/java/com/squareup/anvil/sample/RandomModule.kt
@@ -16,10 +16,13 @@ object RandomModule {
   @Provides
   fun provideRandomNumber() = Random.nextInt()
 
-  @Provides @Named("random") fun provideString(number: Int): String = "Hello! $number"
+  @Provides
+  @Named("random")
+  fun provideString(number: Int): String = "Hello! $number"
 }
 
 @ContributesTo(AppScope::class)
 interface RandomComponent {
-  @Named("random") fun string(): String
+  @Named("random")
+  fun string(): String
 }

--- a/sample/library/src/main/java/com/squareup/anvil/sample/God.kt
+++ b/sample/library/src/main/java/com/squareup/anvil/sample/God.kt
@@ -10,5 +10,6 @@ enum class God(val parent: Parent) {
 }
 
 enum class Parent {
-  FATHER, MOTHER
+  FATHER,
+  MOTHER,
 }


### PR DESCRIPTION
It will be applied everywhere with the new convention plugins, but it hasn't been since [(#763)](https://github.com/square/anvil/pull/763) landed.  Since we now add trailing commas, there's a bit of a diff.