### PR TITLE
fix interface based @ContributesSubcomponent.Factory in KSP

### DIFF
--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesSubcomponentCodeGen.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesSubcomponentCodeGen.kt
@@ -205,13 +205,7 @@ internal object ContributesSubcomponentCodeGen : AnvilApplicabilityChecker {
       }
 
       val functions = factory.getAllFunctions()
-        .let { functions ->
-          if (factory.isInterface()) {
-            functions
-          } else {
-            functions.filter { it.isAbstract }
-          }
-        }
+        .filter { it.isAbstract }
         .toList()
 
       if (functions.size != 1 || functions[0].returnType?.resolve()

--- a/compiler/src/test/java/com/squareup/anvil/compiler/codegen/ContributesSubcomponentGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/codegen/ContributesSubcomponentGeneratorTest.kt
@@ -135,6 +135,33 @@ class ContributesSubcomponentGeneratorTest(
     }
   }
 
+  @Test fun `there is a hint for contributed subcomponents with an abstract class factory`() {
+    compile(
+      """
+      package com.squareup.test
+
+      import com.squareup.anvil.annotations.ContributesSubcomponent
+      import com.squareup.anvil.annotations.ContributesSubcomponent.Factory
+
+      @ContributesSubcomponent(Any::class, Unit::class)
+      interface SubcomponentInterface {
+        @Factory
+        abstract class SubcomponentFactory {
+          abstract fun create(): SubcomponentInterface
+        }
+      }
+      """,
+      mode = mode,
+    ) {
+      assertThat(subcomponentInterface.hintSubcomponent?.java).isEqualTo(subcomponentInterface)
+      assertThat(subcomponentInterface.hintSubcomponentParentScope).isEqualTo(Unit::class)
+
+      val generatedFile = walkGeneratedFiles(mode).single()
+
+      assertThat(generatedFile.name).isEqualTo("SubcomponentInterface.kt")
+    }
+  }
+
   @Test fun `contributed subcomponents must be a interfaces or abstract classes`() {
     compile(
       """

--- a/compiler/src/test/java/com/squareup/anvil/compiler/codegen/ContributesSubcomponentGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/codegen/ContributesSubcomponentGeneratorTest.kt
@@ -108,6 +108,33 @@ class ContributesSubcomponentGeneratorTest(
     }
   }
 
+  @Test fun `there is a hint for contributed subcomponents with an interace factory`() {
+    compile(
+      """
+      package com.squareup.test
+
+      import com.squareup.anvil.annotations.ContributesSubcomponent
+      import com.squareup.anvil.annotations.ContributesSubcomponent.Factory
+
+      @ContributesSubcomponent(Any::class, Unit::class)
+      interface SubcomponentInterface {
+        @Factory
+        interface SubcomponentFactory {
+          fun create(): SubcomponentInterface
+        }
+      }
+      """,
+      mode = mode,
+    ) {
+      assertThat(subcomponentInterface.hintSubcomponent?.java).isEqualTo(subcomponentInterface)
+      assertThat(subcomponentInterface.hintSubcomponentParentScope).isEqualTo(Unit::class)
+
+      val generatedFile = walkGeneratedFiles(mode).single()
+
+      assertThat(generatedFile.name).isEqualTo("SubcomponentInterface.kt")
+    }
+  }
+
   @Test fun `contributed subcomponents must be a interfaces or abstract classes`() {
     compile(
       """


### PR DESCRIPTION
Currently any `@ContributesSubcomponent.Factory` that is an interface fails the KSP codegen with "A factory must have exactly one abstract function returning the subcomponent ...".  The `getAllFunctions()` returns non abstract methods like equals/hashCode for interfaces, so we need to filter for interfaces as well. 