### PR TITLE
Revert "[bugfix] Binding supertype which is narrower than return type is wrongly allowed"

### DIFF
--- a/build-logic/conventions/src/main/kotlin/com/squareup/anvil/conventions/KtlintConventionPlugin.kt
+++ b/build-logic/conventions/src/main/kotlin/com/squareup/anvil/conventions/KtlintConventionPlugin.kt
@@ -13,18 +13,6 @@ open class KtlintConventionPlugin : Plugin<Project> {
 
     target.extensions.configure(KtlintExtension::class.java) { ktlint ->
       ktlint.version.set(target.libs.versions.ktlint)
-      val pathsToExclude = listOf(
-        "build/generated",
-        "root-build/generated",
-        "included-build/generated",
-      )
-      ktlint.filter {
-        it.exclude {
-          pathsToExclude.any { excludePath ->
-            it.file.path.contains(excludePath)
-          }
-        }
-      }
       ktlint.verbose.set(true)
     }
   }

--- a/compiler-utils/api/compiler-utils.api
+++ b/compiler-utils/api/compiler-utils.api
@@ -627,8 +627,6 @@ public final class com/squareup/anvil/compiler/internal/reference/TypeReference$
 public final class com/squareup/anvil/compiler/internal/reference/TypeReferenceKt {
 	public static final fun AnvilCompilationExceptionTypReference (Lcom/squareup/anvil/compiler/internal/reference/TypeReference;Ljava/lang/String;Ljava/lang/Throwable;)Lcom/squareup/anvil/compiler/api/AnvilCompilationException;
 	public static synthetic fun AnvilCompilationExceptionTypReference$default (Lcom/squareup/anvil/compiler/internal/reference/TypeReference;Ljava/lang/String;Ljava/lang/Throwable;ILjava/lang/Object;)Lcom/squareup/anvil/compiler/api/AnvilCompilationException;
-	public static final fun allSuperTypeReferences (Lcom/squareup/anvil/compiler/internal/reference/TypeReference;Z)Lkotlin/sequences/Sequence;
-	public static synthetic fun allSuperTypeReferences$default (Lcom/squareup/anvil/compiler/internal/reference/TypeReference;ZILjava/lang/Object;)Lkotlin/sequences/Sequence;
 	public static final fun toTypeReference (Lorg/jetbrains/kotlin/psi/KtTypeReference;Lcom/squareup/anvil/compiler/internal/reference/ClassReference$Psi;Lcom/squareup/anvil/compiler/internal/reference/AnvilModuleDescriptor;)Lcom/squareup/anvil/compiler/internal/reference/TypeReference$Psi;
 	public static final fun toTypeReference (Lorg/jetbrains/kotlin/types/KotlinType;Lcom/squareup/anvil/compiler/internal/reference/ClassReference;Lcom/squareup/anvil/compiler/internal/reference/AnvilModuleDescriptor;)Lcom/squareup/anvil/compiler/internal/reference/TypeReference$Descriptor;
 }

--- a/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/reference/ClassReference.kt
+++ b/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/reference/ClassReference.kt
@@ -451,7 +451,6 @@ public fun AnvilCompilationExceptionClassReference(
     message = message,
     cause = cause,
   )
-
   is Descriptor -> AnvilCompilationException(
     classDescriptor = classReference.clazz,
     message = message,

--- a/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/reference/TypeReference.kt
+++ b/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/reference/TypeReference.kt
@@ -666,30 +666,3 @@ private fun TypeName.lambdaFix(): TypeName {
     .parameterizedBy(allTypes)
     .copy(nullable = isNullable)
 }
-
-/**
- * This will return all super types as [TypeReference], whether they're parsed as [KtTypeReference]
- * or [KotlinType]. This will include generated code, assuming it has already been generated.
- * The returned sequence will be distinct by FqName, and Psi types are preferred over Descriptors.
- *
- * The first elements in the returned sequence represent the direct superclass to the receiver. The
- * last elements represent the types which are furthest up-stream.
- *
- * @param includeSelf If true, the receiver class is the first element of the sequence
- */
-@ExperimentalAnvilApi
-public fun TypeReference.allSuperTypeReferences(
-  includeSelf: Boolean = false,
-): Sequence<TypeReference> {
-  return generateSequence(listOf(this)) { superTypes ->
-    superTypes
-      .mapNotNull { it.asClassReferenceOrNull() }
-      .flatMap { classRef ->
-        classRef.directSuperTypeReferences()
-      }
-      .takeIf { it.isNotEmpty() }
-  }
-    .drop(if (includeSelf) 0 else 1)
-    .flatten()
-    .distinct()
-}

--- a/compiler/src/test/java/com/squareup/anvil/compiler/dagger/BindsMethodValidatorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/dagger/BindsMethodValidatorTest.kt
@@ -55,8 +55,8 @@ class BindsMethodValidatorTest(
       )
       if (!useDagger) {
         assertThat(messages).contains(
-          "Expected binding of type com.squareup.test.Bar but impl parameter of type com.squareup.test.Foo only has the following " +
-            "supertypes: [com.squareup.test.Ipsum, com.squareup.test.Lorem]",
+          "Expected binding of type Bar but impl parameter of type Foo only has the following " +
+            "supertypes: [Ipsum, Lorem]",
         )
       }
     }
@@ -88,7 +88,7 @@ class BindsMethodValidatorTest(
       )
       if (!useDagger) {
         assertThat(messages).contains(
-          "Expected binding of type com.squareup.test.Bar but impl parameter of type com.squareup.test.Foo has no supertypes.",
+          "Expected binding of type Bar but impl parameter of type Foo has no supertypes.",
         )
       }
     }
@@ -311,44 +311,6 @@ class BindsMethodValidatorTest(
     ) {
       assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
       assertThat(messages).contains("@Binds methods can not be an extension function")
-    }
-  }
-
-  @Test
-  fun `binding which supertype is narrower than return type fails to compile`() {
-    compile(
-      """
-        package com.squareup.test
-
-        import dagger.Module
-        import dagger.Binds
-    
-        sealed interface ItemDetail {
-          object DetailTypeA : ItemDetail
-        }
-
-        interface ItemMapper<T : ItemDetail>
-
-        class DetailTypeAItemMapper : ItemMapper<ItemDetail.DetailTypeA>
-        
-        @Module
-        interface SomeModule {
-          @Binds fun shouldBeInvalidComplexBinding(real: DetailTypeAItemMapper): ItemMapper<ItemDetail>
-        }
-      """.trimIndent(),
-    ) {
-      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
-      assertThat(messages).contains(
-        "@Binds methods' parameter type must be assignable to the return type",
-      )
-      if (!useDagger) {
-        assertThat(messages).contains(
-          "@Binds methods' parameter type must be assignable to the return type. Expected " +
-            "binding of type com.squareup.test.ItemMapper<com.squareup.test.ItemDetail> but impl " +
-            "parameter of type com.squareup.test.DetailTypeAItemMapper only has the following " +
-            "supertypes: [com.squareup.test.ItemMapper<com.squareup.test.ItemDetail.DetailTypeA>]",
-        )
-      }
     }
   }
 


### PR DESCRIPTION
Reverts square/anvil#833

see ([#833](https://github.com/square/anvil/issues/885)).

"Assignable" checks aren't working for most generic type references, and it doesn't seem to be a quick fix.