### PR TITLE
treat any input `KtFile`s as changed/invalidated

### DIFF
--- a/compiler/src/main/java/com/squareup/anvil/compiler/Utils.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/Utils.kt
@@ -140,3 +140,35 @@ internal fun File.requireDelete() {
     throw AnvilCompilationException("Could not delete file: $this")
   }
 }
+
+/**
+ * Transforms the elements of the receiver collection and adds the results to a set.
+ *
+ * @param destination The destination set where the transformed
+ *   elements are placed. By default, it is an empty mutable set.
+ * @param transform Maps elements of the receiver collection to the output set.
+ * @receiver The collection to be transformed.
+ * @return A set containing the transformed elements from the receiver collection.
+ */
+internal inline fun <C : Collection<T>, T, R> C.mapToSet(
+  destination: MutableSet<R> = mutableSetOf(),
+  transform: (T) -> R,
+): Set<R> {
+  return mapTo(destination, transform)
+}
+
+/**
+ * Transforms the elements of the receiver array and adds the results to a set.
+ *
+ * @param destination The destination set where the transformed
+ *   elements are placed. By default, it is an empty mutable set.
+ * @param transform Maps elements of the receiver collection to the output set.
+ * @receiver The array to be transformed.
+ * @return A set containing the transformed elements from the receiver array.
+ */
+internal inline fun <T, R> Array<T>.mapToSet(
+  destination: MutableSet<R> = mutableSetOf(),
+  transform: (T) -> R,
+): Set<R> {
+  return mapTo(destination, transform)
+}

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/incremental/GeneratedFileCache.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/incremental/GeneratedFileCache.kt
@@ -4,6 +4,7 @@ import com.squareup.anvil.compiler.api.AnvilCompilationException
 import com.squareup.anvil.compiler.api.GeneratedFileWithSources
 import com.squareup.anvil.compiler.codegen.incremental.collections.Multimap
 import com.squareup.anvil.compiler.codegen.incremental.collections.MutableBiMap
+import com.squareup.anvil.compiler.mapToSet
 import java.io.Closeable
 import java.io.File
 import java.io.IOException
