### PR TITLE
Renovate `best-practices` preset & making Renovate work with workflow files 

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -633,6 +633,8 @@ ij_html_uniform_ident = false
 [{*.yaml,*.yml}]
 ij_yaml_keep_indents_on_empty_lines = false
 ij_yaml_keep_line_breaks = true
-ij_yaml_space_before_colon = true
+# spaces before colons break Renovate's parsing of GitHub workflow files
+# https://github.com/renovatebot/renovate/discussions/27088
+ij_yaml_space_before_colon = false
 ij_yaml_spaces_within_braces = true
 ij_yaml_spaces_within_brackets = true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,72 +1,72 @@
-name : CI
+name: CI
 
-on :
-  push :
-    branches :
+on:
+  push:
+    branches:
       - main
-    tags-ignore :
+    tags-ignore:
       - '**'
-  pull_request :
+  pull_request:
 
-jobs :
-  binary-compatibility-check :
-    runs-on : ubuntu-latest
-    timeout-minutes : 25
+jobs:
+  binary-compatibility-check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
 
-    strategy :
-      fail-fast : false
-      matrix :
-        kotlin-version : [ 1.9.22 ]
+    strategy:
+      fail-fast: false
+      matrix:
+        kotlin-version: [ 1.9.22 ]
 
-    steps :
-      - uses : actions/checkout@v3
-      - uses : actions/setup-java@v3
-        with :
-          distribution : 'temurin'
-          java-version : '11'
-          check-latest : true
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+          check-latest: true
 
-      - name : API check
-        run : ./gradlew apiCheck --no-daemon --stacktrace
+      - name: API check
+        run: ./gradlew apiCheck --no-daemon --stacktrace
 
-  test-ubuntu :
-    runs-on : ubuntu-latest
-    timeout-minutes : 25
+  test-ubuntu:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
 
-    strategy :
-      fail-fast : false
-      matrix :
-        kotlin-version : [ 1.9.22 ]
+    strategy:
+      fail-fast: false
+      matrix:
+        kotlin-version: [ 1.9.22 ]
 
-    steps :
-      - uses : actions/checkout@v3
-      - uses : actions/setup-java@v3
-        with :
-          distribution : 'zulu'
-          java-version : '17'
-          check-latest : true
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+          check-latest: true
 
-      - name : Test on Ubuntu
-        run : ./gradlew assemble test --no-build-cache --no-daemon --stacktrace -Doverride_kotlin=${{ matrix.kotlin-version }}
+      - name: Test on Ubuntu
+        run: ./gradlew assemble test --no-build-cache --no-daemon --stacktrace -Doverride_kotlin=${{ matrix.kotlin-version }}
 
-      - name : Upload Test Results
-        uses : actions/upload-artifact@v3
-        if : ${{ failure() }}
-        with :
-          name : test-results-${{ matrix.kotlin-version }}
-          path : ./**/build/reports/tests/
+      - name: Upload Test Results
+        uses: actions/upload-artifact@v3
+        if: ${{ failure() }}
+        with:
+          name: test-results-${{ matrix.kotlin-version }}
+          path: ./**/build/reports/tests/
 
-  test-windows :
-    runs-on : windows-latest
-    timeout-minutes : 25
+  test-windows:
+    runs-on: windows-latest
+    timeout-minutes: 25
 
-    steps :
-      - uses : actions/checkout@v3
-      - uses : actions/setup-java@v3
-        with :
-          distribution : 'zulu'
-          java-version : '17'
-          check-latest : true
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+          check-latest: true
 
       # On Windows the command looks a little bit different. Notice that we use the .bat file and
       # quotes for the Kotlin version, because dots "." in the Kotlin version and parameter name
@@ -74,256 +74,256 @@ jobs :
       #
       # Expressions in Github actions are limited. If there would be an if expression, then we
       # wouldn't need to duplicate the next step and depending on the OS enable / disable them.
-      - name : Test on Windows
-        run : ./gradlew.bat assemble test --no-build-cache --no-daemon --stacktrace -Doverride_config-fullTestRun=false -Doverride_config-includeKspTests=false
+      - name: Test on Windows
+        run: ./gradlew.bat assemble test --no-build-cache --no-daemon --stacktrace -Doverride_config-fullTestRun=false -Doverride_config-includeKspTests=false
 
