### PR TITLE
switch Renovate's `rebaseWhen` setting to `auto`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,7 @@
   "extends" : [
     "config:best-practices"
   ],
-  "rebaseWhen" : "conflicted",
+  "rebaseWhen" : "auto",
   "rebaseLabel" : "rebase",
   "packageRules" : [
     {


### PR DESCRIPTION
[docs](https://docs.renovatebot.com/configuration-options/#rebasewhen)

The `conflicted` setting is copy-pasta from one of my projects where I use Kodiak to handle updating/merging.  Without Kodiak, it just means we have to babysit the PRs.