### PR TITLE
Revert "Update kotlinpoet to v1.15.3"

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,7 +23,7 @@ gradlePublish = "1.2.1"
 kct = "0.3.1"
 kgx = "0.1.9"
 kotlin = "1.9.10"
-kotlinpoet = "1.15.3"
+kotlinpoet = "1.14.2"
 # If updating KSP version, we currently have ksp override logic in settings.gradle that needs to be updated too
 ksp = "1.9.10-1.0.13"
 ktlint = "1.0.1"


### PR DESCRIPTION
This reverts commit e068cd87ec922754943473b6bdfba88402bb0eaf.

There was an uncaught merge conflict between https://github.com/square/anvil/pull/793 and https://github.com/square/anvil/pull/795. This reverts the KotlinPoet bump to get main back to green and we can look at the failures separately as part of re-bumping the version.