### PR TITLE
replace deprecated use of `android()` with `androidTarget()`

### DIFF
--- a/integration-tests/mpp/android-module/build.gradle.kts
+++ b/integration-tests/mpp/android-module/build.gradle.kts
@@ -39,10 +39,7 @@ androidComponents {
 
 kotlin {
 
-  // The `android()` target is deprecated in Kotlin 1.9.0+,
-  // but the new `androidTarget()` alternative doesn't exist in KGP 1.8.x.
-  @Suppress("DEPRECATION")
-  android()
+  androidTarget()
 
   sourceSets {
     val androidMain by getting {


### PR DESCRIPTION
We were using `android()` for the sake of Kotlin 1.8.22 support in CI. Since that's no longer supported,
we can update the build file and lose the warning in the terminal.

The warning was:

```
> Configure project :delegate:integration-tests:mpp:android-module
w: Please use `androidTarget` function instead of `android` to configure android target inside `kotlin { }` block.
```