### PR TITLE
Remove the `Project` parameter from `AnvilExtension.useKsp(...)`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,8 +254,8 @@ jobs:
 
   gradle-integration-tests:
     name: Gradle integration tests
-    runs-on: macos-latest
-    timeout-minutes: 20
+    runs-on: macos-14
+    timeout-minutes: 25
 
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4

--- a/build-logic/conventions/src/main/kotlin/com/squareup/anvil/conventions/KtlintConventionPlugin.kt
+++ b/build-logic/conventions/src/main/kotlin/com/squareup/anvil/conventions/KtlintConventionPlugin.kt
@@ -13,6 +13,18 @@ open class KtlintConventionPlugin : Plugin<Project> {
 
     target.extensions.configure(KtlintExtension::class.java) { ktlint ->
       ktlint.version.set(target.libs.versions.ktlint)
+      val pathsToExclude = listOf(
+        "build/generated",
+        "root-build/generated",
+        "included-build/generated",
+      )
+      ktlint.filter {
+        it.exclude {
+          pathsToExclude.any { excludePath ->
+            it.file.path.contains(excludePath)
+          }
+        }
+      }
       ktlint.verbose.set(true)
     }
   }

--- a/gradle-plugin/api/gradle-plugin.api
+++ b/gradle-plugin/api/gradle-plugin.api
@@ -31,9 +31,9 @@ public abstract class com/squareup/anvil/plugin/AnvilExtension {
 	public final fun getTrackSourceFiles ()Lorg/gradle/api/provider/Property;
 	public final fun getUseKspBackend ()Lorg/gradle/api/provider/Property;
 	public final fun getUseKspComponentMergingBackend ()Lorg/gradle/api/provider/Property;
-	public final fun useKsp (Lorg/gradle/api/Project;Z)V
-	public final fun useKsp (Lorg/gradle/api/Project;ZZ)V
-	public static synthetic fun useKsp$default (Lcom/squareup/anvil/plugin/AnvilExtension;Lorg/gradle/api/Project;ZZILjava/lang/Object;)V
+	public final fun useKsp (Z)V
+	public final fun useKsp (ZZ)V
+	public static synthetic fun useKsp$default (Lcom/squareup/anvil/plugin/AnvilExtension;ZZILjava/lang/Object;)V
 	public final fun variantFilter (Lorg/gradle/api/Action;)V
 }
 

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -50,13 +50,14 @@ buildConfig {
       topLevelConstants = true
     }
 
-    val buildM2 = rootProject.layout.buildDirectory.dir("m2").map { "File(\"${it}\")" }
-    buildConfigField("java.io.File", "localBuildM2Dir", buildM2)
-    buildConfigField("String", "anvilVersion", "\"$VERSION_NAME\"")
-    buildConfigField("String", "kotlinVersion", "\"${libs.versions.kotlin.get()}\"")
-    buildConfigField("String", "gradleVersion", "\"${gradle.gradleVersion}\"")
-    buildConfigField("String", "daggerVersion", "\"${libs.versions.dagger.get()}\"")
-    buildConfigField("kotlin.Boolean", "fullTestRun", libs.versions.config.fullTestRun.get())
+    val buildM2 = rootProject.layout.buildDirectory.dir("m2").map { it.asFile }
+    buildConfigField("anvilVersion", VERSION_NAME)
+    buildConfigField("daggerVersion", libs.versions.dagger)
+    buildConfigField("fullTestRun", libs.versions.config.fullTestRun.map(String::toBoolean))
+    buildConfigField("gradleVersion", gradle.gradleVersion)
+    buildConfigField("kotlinVersion", libs.versions.kotlin)
+    buildConfigField("kspVersion", libs.versions.ksp)
+    buildConfigField("localBuildM2Dir", buildM2)
   }
 }
 

--- a/gradle-plugin/src/gradleTest/java/com/squareup/anvil/plugin/AnvilExtensionTest.kt
+++ b/gradle-plugin/src/gradleTest/java/com/squareup/anvil/plugin/AnvilExtensionTest.kt
@@ -8,7 +8,6 @@ import com.rickbusarow.kase.gradle.HasGradleDependencyVersion
 import com.rickbusarow.kase.gradle.HasKotlinDependencyVersion
 import com.rickbusarow.kase.gradle.KotlinDependencyVersion
 import com.rickbusarow.kase.kase