@@ -217,7 +218,7 @@ internal class GeneratedFileCache private constructor(
 
     fun getSourceFilesWithoutGeneratedContent(): Set<RelativeFile> = sourcesToGenerated.keys
       .filter { !generatedToContent.containsKey(it) }
-      .mapTo(mutableSetOf()) { fileIds.inverse.getValue(it) }
+      .mapToSet { fileIds.inverse.getValue(it) }
 
     fun putSourceGeneratedPair(sourceFile: RelativeFile, generatedFile: RelativeFile) {
       sourcesToGenerated.add(sourceFile.id, generatedFile.id)
@@ -248,11 +249,11 @@ internal class GeneratedFileCache private constructor(
 
     fun getSourceFiles(generatedFile: RelativeFile): Set<RelativeFile> =
       generatedToSources[generatedFile.id]
-        .mapTo(mutableSetOf()) { fileIds.inverse.getValue(it) }
+        .mapToSet { fileIds.inverse.getValue(it) }
 
     fun getGeneratedFiles(sourceFile: RelativeFile): Set<RelativeFile> =
       sourcesToGenerated[sourceFile.id]
-        .mapTo(mutableSetOf()) { fileIds.inverse.getValue(it) }
+        .mapToSet { fileIds.inverse.getValue(it) }
 
     fun putGeneratedContent(generatedFile: RelativeFile, content: String): String? {
       return generatedToContent.put(generatedFile.id, content)

--- a/compiler/src/test/java/com/squareup/anvil/compiler/codegen/incremental/CacheTestEnvironment.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/codegen/incremental/CacheTestEnvironment.kt
@@ -7,6 +7,7 @@ import com.rickbusarow.kase.NoParamTestEnvironmentFactory
 import com.rickbusarow.kase.files.TestLocation
 import com.rickbusarow.kase.stdlib.createSafely
 import com.squareup.anvil.compiler.api.GeneratedFileWithSources
+import com.squareup.anvil.compiler.mapToSet
 import io.kotest.matchers.file.shouldExist
 import io.kotest.matchers.shouldBe
 import java.io.File
@@ -120,6 +121,18 @@ internal class CacheTestEnvironment(
 
   fun FileCacheOperations.addToCache(vararg gens: GeneratedFileWithSources) {
     addToCache(emptyList(), gens.toList())
+  }
+
+  fun FileCacheOperations.restoreFromCache(vararg sources: FileType) {
+    restoreFromCache(
+      generatedDir = generatedDir,
+      inputKtFiles = sources.mapToSet { fileType ->
+        when (fileType) {
+          is AbsoluteFile -> fileType.relativeTo(projectDir)
+          is RelativeFile -> fileType
+        }
+      },
+    )
   }
 
   fun newCache(binaryFile: File = this.binaryFile): GeneratedFileCache {

--- a/compiler/src/test/java/com/squareup/anvil/compiler/codegen/incremental/FileCacheOperationsTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/codegen/incremental/FileCacheOperationsTest.kt
@@ -23,6 +23,30 @@ internal class FileCacheOperationsTest : CacheTests {
   }
 
   @Test
+  fun `restoreFromCache passing a source file as input deletes it and everything downstream`() = test {
+
+    fileOperations.addToCache(
+      gen1.withSources(source1),
+      gen2.withSources(source2),
+      gen3.withSources(gen2.toSourceFile()),
+      gen4.withSources(source3),
+    )
+
+    listOf(gen1, gen2, gen3)
+      .forEach { it.file.delete() }
+
+    fileOperations.restoreFromCache(generatedDir, setOf(source2))
+
+    currentFiles() shouldBe listOf(
+      gen1.relativeFile,
+      gen4.relativeFile,
+      source1,
+      source2,
+      source3,
+    )
+  }
+
+  @Test
   fun `restoreFromCache missing generated files are restored`() = test {
 
     fileOperations.addToCache(
@@ -34,7 +58,7 @@ internal class FileCacheOperationsTest : CacheTests {
     listOf(gen1, gen2, gen3)
       .forEach { it.file.delete() }
 
-    fileOperations.restoreFromCache(generatedDir)
+    fileOperations.restoreFromCache()
 
     currentFiles() shouldBe listOf(
       gen1.relativeFile,
@@ -64,7 +88,7 @@ internal class FileCacheOperationsTest : CacheTests {
       gen3.withSources(gen2.toSourceFile()),
     )
 
-    fileOperations.restoreFromCache(generatedDir)
+    fileOperations.restoreFromCache()
 
     currentFiles() shouldBe listOf(
       gen1.relativeFile,
@@ -87,7 +111,7 @@ internal class FileCacheOperationsTest : CacheTests {
 
       source1.writeText("changed")
 
-      fileOperations.restoreFromCache(generatedDir)
+      fileOperations.restoreFromCache(source1)
 
       currentFiles() shouldBe listOf(gen3.relativeFile, source1, source2)
     }
@@ -103,7 +127,7 @@ internal class FileCacheOperationsTest : CacheTests {
 
     source2.writeText("changed")
 
-    fileOperations.restoreFromCache(generatedDir)
+    fileOperations.restoreFromCache(source2)
 
     currentFiles() shouldBe listOf(gen1.relativeFile, source1, source2)
   }
@@ -121,7 +145,7 @@ internal class FileCacheOperationsTest : CacheTests {
 
     currentFiles() shouldBe listOf(gen1.relativeFile, untracked, source1)
 
-    fileOperations.restoreFromCache(generatedDir)
+    fileOperations.restoreFromCache()
 
     currentFiles() shouldBe listOf(gen1.relativeFile, source1)
   }
@@ -143,7 +167,7 @@ internal class FileCacheOperationsTest : CacheTests {
     )
       .forEach { it.absoluteFile.delete() }
 
-    fileOperations.restoreFromCache(generatedDir)
+    fileOperations.restoreFromCache()
 
     currentFiles() shouldBe listOf(gen2.relativeFile, gen3.relativeFile, source2)
   }

--- a/gradle-plugin/src/gradleTest/java/com/squareup/anvil/plugin/testing/AnvilGradleTestEnvironment.kt
+++ b/gradle-plugin/src/gradleTest/java/com/squareup/anvil/plugin/testing/AnvilGradleTestEnvironment.kt
@@ -51,9 +51,9 @@ class AnvilGradleTestEnvironment(
    *   )
    * ```
    */
-  fun File.listRelativeFilePaths(): List<String> = walkBottomUp()
+  fun File.listRelativeFilePaths(parentDir: File = this): List<String> = walkBottomUp()
     .filter { it.isFile }
-    .map { it.toRelativeString(rootAnvilMainGenerated) }
+    .map { it.toRelativeString(parentDir) }
     .sorted()
     .toList()
 


### PR DESCRIPTION
fixes #898

By "input `KtFile`s" I'm referring to the `files: List<KtFile>` parameters in `CodeGeneratorExtension.doAnalysis(...)` and `CodeGeneratorExtension.onAnalysisCompleted(...)`.

For any given compilation, on the very first round of analysis/generation, the `files` parameter will roughly correspond to the incremental files from Gradle's `InputChanges` instance.

We should treat these files as changed because:

1. If they're also in our internal cache, with the same contents (MD5 hash), then there must be some reason that Gradle decided to pass them as input again and the compiler agreed. This is most likely because of a classpath change, either in a dependency project or an external library.

   In this case, since Anvil uses classpath discovery to generate binding modules and merged interfaces, its expected output can easily change even if the source files in that module haven't.

2. If they come from `InputChanges`, they're changed by definition.

3. If they're input files, then we'll be generating code for them again anyway and it will be up-to-date.

With this change, a source file is considered to be unchanged (eligible for restoration) if it exists on the disk and in the cache with the same content hash and it wasn't passed as an input file.  Since they aren't inputs, they won't be passed to the code generators, and we need to restore any downstream generated files from the cache.