-      - name : Upload Test Results
-        uses : actions/upload-artifact@v3
-        if : ${{ failure() }}
-        with :
-          name : test-results-windows
-          path : ./**/build/reports/tests/
+      - name: Upload Test Results
+        uses: actions/upload-artifact@v3
+        if: ${{ failure() }}
+        with:
+          name: test-results-windows
+          path: ./**/build/reports/tests/
 
-  dependency-guard :
-    runs-on : ubuntu-latest
-    timeout-minutes : 15
+  dependency-guard:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
 
-    steps :
-      - uses : actions/checkout@v3
-      - uses : actions/setup-java@v3
-        with :
-          distribution : 'temurin'
-          java-version : '11'
-          check-latest : true
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+          check-latest: true
 
-      - name : Dependency Guard Check
-        run : ./gradlew dependencyGuard --no-build-cache --no-daemon --stacktrace
+      - name: Dependency Guard Check
+        run: ./gradlew dependencyGuard --no-build-cache --no-daemon --stacktrace
 
-  ktlint :
-    runs-on : ubuntu-latest
-    timeout-minutes : 15
+  ktlint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
 
-    steps :
-      - uses : actions/checkout@v3
-      - uses : actions/setup-java@v3
-        with :
-          distribution : 'zulu'
-          java-version : '17'
-          check-latest : true
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+          check-latest: true
 
-      - name : KtLint
-        run : ./gradlew ktlintCheck --no-build-cache --no-daemon --stacktrace
+      - name: KtLint
+        run: ./gradlew ktlintCheck --no-build-cache --no-daemon --stacktrace
 
-  lint :
-    runs-on : ubuntu-latest
-    timeout-minutes : 15
+  lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
 
-    steps :
-      - uses : actions/checkout@v3
-      - uses : actions/setup-java@v3
-        with :
-          distribution : 'zulu'
-          java-version : '17'
-          check-latest : true
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+          check-latest: true
 
-      - name : Android Lint
-        run : ./gradlew -p build-logic/delegate lint --no-build-cache --no-daemon --stacktrace
+      - name: Android Lint
+        run: ./gradlew -p build-logic/delegate lint --no-build-cache --no-daemon --stacktrace
 
-      - name : Upload Lint Results
-        uses : actions/upload-artifact@v3
-        if : ${{ failure() }}
-        with :
-          name : lint-results
-          path : ./**/build/reports/lint-results.html
+      - name: Upload Lint Results
+        uses: actions/upload-artifact@v3
+        if: ${{ failure() }}
+        with:
+          name: lint-results
+          path: ./**/build/reports/lint-results.html
 
-  publish-maven-local :
-    runs-on : ubuntu-latest
-    timeout-minutes : 15
+  publish-maven-local:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
 
-    steps :
-      - uses : actions/checkout@v3
-      - uses : actions/setup-java@v3
-        with :
-          distribution : 'zulu'
-          java-version : '17'
-          check-latest : true
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+          check-latest: true
 
-      - name : Publish to Maven Local
-        run : ./gradlew clean publishToMavenLocal --no-build-cache --no-daemon --stacktrace --no-parallel
+      - name: Publish to Maven Local
+        run: ./gradlew clean publishToMavenLocal --no-build-cache --no-daemon --stacktrace --no-parallel
 
-  publish-snapshot :
-    runs-on : ubuntu-latest
-    if : github.repository == 'square/anvil' && github.ref == 'refs/heads/main'
-    timeout-minutes : 25
-    needs :
+  publish-snapshot:
+    runs-on: ubuntu-latest
+    if: github.repository == 'square/anvil' && github.ref == 'refs/heads/main'
+    timeout-minutes: 25
+    needs:
       - test-ubuntu
       - test-gradle-plugin
       - gradle-wrapper-validation
       - publish-maven-local
 
-    steps :
-      - uses : actions/checkout@v3
-      - uses : actions/setup-java@v3
-        with :
-          distribution : 'zulu'
-          java-version : '17'
-          check-latest : true
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+          check-latest: true
 
-      - name : Publish Snapshots 1.9
-        run : ./gradlew clean publish --no-build-cache --no-daemon --stacktrace --no-parallel
-        env :
-          ORG_GRADLE_PROJECT_mavenCentralUsername : ${{ secrets.SONATYPE_NEXUS_USERNAME }}
-          ORG_GRADLE_PROJECT_mavenCentralPassword : ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
+      - name: Publish Snapshots 1.9
+        run: ./gradlew clean publish --no-build-cache --no-daemon --stacktrace --no-parallel
+        env:
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
 
