### PR TITLE
Fix contributed interface merging when KSP backend is enabled

### DIFF
--- a/compiler/src/main/java/com/squareup/anvil/compiler/AnvilComponentRegistrar.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/AnvilComponentRegistrar.kt
@@ -57,17 +57,18 @@ public class AnvilComponentRegistrar : ComponentRegistrar {
       }
     }
 
-    // Everything below this point is only when running in embedded compilation mode. If running in
-    // KSP, there's nothing else to do.
-    if (commandLineOptions.backend != AnalysisBackend.EMBEDDED) {
-      return
-    }
-
+    // TODO this won't work in K2, we will eventually need an InterfaceMergerIr
     if (mergingEnabled) {
       SyntheticResolveExtension.registerExtension(
         project,
         InterfaceMerger(scanner, moduleDescriptorFactory),
       )
+    }
+
+    // Everything below this point is only when running in embedded compilation mode. If running in
+    // KSP, there's nothing else to do.
+    if (commandLineOptions.backend != AnalysisBackend.EMBEDDED) {
+      return
     }
 
     val sourceGenFolder = configuration.getNotNull(srcGenDirKey)


### PR DESCRIPTION
I had assumed that `ModuleMergerIr` somewhere also handled merging contributed interfaces, but that's actually still done separately in `InterfaceMerger`. With the KSP controls, we currently don't add this impl if we enable the KSP backend. Easy enough fix for now is to move it back up to before, but this'll be another thing we need to do to fully support K2 (i.e. `InterfaceMergerIr`).