### PR TITLE
binding extension properties to Gradle properties

### DIFF
--- a/gradle-plugin/api/gradle-plugin.api
+++ b/gradle-plugin/api/gradle-plugin.api
@@ -16,7 +16,7 @@ public final class com/squareup/anvil/plugin/AndroidVariantFilter : com/squareup
 }
 
 public abstract class com/squareup/anvil/plugin/AnvilExtension {
-	public fun <init> (Lorg/gradle/api/model/ObjectFactory;)V
+	public fun <init> (Lorg/gradle/api/model/ObjectFactory;Lorg/gradle/api/provider/ProviderFactory;)V
 	public final fun getAddOptionalAnnotations ()Lorg/gradle/api/provider/Property;
 	public final fun getDisableComponentMerging ()Lorg/gradle/api/provider/Property;
 	public final fun getGenerateDaggerFactories ()Lorg/gradle/api/provider/Property;

--- a/gradle-plugin/src/gradleTest/java/com/squareup/anvil/plugin/AnvilExtensionTest.kt
+++ b/gradle-plugin/src/gradleTest/java/com/squareup/anvil/plugin/AnvilExtensionTest.kt
@@ -1,23 +1,71 @@
 package com.squareup.anvil.plugin
 
+import com.rickbusarow.kase.Kase4
+import com.rickbusarow.kase.gradle.GradleDependencyVersion
+import com.rickbusarow.kase.gradle.GradleKotlinTestVersions
+import com.rickbusarow.kase.gradle.GradleProjectBuilder
+import com.rickbusarow.kase.gradle.HasGradleDependencyVersion
+import com.rickbusarow.kase.gradle.HasKotlinDependencyVersion
+import com.rickbusarow.kase.gradle.KotlinDependencyVersion
 import com.rickbusarow.kase.kase
-import io.kotest.assertions.asClue
+import com.rickbusarow.kase.times
 import io.kotest.matchers.string.shouldContain
+import org.junit.jupiter.api.DynamicNode
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.TestFactory
+import java.util.stream.Stream
 
 class AnvilExtensionTest : BaseGradleTest() {
 
-  @TestFactory
-  fun `gradle properties map to extension properties`() = listOf(
-    kase(a1 = "generateDaggerFactories", false),
-    kase(a1 = "generateDaggerFactoriesOnly", false),
-    kase(a1 = "disableComponentMerging", false),
-    kase(a1 = "syncGeneratedSources", false),
-    kase(a1 = "addOptionalAnnotations", false),
-  )
-    .asContainers { (propertyName, default) ->
-      testFactory { versions ->
+  @Nested
+  inner class `gradle property to extension property mapping` {
 
+    val properties = listOf(
+      kase(a1 = "generateDaggerFactories", false),
+      kase(a1 = "generateDaggerFactoriesOnly", false),
+      kase(a1 = "disableComponentMerging", false),
+      kase(a1 = "syncGeneratedSources", false),
+      kase(a1 = "addOptionalAnnotations", false),
+    )
+
+    fun GradleProjectBuilder.gradlePropertiesFile(propertyName: String, value: Any) {
+      val props = buildList {
+        if (propertyName == "generateDaggerFactoriesOnly") {
+          // The "__FactoriesOnly" toggle requires the "__Factories" toggle to be enabled.
+          add("com.squareup.anvil.generateDaggerFactories=true")
+        }
+        add("com.squareup.anvil.$propertyName=$value")
+      }
+      gradlePropertiesFile(props.joinToString("\n"))
+    }
+
+    @TestFactory
+    fun `extension properties are their default value when not set anywhere`() =
+      tests { versions, propertyName, default ->
+
+        rootProject.buildFile(
+          """
+          plugins {
+            kotlin("jvm") version "${versions.kotlinVersion}"
+            id("com.squareup.anvil") version "$anvilVersion"
+          }
+          
+          tasks.register("printProperty") {
+            doLast {
+              println("$propertyName: ${'$'}{anvil.$propertyName.get()}")
+            }
+          } 
+          """.trimIndent(),
+        )
+
+        shouldSucceed("printProperty") {
+          output shouldContain "$propertyName: $default"
+        }
+      }
+
+    @TestFactory
+    fun `the extension property is not default when only set in gradle properties`() =
+      tests { versions, propertyName, default ->
         rootProject {
           buildFile(
             """
@@ -30,85 +78,115 @@ class AnvilExtensionTest : BaseGradleTest() {
               doLast {
                 println("$propertyName: ${'$'}{anvil.$propertyName.get()}")
               }
-            }
+            } 
             """.trimIndent(),
           )
+
+          gradlePropertiesFile(propertyName, !default)
         }
 
-        "the extension property is $default when not set anywhere".asClue {
-
-          shouldSucceed("printProperty") {
-            output shouldContain "$propertyName: $default"
-          }
-        }
-
-        val addFactoryGen = propertyName == "generateDaggerFactoriesOnly"
-
-        rootProject { // The "factories only" toggle requires the "factories" toggle to be enabled.
-
-          if (addFactoryGen) {
-            gradlePropertiesFile(
-              """
-              com.squareup.anvil.generateDaggerFactories=true
-              com.squareup.anvil.$propertyName=${!default}
-              """.trimIndent(),
-            )
-          } else {
-            gradlePropertiesFile(
-              """
-              com.squareup.anvil.$propertyName=${!default}
-              """.trimIndent(),
-            )
-          }
-        }
-
-        "the extension property is ${!default} when only set in gradle.properties".asClue {
-
-          shouldSucceed("printProperty") {
-            output shouldContain "$propertyName: ${!default}"
-          }
-        }
-
-        rootProject {
-          gradlePropertiesFile(
-            """
-            com.squareup.anvil.$propertyName=$default
-            """.trimIndent(),
-          )
-        }
-
-        "the extension property is $default when set in gradle.properties".asClue {
-
-          shouldSucceed("printProperty") {
-            output shouldContain "$propertyName: $default"
-          }
-        }
-
-        val extensionText = if (addFactoryGen) {
-          """
-          anvil {
-            generateDaggerFactories = true
-            $propertyName = ${!default}
-          }
-          """.trimIndent()
-        } else {
-          """
-          anvil {
-            $propertyName = ${!default}
-          }
-          """.trimIndent()
-        }
-
-        rootProject.path
-          .resolve(dslLanguage.buildFileName)
-          .appendText("\n$extensionText")
-
-        "setting a value in the extension property supersedes the value in gradle.properties".asClue {
-
-          shouldSucceed("printProperty") {
-            output shouldContain "$propertyName: ${!default}"
-          }
+        shouldSucceed("printProperty") {
+          output shouldContain "$propertyName: ${!default}"
         }
       }
+
+    @TestFactory
+    fun `the extension property is default when explicitly set to it in gradle properties`() =
+      tests { versions, propertyName, default ->
+        rootProject {
+          buildFile(
+            """
+            plugins {
+              kotlin("jvm") version "${versions.kotlinVersion}"
+              id("com.squareup.anvil") version "$anvilVersion"
+            }
+            
+            tasks.register("printProperty") {
+              doLast {
+                println("$propertyName: ${'$'}{anvil.$propertyName.get()}")
+              }
+            } 
+            """.trimIndent(),
+          )
+
+          gradlePropertiesFile(propertyName, default)
+        }
+
+        shouldSucceed("printProperty") {
+          output shouldContain "$propertyName: $default"
+        }
+      }
+
+    @TestFactory
+    fun `the extension property overrides the gradle properties value when set`() =
+      tests { versions, propertyName, default ->
+
+        rootProject {
+          val extensionText = if (propertyName == "generateDaggerFactoriesOnly") {
+            """
+            anvil {
+              generateDaggerFactories = true
+              $propertyName = ${!default}
+            }
+            """.trimIndent()
+          } else {
+            """
+            anvil {
+              $propertyName = ${!default}
+            }
+            """.trimIndent()
+          }
+          buildFile(
+            """
+            plugins {
+              kotlin("jvm") version "${versions.kotlinVersion}"
+              id("com.squareup.anvil") version "$anvilVersion"
+            }
+            
+            tasks.register("printProperty") {
+              doLast {
+                println("$propertyName: ${'$'}{anvil.$propertyName.get()}")
+              }
+            }
+             
+            $extensionText
+            """.trimIndent(),
+          )
+
+          gradlePropertiesFile(propertyName, default)
+        }
+
+        shouldSucceed("printProperty") {
+          output shouldContain "$propertyName: ${!default}"
+        }
+      }
+
+    inline fun tests(
+      crossinline action: AnvilGradleTestEnvironment.(
+        GradleKotlinTestVersions,
+        String,
+        Boolean,
+      ) -> Unit,
+    ): Stream<out DynamicNode> = params.asContainers { versions ->
+      properties.times(listOf(versions), instanceFactory = ::PropertyKase)
+        .asTests { kase -> action(versions, kase.propertyName, kase.default) }
     }
+  }
 }
+
+@PublishedApi
+internal class PropertyKase(
+  val propertyName: String,
+  val default: Boolean,
+  override val gradle: GradleDependencyVersion,
+  override val kotlin: KotlinDependencyVersion,
+) : Kase4<GradleDependencyVersion, KotlinDependencyVersion, String, Boolean> by kase(
+  displayName = "property: $propertyName | default: $default",
+  a1 = gradle,
+  a2 = kotlin,
+  a3 = propertyName,
+  a4 = default,
+),
+  GradleKotlinTestVersions,
+  HasGradleDependencyVersion by HasGradleDependencyVersion(gradle),
+  HasKotlinDependencyVersion by HasKotlinDependencyVersion(kotlin)

--- a/gradle-plugin/src/gradleTest/java/com/squareup/anvil/plugin/AnvilExtensionTest.kt
+++ b/gradle-plugin/src/gradleTest/java/com/squareup/anvil/plugin/AnvilExtensionTest.kt
@@ -1,0 +1,114 @@
+package com.squareup.anvil.plugin
+
+import com.rickbusarow.kase.kase
+import io.kotest.assertions.asClue
+import io.kotest.matchers.string.shouldContain
+import org.junit.jupiter.api.TestFactory
+
+class AnvilExtensionTest : BaseGradleTest() {
+
+  @TestFactory
+  fun `gradle properties map to extension properties`() = listOf(
+    kase(a1 = "generateDaggerFactories", false),
+    kase(a1 = "generateDaggerFactoriesOnly", false),
+    kase(a1 = "disableComponentMerging", false),
+    kase(a1 = "syncGeneratedSources", false),
+    kase(a1 = "addOptionalAnnotations", false),
+  )
+    .asContainers { (propertyName, default) ->
+      testFactory { versions ->
+
+        rootProject {
+          buildFile(
+            """
+            plugins {
+              kotlin("jvm") version "${versions.kotlinVersion}"
+              id("com.squareup.anvil") version "$anvilVersion"
+            }
+            
+            tasks.register("printProperty") {
+              doLast {
+                println("$propertyName: ${'$'}{anvil.$propertyName.get()}")
+              }
+            }
+            """.trimIndent(),
+          )
+        }
+
+        "the extension property is $default when not set anywhere".asClue {
+
+          shouldSucceed("printProperty") {
+            output shouldContain "$propertyName: $default"
+          }
+        }
+
+        val addFactoryGen = propertyName == "generateDaggerFactoriesOnly"
+
+        rootProject { // The "factories only" toggle requires the "factories" toggle to be enabled.
+
+          if (addFactoryGen) {
+            gradlePropertiesFile(
+              """
+              com.squareup.anvil.generateDaggerFactories=true
+              com.squareup.anvil.$propertyName=${!default}
+              """.trimIndent(),
+            )
+          } else {
+            gradlePropertiesFile(
+              """
+              com.squareup.anvil.$propertyName=${!default}
+              """.trimIndent(),
+            )
+          }
+        }
+
+        "the extension property is ${!default} when only set in gradle.properties".asClue {
+
+          shouldSucceed("printProperty") {
+            output shouldContain "$propertyName: ${!default}"
+          }
+        }
+
+        rootProject {
+          gradlePropertiesFile(
+            """
+            com.squareup.anvil.$propertyName=$default
+            """.trimIndent(),
+          )
+        }
+
+        "the extension property is $default when set in gradle.properties".asClue {
+
+          shouldSucceed("printProperty") {
+            output shouldContain "$propertyName: $default"
+          }
+        }
+
+        val extensionText = if (addFactoryGen) {
+          """
+          anvil {
+            generateDaggerFactories = true
+            $propertyName = ${!default}
+          }
+          """.trimIndent()
+        } else {
+          """
+          anvil {
+            $propertyName = ${!default}
+          }
+          """.trimIndent()
+        }
+
+        rootProject.path
+          .resolve(dslLanguage.buildFileName)
+          .appendText("\n$extensionText")
+
+        "setting a value in the extension property supersedes the value in gradle.properties".asClue {
+
+          shouldSucceed("printProperty") {
+            output shouldContain "$propertyName: ${!default}"
+          }
+        }
+      }
+    }
+}


### PR DESCRIPTION
This change makes it so that all of Anvil's existing configuration options can be set via a `gradle.properties` or a `-P_______` command line option.

For any setting, Anvil take the first non-null value out of:
1. Settings in the Gradle DSL:
   ```kotlin
   anvil {
     generateDaggerFactories.set(true)
   }
   ```
3. Properties set via the command line like:
   ```sh
   ./gradlew build -Pcom.squareup.anvil.generateDaggerFactories=true
   ```
4. Properties specified in a project-level, root-project-level, or `~/.gradle/`-level `gradle.properties`:
   ```properties
   com.squareup.anvil.generateDaggerFactories = true
   ```
5. Hard-coded default values (never null)

Practically speaking, this makes it possible to *locally* feature-toggle things (like the upcoming incremental fix) without touching a project's build logic.