-  test-gradle-plugin :
-    runs-on : ubuntu-latest
+  test-gradle-plugin:
+    runs-on: ubuntu-latest
 
-    timeout-minutes : 15
+    timeout-minutes: 15
 
-    strategy :
+    strategy:
       # Run all tasks, even if some fail. Note that they don't share an output, some tasks overlap
       # which is expected. If they need to share their outputs, then we need a proper caching
       # solution.
-      fail-fast : false
-      matrix :
-        kotlin-version : [ 1.9.22 ]
-        agp-version : [ 7.1.1, 7.2.0, 7.3.1 ]
+      fail-fast: false
+      matrix:
+        kotlin-version: [ 1.9.22 ]
+        agp-version: [ 7.1.1, 7.2.0, 7.3.1 ]
 
-    steps :
-      - uses : actions/checkout@v3
-      - uses : actions/setup-java@v3
-        with :
-          distribution : 'zulu'
-          java-version : '17'
-          check-latest : true
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+          check-latest: true
 
-      - name : Test Gradle Plugin
-        run : ./gradlew :gradle-plugin:assemble :gradle-plugin:test --no-build-cache --no-daemon --stacktrace -Doverride_kotlin=${{ matrix.kotlin-version }} -Doverride_agp=${{ matrix.agp-version }}
+      - name: Test Gradle Plugin
+        run: ./gradlew :gradle-plugin:assemble :gradle-plugin:test --no-build-cache --no-daemon --stacktrace -Doverride_kotlin=${{ matrix.kotlin-version }} -Doverride_agp=${{ matrix.agp-version }}
 
-      - name : Upload Test Results
-        uses : actions/upload-artifact@v3
-        if : ${{ failure() }}
-        with :
+      - name: Upload Test Results
+        uses: actions/upload-artifact@v3
+        if: ${{ failure() }}
+        with:
           # Use the Kotlin version to prevent overrides.
-          name : test-results-gradle-plugin-${{ matrix.kotlin-version }}-${{ matrix.agp-version }}
-          path : ./**/build/reports/tests/
+          name: test-results-gradle-plugin-${{ matrix.kotlin-version }}-${{ matrix.agp-version }}
+          path: ./**/build/reports/tests/
 
-  kapt-for-dagger-factories :
-    runs-on : ubuntu-latest
-    timeout-minutes : 25
+  kapt-for-dagger-factories:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
 
-    strategy :
+    strategy:
       # Run all tasks, even if some fail. Note that they don't share an output, some tasks overlap
       # which is expected. If they need to share their outputs, then we need a proper caching
       # solution.
-      fail-fast : false
-      matrix :
-        kotlin-version : [ 1.9.22 ]
+      fail-fast: false
+      matrix:
+        kotlin-version: [ 1.9.22 ]
 
-    steps :
-      - uses : actions/checkout@v3
-      - uses : actions/setup-java@v3
-        with :
-          distribution : 'zulu'
-          java-version : '17'
-          check-latest : true
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+          check-latest: true
 
-      - name : Run integration tests
-        run : ./gradlew -p build-logic/delegate test --no-build-cache --no-daemon --stacktrace -Doverride_kotlin=${{ matrix.kotlin-version }} -Doverride_config-generateDaggerFactoriesWithAnvil=false
+      - name: Run integration tests
+        run: ./gradlew -p build-logic/delegate test --no-build-cache --no-daemon --stacktrace -Doverride_kotlin=${{ matrix.kotlin-version }} -Doverride_config-generateDaggerFactoriesWithAnvil=false
 
-      - name : Build the sample
-        run : ./gradlew :delegate:sample:app:assembleDebug --no-build-cache --no-daemon --stacktrace -Doverride_kotlin=${{ matrix.kotlin-version }} -Doverride_config-generateDaggerFactoriesWithAnvil=false
+      - name: Build the sample
+        run: ./gradlew :delegate:sample:app:assembleDebug --no-build-cache --no-daemon --stacktrace -Doverride_kotlin=${{ matrix.kotlin-version }} -Doverride_config-generateDaggerFactoriesWithAnvil=false
 