-import com.rickbusarow.kase.times
 import com.squareup.anvil.plugin.testing.AnvilGradleTestEnvironment
 import com.squareup.anvil.plugin.testing.BaseGradleTest
 import org.junit.jupiter.api.DynamicNode
@@ -170,8 +169,14 @@ class AnvilExtensionTest : BaseGradleTest() {
         Boolean,
       ) -> Unit,
     ): Stream<out DynamicNode> = params.asContainers { versions ->
-      properties.times(listOf(versions), instanceFactory = ::PropertyKase)
-        .asTests { kase -> action(versions, kase.propertyName, kase.default) }
+      properties.map { (propertyName, default) ->
+        PropertyKase(
+          propertyName = propertyName,
+          default = default,
+          gradle = versions.gradle,
+          kotlin = versions.kotlin,
+        )
+      }.asTests { kase -> action(versions, kase.propertyName, kase.default) }
     }
   }
 }

--- a/gradle-plugin/src/gradleTest/java/com/squareup/anvil/plugin/IncrementalTest.kt
+++ b/gradle-plugin/src/gradleTest/java/com/squareup/anvil/plugin/IncrementalTest.kt
@@ -142,11 +142,11 @@ class IncrementalTest : BaseGradleTest() {
         )
       }
 
-      val notRealKotlinFile = rootProject.path.anvilMainGenerated
+      val notRealKotlinFile = rootAnvilMainGenerated
         .resolve("com/squareup/test/NotRealKotlin.kt")
         .createSafely("This won't compile")
 
-      rootProject.path.anvilMainCaches.shouldNotExist()
+      rootProject.path.buildAnvilMainCaches.shouldNotExist()
 
       shouldSucceed("jar")
 
@@ -157,7 +157,7 @@ class IncrementalTest : BaseGradleTest() {
 
       notRealKotlinFile.shouldNotExist()
 
-      rootProject.path.anvilMainGenerated.injectClassFactory.shouldExist()
+      rootAnvilMainGenerated.injectClassFactory.shouldExist()
     }
 
   @TestFactory
