### PR TITLE
Update usage of KGP's `Any.extraProperties` extension for `1.9.20`+

### DIFF
--- a/build-logic/conventions/src/main/kotlin/com/squareup/anvil/conventions/CompositePlugin.kt
+++ b/build-logic/conventions/src/main/kotlin/com/squareup/anvil/conventions/CompositePlugin.kt
@@ -1,7 +1,7 @@
 package com.squareup.anvil.conventions
 
 import com.rickbusarow.kgx.checkProjectIsRoot
-import com.squareup.anvil.conventions.utils.namedOrNull
+import com.squareup.anvil.conventions.utils.hasTask
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.composite.internal.DefaultIncludedBuild
@@ -66,7 +66,7 @@ class CompositePlugin : Plugin<Project> {
             // Don't include tasks that are already in the task graph
             if (taskPaths.contains(includedPath)) return@mapNotNull null
 
-            includedProject.tasks.namedOrNull(taskName) ?: return@mapNotNull null
+            if (!includedProject.hasTask(taskName)) return@mapNotNull null
 
             target.logger.quiet("The task $taskName will delegate to $includedPath")
 
@@ -79,8 +79,7 @@ class CompositePlugin : Plugin<Project> {
           buildList {
 
             // Looks to see if any project in this build has a task with this name.
-            val resolvedInRootBuild = target.allprojects
-              .any { project -> project.tasks.namedOrNull(taskName) != null }
+            val resolvedInRootBuild = target.allprojects.any { it.hasTask(taskName) }
 
             if (resolvedInRootBuild) {
               add(taskWithArgs)


### PR DESCRIPTION
Prior to `1.9.20`, KGP had this convenience extension for getting any domain object's extra properties:

```kotlin
inline val Any.extraProperties: ExtraPropertiesExtension
  get() = (this as ExtensionAware).extensions.extraProperties
```

It worked under normal circumstances because Gradle's generated decorated classes all implement `ExtensionAware`, even when the original type in the source code does not.

In `1.9.20`, that extension is changed to this:

```kotlin
inline val ExtensionAware.extraProperties: ExtraPropertiesExtension
  get() = extensions.extraProperties
```

So no more foot-gun, but existing usages that were unsafe will no longer resolve.