-      - name : Upload Test Results
-        uses : actions/upload-artifact@v3
-        if : ${{ failure() }}
-        with :
+      - name: Upload Test Results
+        uses: actions/upload-artifact@v3
+        if: ${{ failure() }}
+        with:
           # Use the Kotlin version to prevent overrides.
-          name : test-results-kapt-${{ matrix.kotlin-version }}
-          path : ./**/build/reports/tests/
+          name: test-results-kapt-${{ matrix.kotlin-version }}
+          path: ./**/build/reports/tests/
 
-  instrumentation-tests :
-    name : Instrumentation tests
-    runs-on : macos-latest
-    timeout-minutes : 20
-    strategy :
+  instrumentation-tests:
+    name: Instrumentation tests
+    runs-on: macos-latest
+    timeout-minutes: 20
+    strategy:
       # Allow tests to continue on other devices if they fail on one device.
-      fail-fast : false
-      matrix :
-        api-level :
+      fail-fast: false
+      matrix:
+        api-level:
           # Consider other devices in case it's needed.
           #- 24
           - 29
-    steps :
-      - uses : actions/checkout@v3
-      - uses : actions/setup-java@v3
-        with :
-          distribution : 'zulu'
-          java-version : '17'
-          check-latest : true
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+          check-latest: true
 
-      - name : Instrumentation Tests
-        uses : reactivecircus/android-emulator-runner@v2
-        with :
-          api-level : ${{ matrix.api-level }}
-          target : default
-          arch : x86_64
-          script : ./gradlew connectedCheck --no-build-cache --no-daemon --stacktrace
+      - name: Instrumentation Tests
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.api-level }}
+          target: default
+          arch: x86_64
+          script: ./gradlew connectedCheck --no-build-cache --no-daemon --stacktrace
 
-      - name : Upload results
-        uses : actions/upload-artifact@v3
-        with :
-          name : insrumentation-test-results
-          path : ./**/build/reports/androidTests/connected/**
+      - name: Upload results
+        uses: actions/upload-artifact@v3
+        with:
+          name: insrumentation-test-results
+          path: ./**/build/reports/androidTests/connected/**
 
-  gradle-integration-tests :
-    name : Gradle integration tests
-    runs-on : macos-latest
-    timeout-minutes : 20
+  gradle-integration-tests:
+    name: Gradle integration tests
+    runs-on: macos-latest
+    timeout-minutes: 20
 
-    steps :
-      - uses : actions/checkout@v3
-      - uses : actions/setup-java@v3
-        with :
-          distribution : 'zulu'
-          java-version : '17'
-          check-latest : true
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+          check-latest: true
 
-      - name : Gradle integration tests
-        run : ./gradlew gradleTest --stacktrace
+      - name: Gradle integration tests
+        run: ./gradlew gradleTest --stacktrace
 
-      - name : Upload Test Results
-        uses : actions/upload-artifact@v3
-        if : ${{ failure() }}
-        with :
-          name : test-results-gradle-integration
-          path : ./**/build/reports/tests/
+      - name: Upload Test Results
+        uses: actions/upload-artifact@v3
+        if: ${{ failure() }}
+        with:
+          name: test-results-gradle-integration
+          path: ./**/build/reports/tests/
 
-  gradle-wrapper-validation :
-    name : "Validate the Gradle Wrapper"
-    runs-on : ubuntu-latest
-    timeout-minutes : 15
-    steps :
-      - uses : actions/checkout@v3
-      - uses : gradle/wrapper-validation-action@v1
+  gradle-wrapper-validation:
+    name: "Validate the Gradle Wrapper"
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v3
+      - uses: gradle/wrapper-validation-action@v1
 
-  build-benchmark-project :
-    runs-on : ubuntu-latest
-    timeout-minutes : 25
+  build-benchmark-project:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
 
-    steps :
-      - uses : actions/checkout@v3
-      - uses : actions/setup-java@v3
-        with :
-          distribution : 'zulu'
-          java-version : '17'
-          check-latest : true
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+          check-latest: true
 
-      - name : "Generate Project"
-        run : ./gradlew :createBenchmarkProject
+      - name: "Generate Project"
+        run: ./gradlew :createBenchmarkProject
 