@@ -834,8 +834,7 @@ class IncrementalTest : BaseGradleTest() {
 
       val lib by rootProject.subprojects
 
-      val assistedClassFactoryImpl = lib.path
-        .anvilMainGenerated
+      val assistedClassFactoryImpl = lib.generatedDir(false)
         .resolve("com/squareup/test/lib/AssistedClass_Factory_Impl.kt")
 
       assistedClassFactoryImpl shouldExistWithTextContaining """
@@ -913,7 +912,7 @@ class IncrementalTest : BaseGradleTest() {
 
         // This file wasn't generated in the `root-b` project,
         // but it was cached and restored even though it isn't part of the normal 'classes' output.
-        rootB.path.anvilMainGenerated.injectClassFactory.shouldExist()
+        rootB.generatedDir(false).injectClassFactory.shouldExist()
 
         rootB.classGraphResult().allClasses shouldContainExactly listOf(
           "com.squareup.test.InjectClass",

--- a/gradle-plugin/src/gradleTest/java/com/squareup/anvil/plugin/LifecycleTest.kt
+++ b/gradle-plugin/src/gradleTest/java/com/squareup/anvil/plugin/LifecycleTest.kt
@@ -1,17 +1,24 @@
 package com.squareup.anvil.plugin
 
+import com.rickbusarow.kase.gradle.GradleKotlinTestVersions
+import com.rickbusarow.kase.gradle.dsl.BuildFileSpec
 import com.rickbusarow.kase.gradle.dsl.buildFile
 import com.rickbusarow.kase.gradle.rootProject
 import com.rickbusarow.kase.stdlib.div
+import com.rickbusarow.kase.wrap
 import com.squareup.anvil.plugin.buildProperties.kotlinVersion
+import com.squareup.anvil.plugin.testing.AnvilGradleTestEnvironment
 import com.squareup.anvil.plugin.testing.BaseGradleTest
 import com.squareup.anvil.plugin.testing.anvil
+import com.squareup.anvil.plugin.testing.classGraphResult
 import io.kotest.matchers.file.shouldExist
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldInclude
 import io.kotest.matchers.string.shouldNotInclude
 import org.gradle.testkit.runner.TaskOutcome
+import org.junit.jupiter.api.DynamicNode
 import org.junit.jupiter.api.TestFactory
+import java.util.stream.Stream
 
 class LifecycleTest : BaseGradleTest() {
 
@@ -19,15 +26,15 @@ class LifecycleTest : BaseGradleTest() {
   fun `tasks are compatible with configuration caching when targeting kotlin-jvm`() =
     params
       .distinctBy { it.gradleVersion }
-      .asTests {
+      .withKspToggle { versions, useKsp ->
 
         rootProject {
           buildFile {
-            plugins {
-              kotlin("jvm", it.kotlinVersion)
-              id("com.squareup.anvil", anvilVersion)
-            }
+
+            pluginsBlock(useKsp)
+            anvilBlock(useKsp)
             dependencies {
+              api(libs.dagger2.annotations)
               compileOnly(libs.inject)
             }
           }
@@ -38,7 +45,7 @@ class LifecycleTest : BaseGradleTest() {
         }
 
         val calculatingMessage = when {
-          it.gradleVersion >= "8.5" -> "Calculating task graph as no cached configuration is available for tasks: compileKotlin"
+          versions.gradleVersion >= "8.5" -> "Calculating task graph as no cached configuration is available for tasks: compileKotlin"
           else -> "Calculating task graph as no configuration cache is available for tasks: compileKotlin"
         }
 
@@ -68,9 +75,22 @@ class LifecycleTest : BaseGradleTest() {
       }
 
   @TestFactory
-  fun `compileKotlin is up to date when no changes are made`() = testFactory {
+  fun `compileKotlin is up to date when no changes are made`() = params.withKspToggle { _, useKsp ->
 
     rootProject {
+
+      buildFile {
+
+        pluginsBlock(useKsp)
+
+        anvilBlock(useKsp)
+
+        dependencies {
+          api(libs.dagger2.annotations)
+          compileOnly(libs.inject)
+        }
+      }
+
       dir("src/main/java") {
         injectClass()
       }
@@ -83,176 +103,228 @@ class LifecycleTest : BaseGradleTest() {
   }
 
   @TestFactory
-  fun `compileKotlin is FROM-CACHE after the project build directory is deleted`() = testFactory {
-    rootProject {
-      dir("src/main/java") {
-        injectClass()
-      }
-      gradlePropertiesFile(
-        """
-        org.gradle.caching=true
-        com.squareup.anvil.trackSourceFiles=true
-        """.trimIndent(),
-      )
-    }
+  fun `compileKotlin is FROM-CACHE after the project build directory is deleted`() =
+    params.withKspToggle { _, useKsp ->
 
-    shouldSucceed("compileJava", withHermeticTestKit = true)
+      rootProject {
 
-    workingDir.resolve("build").deleteRecursively()
-
-    // `compileJava` depends upon `compileKotlin`.
-    // Compile Java just to ensure that everything that needed to be restored was restored.
-    shouldSucceed("compileJava", withHermeticTestKit = true) {
-      task(":compileKotlin")?.outcome shouldBe TaskOutcome.FROM_CACHE
-
-      rootAnvilMainGenerated.injectClassFactory.shouldExist()
-    }
-  }
-
-  @TestFactory
-  fun `build cache works across different project directories`() = testFactory(
-    // This test exercises enough of the compiler that it runs into version compatibility issues.
-    params.filter { it.kotlinVersion == kotlinVersion },
-  ) { versions ->
-
-    // The testKit directory has the daemon and build cache.
-    // We'll use the same testKit directory for both projects
-    // to simulate having a shared remote build cache.
-    val runner = gradleRunner
-      .withTestKitDir(workingDir / "testKit")
-      .withArguments("compileJava", "--stacktrace")
-
-    val rootA = workingDir / "root-a"
-    // The second project has an extra parent directory
-    // so that `root-a` and `root-b` have different relative paths to the build cache.
-    val rootB = workingDir / "dir/root-b"
-
-    for (root in listOf(rootA, rootB)) {
-      rootProject(path = root) {
         buildFile {
-          plugins {
-            kotlin("jvm", version = versions.kotlinVersion, apply = false)
-            id("com.squareup.anvil", version = anvilVersion, apply = false)
+          pluginsBlock(useKsp)
+
+          anvilBlock(useKsp)
+
+          dependencies {
+            compileOnly(libs.inject)
+            api(libs.dagger2.annotations)
           }
         }
-        settingsFile(
-          """
-          ${rootProject.settingsFileAsFile.readText()}
 
-          include("lib-1")
-          include("lib-2")
-          include("app")
-          """.trimIndent(),
-        )
-
+        dir("src/main/java") {
+          injectClass()
+        }
         gradlePropertiesFile(
           """
           org.gradle.caching=true
+          com.squareup.anvil.trackSourceFiles=true
           """.trimIndent(),
         )
+      }
 
-        project("lib-1") {
+      shouldSucceed("compileJava", withHermeticTestKit = true)
+
+      rootProject.generatedDir(useKsp).injectClassFactory.shouldExist()
+
+      workingDir.resolve("build").deleteRecursivelyOrFail()
+
+      // `compileJava` depends upon `compileKotlin`.
+      // Compile Java just to ensure that everything that needed to be restored was restored.
+      shouldSucceed("jar", withHermeticTestKit = true) {
+        task(":compileKotlin")?.outcome shouldBe TaskOutcome.FROM_CACHE
+      }
+
+      rootProject.classGraphResult() shouldContainClass "com.squareup.test.InjectClass_Factory"
+
+      rootProject.generatedDir(useKsp).injectClassFactory.shouldExist()
+    }
+
+  @TestFactory
+  fun `build cache works across different project directories`() = params
+    // This test exercises enough of the compiler that it runs into version compatibility issues.
+    .filter { it.kotlinVersion == kotlinVersion }
+    .withKspToggle { _, useKsp ->
+
+      // The testKit directory has the daemon and build cache.
+      // We'll use the same testKit directory for both projects
+      // to simulate having a shared remote build cache.
+      val runner = gradleRunner
+        .withTestKitDir(workingDir / "testKit")
+        .withArguments("compileJava", "--stacktrace")
+
+      val rootA = workingDir / "root-a"
+      // The second project has an extra parent directory
+      // so that `root-a` and `root-b` have different relative paths to the build cache.
+      val rootB = workingDir / "dir/root-b"
+
+      for (root in listOf(rootA, rootB)) {
+        rootProject(path = root) {
           buildFile {
             plugins {
-              kotlin("jvm")
-              id("com.squareup.anvil")
+              kotlin("jvm", apply = false)
+              id("com.squareup.anvil", apply = false)
+              id("com.google.devtools.ksp", apply = false)
             }
-            anvil {
-              generateDaggerFactories.set(true)
+          }
+          settingsFile(
+            """
+            ${rootProject.settingsFileAsFile.readText()}
+  
+            include("lib-1")
+            include("lib-2")
+            include("app")
+            """.trimIndent(),
+          )
+
+          gradlePropertiesFile(
+            """
+          org.gradle.caching=true
+            """.trimIndent(),
+          )
+
+          project("lib-1") {
+            buildFile {
+              pluginsBlock(useKsp)
+
+              anvilBlock(useKsp)
+
+              dependencies {
+                api(libs.dagger2.annotations)
+                compileOnly(libs.inject)
+              }
             }
-            dependencies {
-              api(libs.dagger2.annotations)
-              compileOnly(libs.inject)
+
+            dir("src/main/java") {
+              injectClass("com.squareup.lib1")
             }
           }
 
-          dir("src/main/java") {
-            injectClass("com.squareup.lib1")
-          }
-        }
+          project("lib-2") {
+            buildFile {
+              pluginsBlock(useKsp)
+              anvilBlock(useKsp)
+              dependencies {
+                api(libs.dagger2.annotations)
+                api(project(":lib-1"))
+                compileOnly(libs.inject)
+              }
+            }
 
-        project("lib-2") {
-          buildFile {
-            plugins {
-              kotlin("jvm")
-              id("com.squareup.anvil")
-            }
-            anvil {
-              generateDaggerFactories.set(true)
-            }
-            dependencies {
-              api(libs.dagger2.annotations)
-              api(project(":lib-1"))
-              compileOnly(libs.inject)
-            }
-          }
-
-          dir("src/main/java") {
-            kotlinFile(
-              "com/squareup/lib2/OtherClass.kt",
-              """
-              package com.squareup.lib2
-              
-              import com.squareup.lib1.InjectClass
-              import javax.inject.Inject
-              
-              class OtherClass @Inject constructor(
-                private val injectClass: InjectClass
+            dir("src/main/java") {
+              kotlinFile(
+                "com/squareup/lib2/OtherClass.kt",
+                """
+                package com.squareup.lib2
+                
+                import com.squareup.lib1.InjectClass
+                import javax.inject.Inject
+                
+                class OtherClass @Inject constructor(
+                  private val injectClass: InjectClass
+                )
+                """.trimIndent(),
               )
-              """.trimIndent(),
-            )
-          }
-        }
-
-        project("app") {
-          buildFile {
-            plugins {
-              kotlin("jvm")
-              kotlin("kapt")
-              id("com.squareup.anvil")
-            }
-            dependencies {
-              api(project(":lib-1"))
-              api(project(":lib-2"))
-              api(libs.dagger2.annotations)
-              kapt(libs.dagger2.compiler)
             }
           }
 
-          dir("src/main/java") {
-            kotlinFile(
-              "com/squareup/lib2/InjectClass.kt",
-              """
-              package com.squareup.app
-              
-              import com.squareup.anvil.annotations.MergeComponent
-              import com.squareup.lib1.InjectClass
-              import javax.inject.Inject
-              
-              @MergeComponent(Unit::class) 
-              interface AppComponent
-              """.trimIndent(),
-            )
+          project("app") {
+            buildFile {
+              pluginsBlock(useKsp = useKsp, addKapt = !useKsp)
+
+              dependencies {
+                api(project(":lib-1"))
+                api(project(":lib-2"))
+                api(libs.dagger2.annotations)
+                if (useKsp) {
+                  ksp(libs.dagger2.compiler)
+                } else {
+                  kapt(libs.dagger2.compiler)
+                }
+              }
+            }
+
+            dir("src/main/java") {
+              kotlinFile(
+                "com/squareup/lib2/InjectClass.kt",
+                """
+                package com.squareup.app
+                
+                import com.squareup.anvil.annotations.MergeComponent
+                import com.squareup.lib1.InjectClass
+                import javax.inject.Inject
+                
+                @MergeComponent(Unit::class) 
+                interface AppComponent
+                """.trimIndent(),
+              )
+            }
           }
         }
       }
+
+      // Delete the normal auto-generated "root" Gradle files
+      // since we created other projects to work with.
+      rootProject.buildFileAsFile.delete()
+      rootProject.settingsFileAsFile.delete()
+
+      runner.withProjectDir(rootA).build().apply {
+        task(":lib-1:compileKotlin")?.outcome shouldBe TaskOutcome.SUCCESS
+        task(":lib-2:compileKotlin")?.outcome shouldBe TaskOutcome.SUCCESS
+        task(":app:compileKotlin")?.outcome shouldBe TaskOutcome.SUCCESS
+      }
+
+      runner.withProjectDir(rootB).build().apply {
+        task(":lib-1:compileKotlin")?.outcome shouldBe TaskOutcome.FROM_CACHE
+        task(":lib-2:compileKotlin")?.outcome shouldBe TaskOutcome.FROM_CACHE
+        task(":app:compileKotlin")?.outcome shouldBe TaskOutcome.FROM_CACHE
+      }
     }
 
-    // Delete the normal auto-generated "root" Gradle files
-    // since we created other projects to work with.
-    rootProject.buildFileAsFile.delete()
-    rootProject.settingsFileAsFile.delete()
+  private fun BuildFileSpec.anvilBlock(useKsp: Boolean) {
+    anvil {
+      generateDaggerFactories.set(true)
 
-    runner.withProjectDir(rootA).build().apply {
-      task(":lib-1:compileKotlin")?.outcome shouldBe TaskOutcome.SUCCESS
-      task(":lib-2:compileKotlin")?.outcome shouldBe TaskOutcome.SUCCESS
-      task(":app:compileKotlin")?.outcome shouldBe TaskOutcome.SUCCESS
+      if (useKsp) {
+        useKsp(
+          contributesAndFactoryGeneration = true,
+          componentMerging = true,
+        )
+      }
     }
+  }
 
-    runner.withProjectDir(rootB).build().apply {
-      task(":lib-1:compileKotlin")?.outcome shouldBe TaskOutcome.FROM_CACHE
-      task(":lib-2:compileKotlin")?.outcome shouldBe TaskOutcome.FROM_CACHE
-      task(":app:compileKotlin")?.outcome shouldBe TaskOutcome.FROM_CACHE
+  private fun BuildFileSpec.pluginsBlock(useKsp: Boolean, addKapt: Boolean = false) {
+    plugins {
+      kotlin("jvm")
+      id("com.squareup.anvil")
+      if (useKsp) {
+        id("com.google.devtools.ksp")
+      }
+      if (addKapt) {
+        kotlin("kapt")
+      }
     }
+  }
+
+  private inline fun <K : GradleKotlinTestVersions> List<K>.withKspToggle(
+    crossinline testAction: suspend AnvilGradleTestEnvironment.(
+      versions: K,
+      useKsp: Boolean,
+    ) -> Unit,
+  ): Stream<out DynamicNode> = asContainers { versions ->
+    listOf(true, false)
+      .asTests(
+        testEnvironmentFactory = AnvilGradleTestEnvironment.Factory().wrap(versions),
+        testName = { useKsp -> if (useKsp) "KSP" else "Embedded" },
+        testAction = { useKsp -> testAction(versions, useKsp) },
+      )
   }
 }

--- a/gradle-plugin/src/gradleTest/java/com/squareup/anvil/plugin/testing/AnvilExtensionSpec.kt
+++ b/gradle-plugin/src/gradleTest/java/com/squareup/anvil/plugin/testing/AnvilExtensionSpec.kt
@@ -3,6 +3,7 @@ package com.squareup.anvil.plugin.testing
 import com.rickbusarow.kase.gradle.dsl.BuildFileSpec
 import com.rickbusarow.kase.gradle.dsl.model.AbstractDslElementContainer
 import com.rickbusarow.kase.gradle.dsl.model.LambdaParameter
+import com.rickbusarow.kase.gradle.dsl.model.ValueParameter
 import com.rickbusarow.kase.gradle.dsl.model.gradlePropertyReference
 
 /** Adds an [AnvilExtensionSpec] to a [BuildFileSpec]. */
@@ -41,4 +42,13 @@ class AnvilExtensionSpec : AbstractDslElementContainer<AnvilExtensionSpec>() {
   val syncGeneratedSources by gradlePropertyReference()
   val addOptionalAnnotations by gradlePropertyReference()
   val trackSourceFiles by gradlePropertyReference()
+
+  fun useKsp(
+    contributesAndFactoryGeneration: Boolean = false,
+    componentMerging: Boolean = false,
+  ) = functionCall(
+    "useKsp",
+    ValueParameter("contributesAndFactoryGeneration", "$contributesAndFactoryGeneration"),
+    ValueParameter("componentMerging", "$componentMerging"),
+  )
 }

--- a/gradle-plugin/src/gradleTest/java/com/squareup/anvil/plugin/testing/AnvilFilePathExtensions.kt
+++ b/gradle-plugin/src/gradleTest/java/com/squareup/anvil/plugin/testing/AnvilFilePathExtensions.kt
@@ -5,12 +5,16 @@ import java.io.File
 interface AnvilFilePathExtensions {
 
   /** resolves `build/anvil/main/caches` */
-  val File.anvilMainCaches: File
+  val File.buildAnvilMainCaches: File
     get() = resolve("build/anvil/main/caches")
 
   /** resolves `build/anvil/main/generated` */
-  val File.anvilMainGenerated: File
+  val File.buildAnvilMainGenerated: File
     get() = resolve("build/anvil/main/generated")
+
+  /** resolves `build/generated/ksp/main/kotlin` */
+  val File.buildGeneratedKspMainKotlin: File
+    get() = resolve("build/generated/ksp/main/kotlin")
 
   /** resolves `anvil/hint/merge` */
   val File.anvilHintMerge: File
@@ -19,4 +23,13 @@ interface AnvilFilePathExtensions {
   /** resolves `com/squareup/test/InjectClass_Factory.kt` */
   val File.injectClassFactory: File
     get() = resolve("com/squareup/test/InjectClass_Factory.kt")
+
+  /** Resolves the main sourceset generated directory for Anvil or KSP. */
+  fun File.generatedDir(useKsp: Boolean): File {
+    return if (useKsp) {
+      buildGeneratedKspMainKotlin
+    } else {
+      buildAnvilMainGenerated
+    }
+  }
 }

--- a/gradle-plugin/src/gradleTest/java/com/squareup/anvil/plugin/testing/AnvilGradleTestEnvironment.kt
+++ b/gradle-plugin/src/gradleTest/java/com/squareup/anvil/plugin/testing/AnvilGradleTestEnvironment.kt
@@ -34,14 +34,32 @@ class AnvilGradleTestEnvironment(
   LanguageInjection<File> by LanguageInjection(JavaFileFileInjection()),
   AnvilFilePathExtensions {
 
-  /** `workingDir.resolve("build/anvil/main/generated")` */
+  /** `rootProject.path.resolve("build/anvil/main/generated")` */
   val GradleTestEnvironment.rootAnvilMainGenerated: File
-    get() = workingDir.anvilMainGenerated
+    get() = rootProject.generatedDir(useKsp = false)
+
+  /** `rootProject.path.resolve("build/generated/ksp/main/kotlin")` */
+  val GradleTestEnvironment.rootGeneratedKspMainKotlin: File
+    get() = rootProject.generatedDir(useKsp = true)
 
   val GradleProjectBuilder.buildFileAsFile: File
     get() = path.resolve(dslLanguage.buildFileName)
   val GradleProjectBuilder.settingsFileAsFile: File
     get() = path.resolve(dslLanguage.settingsFileName)
+
+  /** Resolves the main sourceset generated directory for Anvil or KSP. */
+  fun GradleTestEnvironment.rootGeneratedDir(useKsp: Boolean): File {
+    return rootProject.generatedDir(useKsp)
+  }
+
+  /** Resolves the main sourceset generated directory for Anvil or KSP. */
+  fun GradleProjectBuilder.generatedDir(useKsp: Boolean): File {
+    return if (useKsp) {
+      path.buildGeneratedKspMainKotlin
+    } else {
+      path.buildAnvilMainGenerated
+    }
+  }
 
   /**
    * ```
@@ -97,6 +115,7 @@ class AnvilGradleTestEnvironment(
             kotlin("jvm", version = versions.kotlinVersion, apply = false)
             kotlin("kapt", version = versions.kotlinVersion, apply = false)
             id("com.squareup.anvil", version = anvilVersion, apply = false)
+            id("com.google.devtools.ksp", version = versions.kspVersion.value, apply = false)
           }
         }
         dependencyResolutionManagement {

--- a/gradle-plugin/src/gradleTest/java/com/squareup/anvil/plugin/testing/AnvilVersionMatrix.kt
+++ b/gradle-plugin/src/gradleTest/java/com/squareup/anvil/plugin/testing/AnvilVersionMatrix.kt
@@ -10,6 +10,7 @@ import com.rickbusarow.kase.gradle.KspDependencyVersion
 import com.squareup.anvil.plugin.buildProperties.daggerVersion
 import com.squareup.anvil.plugin.buildProperties.gradleVersion
 import com.squareup.anvil.plugin.buildProperties.kotlinVersion
+import com.squareup.anvil.plugin.buildProperties.kspVersion as buildPropertyKspVersion
 
 // TODO (rbusarow) move this to build-logic and sync it with the version catalog and `ci.yml`.
 class AnvilVersionMatrix(
@@ -34,12 +35,12 @@ class AnvilVersionMatrix(
 /**
  * Returns the latest KSP version that's compatible with the receiver Kotlin version
  */
-val HasKotlinDependencyVersion.kspDependencyVersion: KspDependencyVersion
+val HasKotlinDependencyVersion.kspVersion: KspDependencyVersion
   get() {
     val kspPart = when (kotlinVersion) {
       in ("1.9.0"..<"1.9.10") -> "1.0.11"
       in ("1.9.10"..<"1.9.20") -> "1.0.13"
-      else -> "1.0.17"
+      else -> buildPropertyKspVersion.substringAfterLast("-")
     }
     return KspDependencyVersion("$kotlinVersion-$kspPart")
   }


### PR DESCRIPTION
The new code manages to be configuration-cache-safe without needing the Project parameter.  I added cases for KSP generation to the Gradle tests in `LifecycleTest`.