### PR TITLE
Use a different build directory per Gradle build for main-build projects

### DIFF
--- a/build-logic/conventions/src/main/kotlin/com/squareup/anvil/conventions/LibraryPlugin.kt
+++ b/build-logic/conventions/src/main/kotlin/com/squareup/anvil/conventions/LibraryPlugin.kt
@@ -2,6 +2,7 @@ package com.squareup.anvil.conventions
 
 import com.dropbox.gradle.plugins.dependencyguard.DependencyGuardPluginExtension
 import com.rickbusarow.kgx.pluginId
+import com.squareup.anvil.conventions.utils.isInAnvilRootBuild
 import com.squareup.anvil.conventions.utils.libs
 import org.gradle.api.Project
 
@@ -10,9 +11,11 @@ open class LibraryPlugin : BasePlugin() {
 
   override fun beforeApply(target: Project) {
     target.plugins.apply(target.libs.plugins.kotlin.jvm.pluginId)
-    target.plugins.apply(target.libs.plugins.kotlinx.binaryCompatibility.pluginId)
 
-    configureDependencyGuard(target)
+    if (target.isInAnvilRootBuild()) {
+      target.plugins.apply(target.libs.plugins.kotlinx.binaryCompatibility.pluginId)
+      configureDependencyGuard(target)
+    }
   }
 
   private fun configureDependencyGuard(target: Project) {

--- a/build-logic/conventions/src/main/kotlin/com/squareup/anvil/conventions/RootPlugin.kt
+++ b/build-logic/conventions/src/main/kotlin/com/squareup/anvil/conventions/RootPlugin.kt
@@ -2,7 +2,7 @@ package com.squareup.anvil.conventions
 
 import com.rickbusarow.kgx.checkProjectIsRoot
 import com.squareup.anvil.benchmark.BenchmarkPlugin
-import com.squareup.anvil.conventions.utils.isInMainAnvilBuild
+import com.squareup.anvil.conventions.utils.isInAnvilRootBuild
 import com.squareup.anvil.conventions.utils.libs
 import org.gradle.api.Project
 
@@ -12,7 +12,7 @@ open class RootPlugin : BasePlugin() {
 
     target.checkProjectIsRoot { "RootPlugin must only be applied to the root project" }
 
-    if (target.isInMainAnvilBuild()) {
+    if (target.isInAnvilRootBuild()) {
       target.plugins.apply(BenchmarkPlugin::class.java)
     }
 

--- a/build-logic/conventions/src/main/kotlin/com/squareup/anvil/conventions/utils/project.kt
+++ b/build-logic/conventions/src/main/kotlin/com/squareup/anvil/conventions/utils/project.kt
@@ -10,7 +10,44 @@ import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.tasks.SourceSet
 import org.gradle.plugin.devel.GradlePluginDevelopmentExtension
 
-internal fun Project.isInMainAnvilBuild() = rootProject.name == "anvil"
+/**
+ * Returns true if this project is included in the root `settings.gradle.kts` file,
+ * using the syntax `include(":this-project")`.
+ *
+ * Note that due to the current composite build structure,
+ * these projects can have two different build roots:
+ *
+ * ### ':' (ex: `:gradle-plugin`)
+ * - the "true" root build, which is the root of the composite build
+ * - All build/publishing/CI/etc. tasks happen in this build
+ *
+ * ### ':anvil' (ex: `:anvil:gradle-plugin`)
+ * - not really the root build.
+ * - This build is included by the `:delegate` build in order to consume the gradle plugin.
+ *
+ * @see isInAnvilRootBuild to check if this project is part of the true root build
+ * @see isInAnvilIncludedBuild to check if this project is part of the plugin included build
+ */
+internal fun Project.isInAnvilBuild() = rootProject.name == "anvil"
+
+/**
+ * Returns true if this project is in the root 'anvil' build, and it is the true root of the build.
+ *
+ * @see isInAnvilBuild
+ * @see isInAnvilIncludedBuild
+ */
+internal fun Project.isInAnvilRootBuild() = isInAnvilBuild() && gradle.parent == null
+
+/**
+ * Returns true if this project is in the root 'anvil' build,
+ * but it is not the true root of the build.
+ * Unless something changes, that means it is included by the `:delegate` build.
+ */
+internal fun Project.isInAnvilIncludedBuild() = isInAnvilBuild() && gradle.parent != null
+
+/**
+ * Returns true if this project is included in the 'delegate' build.
+ */
 internal fun Project.isInDelegateBuild() = rootProject.name == "delegate"
 
 internal val Project.gradlePublishingExtension: PublishingExtension


### PR DESCRIPTION
We been getting flakes in CI like this one:

```
> Cannot access output property 'outputDir' of task ':gradle-plugin:generateGradleTestBuildConfig'. Accessing unreadable inputs or outputs is not supported. Declare the task as untracked by using Task.doNotTrackState(). [...]
   > Failed to create MD5 hash for file '/home/runner/work/anvil/anvil/gradle-plugin/build/generated/sources/buildConfig/gradleTest/com/squareup/anvil/plugin/buildProperties/BuildProperties.kt' as it does not exist.
```

These are happening because the projects in the main "anvil" build are technically part of two different Gradle builds -- the main/root one, and the one that's included by the `:delegate` build.  Both of those builds are acting upon the same files, and Gradle doesn't share concurrency controls between its builds.  So, we have a shared mutable state (their build directories) and every build has a chance of creating a race condition like the one above.

The fix is to have different directories, which are `$projectDir/build/anvil-build` and `$projectDir/build/included-build`.