### PR TITLE
move snapshot publishing into its own workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,31 +149,7 @@ jobs:
           check-latest: true
 
       - name: Publish to Maven Local
-        run: ./gradlew clean publishToMavenLocal --no-build-cache --no-daemon --stacktrace --no-parallel
-
-  publish-snapshot:
-    runs-on: ubuntu-latest
-    if: github.repository == 'square/anvil' && github.ref == 'refs/heads/main'
-    timeout-minutes: 25
-    needs:
-      - test-ubuntu
-      - test-gradle-plugin
-      - gradle-wrapper-validation
-      - publish-maven-local
-
-    steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
-      - uses: actions/setup-java@387ac29b308b003ca37ba93a6cab5eb57c8f5f93 # v4
-        with:
-          distribution: 'zulu'
-          java-version: '17'
-          check-latest: true
-
-      - name: Publish Snapshots 1.9
-        run: ./gradlew clean publish --no-build-cache --no-daemon --stacktrace --no-parallel
-        env:
-          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
-          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
+        run: ./gradlew clean publishToMavenLocal --no-build-cache --no-daemon --stacktrace
 
   test-gradle-plugin:
     runs-on: ubuntu-latest
@@ -336,7 +312,6 @@ jobs:
       - ktlint
       - lint
       - publish-maven-local
-      - publish-snapshot
       - test-gradle-plugin
       - kapt-for-dagger-factories
       - instrumentation-tests

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -1,0 +1,28 @@
+name: Publish snapshot
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish-snapshot:
+    runs-on: ubuntu-latest
+    if: github.repository == 'square/anvil'
+    timeout-minutes: 25
+
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      - uses: gradle/wrapper-validation-action@85cde3f5a1033b2adc2442631c24b530f1183a1a # v2
+      - uses: actions/setup-java@387ac29b308b003ca37ba93a6cab5eb57c8f5f93 # v4
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+          check-latest: true
+
+      - name: Publish Release 1.9
+        run: ./gradlew clean publish --no-build-cache --no-daemon --stacktrace
+        env:
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}


### PR DESCRIPTION
This allows us to manually trigger a publish-snapshot build against a different branch.