-      - name : "Build Benchmark Project"
-        run : ./gradlew -p benchmark :app:assemble
+      - name: "Build Benchmark Project"
+        run: ./gradlew -p benchmark :app:assemble
 
   all-checks:
     if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,40 +1,40 @@
-name : Release
+name: Release
 
-on :
-  push :
-    tags :
+on:
+  push:
+    tags:
       - 'v*.*.*'
 
-jobs :
-  publish-release :
-    runs-on : ubuntu-latest
-    if : github.repository == 'square/anvil'
-    timeout-minutes : 25
+jobs:
+  publish-release:
+    runs-on: ubuntu-latest
+    if: github.repository == 'square/anvil'
+    timeout-minutes: 25
 
-    steps :
-      - uses : actions/checkout@v2
-      - uses : gradle/wrapper-validation-action@v1
-      - uses : actions/setup-java@v2
-        with :
-          distribution : 'temurin'
-          java-version : '11'
-          check-latest : true
+    steps:
+      - uses: actions/checkout@v2
+      - uses: gradle/wrapper-validation-action@v1
+      - uses: actions/setup-java@v2
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+          check-latest: true
 
-      - name : Publish Release 1.9
-        run : ./gradlew clean publish --no-build-cache --no-daemon --stacktrace --no-parallel
-        env :
-          ORG_GRADLE_PROJECT_mavenCentralUsername : ${{ secrets.SONATYPE_NEXUS_USERNAME }}
-          ORG_GRADLE_PROJECT_mavenCentralPassword : ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
-          ORG_GRADLE_PROJECT_signingInMemoryKey : ${{ secrets.ARTIFACT_SIGNING_PRIVATE_KEY }}
-          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword : ''
+      - name: Publish Release 1.9
+        run: ./gradlew clean publish --no-build-cache --no-daemon --stacktrace --no-parallel
+        env:
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.ARTIFACT_SIGNING_PRIVATE_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ''
 
-      - name : Extract release notes
-        id : release_notes
-        uses : ffurrer2/extract-release-notes@v1
+      - name: Extract release notes
+        id: release_notes
+        uses: ffurrer2/extract-release-notes@v1
 
-      - name : Create release
-        uses : softprops/action-gh-release@v1
-        with :
-          body : ${{ steps.release_notes.outputs.release_notes }}
-        env :
-          GITHUB_TOKEN : ${{ secrets.GITHUB_TOKEN }}
+      - name: Create release
+        uses: softprops/action-gh-release@v1
+        with:
+          body: ${{ steps.release_notes.outputs.release_notes }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/renovate.json
+++ b/renovate.json
@@ -1,27 +1,27 @@
 {
   "$schema" : "https://docs.renovatebot.com/renovate-schema.json",
   "extends" : [
-    "config:base"
+    "config:best-practices"
   ],
   "rebaseWhen" : "conflicted",
   "rebaseLabel" : "rebase",
   "packageRules" : [
     {
       "groupName" : "Kotlin and compiler plugins",
-      "matchPackagePatterns" : [
-        "^org\\.jetbrains\\.kotlin:",
-        "^com\\.google\\.devtools\\.ksp:",
-        "^com\\.square\\.anvil:",
-        "^dev\\.zacsweers\\.kctfork:"
+      "matchPackagePrefixes" : [
+        "org.jetbrains.kotlin:",
+        "com.google.devtools.ksp:",
+        "com.square.anvil:",
+        "dev.zacsweers.kctfork:"
       ]
     },
     {
       "groupName" : "androidx.test and friends",
-      "matchPackagePatterns" : [
-        "^androidx\\.test:",
-        "^androidx\\.test\\.ext:",
-        "^com\\.google\\.truth:",
-        "^junit:junit:"
+      "matchPackagePrefixes" : [
+        "androidx.test:",
+        "androidx.test.ext:",
+        "com.google.truth:",
+        "junit:junit:"
       ]
     }
   ],


### PR DESCRIPTION
1. Anvil's codestyle for .yml requires a space before a colon in `.yml`.  That's valid syntax, but Renovate can't parse it -- which means we don't get updates for Actions dependencies.
2. The `config:base` in `renovate.json` is actually deprecated.  Its replacement is `config:recommended`, except that they [actually recommend](https://docs.renovatebot.com/upgrade-best-practices/#use-the-configbest-practices-preset) using `config:best-practices`.