### PR TITLE
Copy the root `gradle` directory during benchmark project generation

### DIFF
--- a/build-logic/conventions/src/main/kotlin/com/squareup/anvil/benchmark/CreateBenchmarkProjectTask.kt
+++ b/build-logic/conventions/src/main/kotlin/com/squareup/anvil/benchmark/CreateBenchmarkProjectTask.kt
@@ -69,6 +69,7 @@ open class CreateBenchmarkProjectTask : DefaultTask() {
     )
 
     createSettingsGradleFile(libraryModules.values + appModule)
+    createGradleDirectory()
     createGradlePropertiesFile()
     createScenariosFile()
     createAppModule(appModule, libraryModules)
@@ -109,9 +110,18 @@ open class CreateBenchmarkProjectTask : DefaultTask() {
     File(rootDir, "settings.gradle").writeTextSafely(content)
   }
 
+  // The benchmark build is invoked as its own top-level build,
+  // from the 'benchmark' directory, without involving the 'anvil' build.
+  // We copy the 'gradle' directory from the 'anvil' build so
+  // that the scenarios use the same Gradle version and library catalog.
+  private fun createGradleDirectory() {
+    rootDir.parentFile.resolve("gradle")
+      .copyRecursively(rootDir.resolve("gradle"), overwrite = true)
+  }
+
   private fun createGradlePropertiesFile() {
     rootDir.parentFile.resolve("gradle.properties")
-      .copyTo(rootDir.resolve("gradle.properties"))
+      .copyTo(rootDir.resolve("gradle.properties"), overwrite = true)
   }
 
   private fun createScenariosFile() {

--- a/build-logic/settings/src/main/kotlin/com/squareup/anvil/builds/settings/SettingsPlugin.kt
+++ b/build-logic/settings/src/main/kotlin/com/squareup/anvil/builds/settings/SettingsPlugin.kt
@@ -17,11 +17,9 @@ abstract class SettingsPlugin @Inject constructor(
 
       val catalogBuilder = container.maybeCreate("libs")
 
-      if (target.rootProject.name != "anvil") {
-        val maybeFile = target.rootDir.resolveInParents("gradle/libs.versions.toml")
-        require(maybeFile.exists()) {
-          "Expected to find libs.versions.toml at $maybeFile"
-        }
+      val maybeFile = target.rootDir.resolveInParents("gradle/libs.versions.toml")
+
+      if (maybeFile != target.rootDir.resolve("gradle/libs.versions.toml")) {
         catalogBuilder.from(fileOperations.immutableFiles(maybeFile))
       }
 


### PR DESCRIPTION
The benchmark project/build is now a standalone build, instead of being subprojects in the main 'anvil' build. As such, it needs its own Gradle Wrapper jar, or the profiler scenarios will default to the version used to build the profiler.