### PR TITLE
Don't cache the `projectDir` or `binaryFile` as part of `GeneratedFileCache`

### DIFF
--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/incremental/GeneratedFileCache.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/incremental/GeneratedFileCache.kt
@@ -4,10 +4,12 @@ import com.squareup.anvil.compiler.api.AnvilCompilationException
 import com.squareup.anvil.compiler.api.GeneratedFileWithSources
 import java.io.Closeable
 import java.io.File
+import java.io.IOException
 import java.io.ObjectInputStream
 import java.io.ObjectOutputStream
 import java.io.Serializable
 import java.security.MessageDigest
+import kotlin.LazyThreadSafetyMode.NONE
 
 internal typealias MD5String = String
 
@@ -16,39 +18,51 @@ internal class GeneratedFileCache private constructor(
   private val projectDir: ProjectDir,
 ) : Serializable, Closeable {
 
-  private val generatedToContent = mutableMapOf<RelativeFile, String>()
-  private val generatedToSources = SimpleMultimap<RelativeFile, RelativeFile>()
-  private val sourcesToGenerated = SimpleMultimap<RelativeFile, RelativeFile>()
+  private val tables: Tables by lazy(NONE) {
 
-  private val filesToMd5 = mutableMapOf<RelativeFile, MD5String>()
+    fun tables() = Tables(
+      generatedToContent = mutableMapOf(),
+      generatedToSources = SimpleMultimap(),
+      sourcesToGenerated = SimpleMultimap(),
+      filesToMd5 = mutableMapOf(),
+    )
 
-  val sourceFiles: Set<RelativeFile> get() = sourcesToGenerated.keys
+    if (!binaryFile.isFile) return@lazy tables()
+    try {
+      ObjectInputStream(binaryFile.inputStream())
+        .use { it.readObject() as Tables }
+    } catch (e: IOException) {
+      tables()
+    }
+  }
+
+  val sourceFiles: Set<RelativeFile> get() = tables.sourcesToGenerated.keys
 
   fun isGenerated(file: FileType): Boolean {
     return when (file) {
       is AbsoluteFile -> isGenerated(file.relativeTo(projectDir))
-      is RelativeFile -> generatedToContent.containsKey(file)
+      is RelativeFile -> tables.generatedToContent.containsKey(file)
     }
   }
 
   fun getSourceFiles(generatedFile: FileType): Set<RelativeFile> {
     return when (generatedFile) {
       is AbsoluteFile -> getSourceFiles(generatedFile.relativeTo(projectDir))
-      is RelativeFile -> generatedToSources[generatedFile]
+      is RelativeFile -> tables.generatedToSources[generatedFile]
     }
   }
 
   fun getContent(generatedFile: FileType): String {
     return when (generatedFile) {
       is AbsoluteFile -> getContent(generatedFile.relativeTo(projectDir))
-      is RelativeFile -> generatedToContent.getValue(generatedFile)
+      is RelativeFile -> tables.generatedToContent.getValue(generatedFile)
     }
   }
 
   fun getGeneratedFiles(sourceFile: FileType): Set<RelativeFile> {
     return when (sourceFile) {
       is AbsoluteFile -> getGeneratedFiles(sourceFile.relativeTo(projectDir))
-      is RelativeFile -> sourcesToGenerated[sourceFile]
+      is RelativeFile -> tables.sourcesToGenerated[sourceFile]
     }
   }
 
@@ -57,9 +71,9 @@ internal class GeneratedFileCache private constructor(
       is AbsoluteFile -> getGeneratedFilesRecursive(sourceFile.relativeTo(projectDir))
       is RelativeFile -> {
         val visited = mutableSetOf<RelativeFile>()
-        generateSequence(sourcesToGenerated[sourceFile]) { generated ->
+        generateSequence(tables.sourcesToGenerated[sourceFile]) { generated ->
           generated.filter { visited.add(it) }
-            .flatMapTo(mutableSetOf()) { sourcesToGenerated[it] }
+            .flatMapTo(mutableSetOf()) { tables.sourcesToGenerated[it] }
             .takeIf { it.iterator().hasNext() }
         }
           .flatten()
@@ -74,9 +88,9 @@ internal class GeneratedFileCache private constructor(
 
   private fun addMd5(sourceFile: RelativeFile, overwrite: Boolean) {
     if (overwrite) {
-      filesToMd5[sourceFile] = sourceFile.md5()
+      tables.filesToMd5[sourceFile] = sourceFile.md5()
     } else {
-      filesToMd5.computeIfAbsent(sourceFile) { sourceFile.md5() }
+      tables.filesToMd5.computeIfAbsent(sourceFile) { sourceFile.md5() }
     }
   }
 
@@ -85,7 +99,7 @@ internal class GeneratedFileCache private constructor(
     val generatedAbsolute = AbsoluteFile(generated.file)
     val generatedRelative = generatedAbsolute.relativeTo(projectDir)
 
-    generatedToContent[generatedRelative] = generated.content
+    tables.generatedToContent[generatedRelative] = generated.content
 
     addMd5(generatedRelative, overwrite = true)
 
@@ -107,8 +121,8 @@ internal class GeneratedFileCache private constructor(
         )
       }
 
-      sourcesToGenerated.add(source, generatedRelative)
-      generatedToSources.add(generatedRelative, source)
+      tables.sourcesToGenerated.add(source, generatedRelative)
+      tables.generatedToSources.add(generatedRelative, source)
 
       // At this point, any source file should be in the md5 map already.
       // But in case it isn't, we'll add it now.
@@ -120,20 +134,20 @@ internal class GeneratedFileCache private constructor(
     when (sourceFile) {
       is AbsoluteFile -> removeSource(sourceFile.relativeTo(projectDir))
       is RelativeFile -> {
-        filesToMd5.remove(sourceFile)
-        generatedToSources.remove(sourceFile)
+        tables.filesToMd5.remove(sourceFile)
+        tables.generatedToSources.remove(sourceFile)
 
         // All generated files that claim this source file as a source.
-        val generated = sourcesToGenerated.remove(sourceFile) ?: return
+        val generated = tables.sourcesToGenerated.remove(sourceFile) ?: return
 
         for (gen in generated) {
 
           // For any generated file that has multiple sources,
           // remove that generated file from the "generated" set for those other sources.
           // Note that this does not call `removeSource` for that other source.
-          for (otherSource in generatedToSources[gen]) {
+          for (otherSource in tables.generatedToSources[gen]) {
             if (otherSource != sourceFile) {
-              sourcesToGenerated.remove(otherSource, gen)
+              tables.sourcesToGenerated.remove(otherSource, gen)
             }
           }
           removeSource(gen)
@@ -151,14 +165,10 @@ internal class GeneratedFileCache private constructor(
       is RelativeFile -> {
         if (sourceFile == RelativeFile.ANY) return true
         val currentMd5 = sourceFile.md5()
-        val previousMd5 = filesToMd5.put(sourceFile, currentMd5)
+        val previousMd5 = tables.filesToMd5.put(sourceFile, currentMd5)
         return previousMd5 != currentMd5
       }
     }
-  }
-
-  override fun close() {
-    writeToBinaryFile()
   }
 
   private fun FileType.md5(): MD5String = when (this) {
@@ -170,67 +180,86 @@ internal class GeneratedFileCache private constructor(
     is RelativeFile -> projectDir.resolve(this).md5()
   }
 
-  override fun toString(): String = """
-    |======================== ${this::class.simpleName}
-    | -- sourcesToGenerated
-    |$sourcesToGenerated
-    |
-    | -- generatedToSources
-    |$generatedToSources
-    |
-    | -- generatedToContent
-    |$generatedToContent
-    |
-    | -- filesToMd5
-    |${filesToMd5.toList().joinToString("\n") { "${it.first} -> ${it.second}" }}
-    |========================
-  """.trimMargin()
+  override fun close() {
+    writeToBinaryFile()
+  }
 
   private fun writeToBinaryFile() {
 
     binaryFile.delete()
     binaryFile.parentFile.mkdirs()
-    ObjectOutputStream(binaryFile.outputStream()).use {
-      it.writeObject(this@GeneratedFileCache)
-    }
+    ObjectOutputStream(binaryFile.outputStream())
+      .use { it.writeObject(tables) }
   }
 
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
     if (other !is GeneratedFileCache) return false
-
-    if (generatedToContent != other.generatedToContent) return false
-    if (generatedToSources != other.generatedToSources) return false
-    if (sourcesToGenerated != other.sourcesToGenerated) return false
-    if (filesToMd5 != other.filesToMd5) return false
-
+    if (tables != other.tables) return false
     return true
   }
 
   override fun hashCode(): Int {
-    var result = generatedToContent.hashCode()
-    result = 31 * result + generatedToSources.hashCode()
-    result = 31 * result + sourcesToGenerated.hashCode()
-    result = 31 * result + filesToMd5.hashCode()
-    return result
+    return tables.hashCode()
+  }
+
+  private class Tables(
+    val generatedToContent: MutableMap<RelativeFile, String>,
+    val generatedToSources: SimpleMultimap<RelativeFile, RelativeFile>,
+    val sourcesToGenerated: SimpleMultimap<RelativeFile, RelativeFile>,
+    val filesToMd5: MutableMap<RelativeFile, MD5String>,
+  ) : Serializable {
+
+    override fun toString(): String = """
+      |======================== ${this::class.simpleName}
+      | -- sourcesToGenerated
+      |$sourcesToGenerated
+      |
+      | -- generatedToSources
+      |$generatedToSources
+      |
+      | -- filesToMd5
+      |${filesToMd5.toList().joinToString("\n") { "${it.first} -> ${it.second}" }}
+      |
+      | -- generatedToContent
+      |$generatedToContent
+      |========================
+    """.trimMargin()
+
+    override fun equals(other: Any?): Boolean {
+      if (this === other) return true
+      if (other !is Tables) return false
+
+      if (generatedToContent != other.generatedToContent) return false
+      if (generatedToSources != other.generatedToSources) return false
+      if (sourcesToGenerated != other.sourcesToGenerated) return false
+      if (filesToMd5 != other.filesToMd5) return false
+
+      return true
+    }
+
+    override fun hashCode(): Int {
+      var result = generatedToContent.hashCode()
+      result = 31 * result + generatedToSources.hashCode()
+      result = 31 * result + sourcesToGenerated.hashCode()
+      result = 31 * result + filesToMd5.hashCode()
+      return result
+    }
+
+    companion object {
+      private const val serialVersionUID: Long = -5573746546333024015L
+    }
   }
 
   companion object {
     const val GENERATED_FILE_CACHE_NAME = "generated-file-cache.bin"
 
-    fun fromFile(binaryFile: File, projectDir: ProjectDir): GeneratedFileCache {
-
-      return if (binaryFile.exists()) {
-        try {
-          ObjectInputStream(binaryFile.inputStream()).use {
-            it.readObject() as GeneratedFileCache
-          }
-        } catch (e: Throwable) {
-          GeneratedFileCache(binaryFile, projectDir)
-        }
-      } else {
-        GeneratedFileCache(binaryFile, projectDir)
-      }
-    }
+    fun fromFile(
+      binaryFile: File,
+      projectDir: ProjectDir,
+    ): GeneratedFileCache = GeneratedFileCache(
+      binaryFile = binaryFile,
+      projectDir = projectDir,
+    )
   }
 }

--- a/compiler/src/test/java/com/squareup/anvil/compiler/codegen/CodeGenerationExtensionTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/codegen/CodeGenerationExtensionTest.kt
@@ -203,7 +203,8 @@ class CodeGenerationExtensionTest {
     }
   }
 
-  @Test fun `a code generator that tracks an a single source per generated file can use trackSourceFiles`() {
+  @Test
+  fun `a code generator that tracks a single source per generated file can use trackSourceFiles`() {
 
     val codeGenerator = simpleCodeGenerator(TRACK_SOURCE_FILES) { clazz ->
 

--- a/gradle-plugin/src/gradleTest/java/com/squareup/anvil/plugin/IncrementalTest.kt
+++ b/gradle-plugin/src/gradleTest/java/com/squareup/anvil/plugin/IncrementalTest.kt
@@ -488,10 +488,8 @@ class IncrementalTest : BaseGradleTest() {
         .withTestKitDir(workingDir / "testKit")
         .withArguments("compileKotlin", "--stacktrace")
 
-      val rootA = workingDir.resolve("root-a")
-      // The second project has an extra parent directory
-      // so that `root-a` and `root-b` have different relative paths to the build cache.
-      val rootB = workingDir.resolve("dir/root-b")
+      val rootA = workingDir.resolve("a/root-a")
+      val rootB = workingDir.resolve("b/root-b")
 
       for (root in listOf(rootA, rootB)) {
         rootProject(path = root) {
@@ -519,6 +517,9 @@ class IncrementalTest : BaseGradleTest() {
       with(runner.withProjectDir(rootA).build()) {
         task(":compileKotlin")?.outcome shouldBe TaskOutcome.SUCCESS
       }
+
+      rootA.deleteRecursively()
+      rootA.shouldNotExist()
 
       with(runner.withProjectDir(rootB).build()) {
         task(":compileKotlin")?.outcome shouldBe TaskOutcome.FROM_CACHE


### PR DESCRIPTION
fixes #880

The `GeneratedFileCache` needs a reference to the current machine's project directory and the path of its binary file.
These values were being written to that binary file and restored on subsequent reads. That breaks things when the same cache is used on a different machine due to remote build caching.

Now, those two files are still part of `GeneratedFileCache`, but only the inner `Tables` class is actually cached.