### PR TITLE
re-run analysis between an incremental sync and code generation

### DIFF
--- a/compiler/src/test/java/com/squareup/anvil/compiler/codegen/CodeGenerationExtensionTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/codegen/CodeGenerationExtensionTest.kt
@@ -1,20 +1,30 @@
 package com.squareup.anvil.compiler.codegen
 
 import com.google.common.truth.Truth.assertThat
+import com.rickbusarow.kase.HasTestEnvironmentFactory
+import com.squareup.anvil.annotations.ContributesTo
+import com.squareup.anvil.compiler.api.createGeneratedFile
 import com.squareup.anvil.compiler.compile
+import com.squareup.anvil.compiler.contributesToFqName
+import com.squareup.anvil.compiler.internal.reference.classAndInnerClassReferences
 import com.squareup.anvil.compiler.internal.testing.SimpleCodeGenerator
 import com.squareup.anvil.compiler.internal.testing.SimpleSourceFileTrackingBehavior.NO_SOURCE_TRACKING
 import com.squareup.anvil.compiler.internal.testing.SimpleSourceFileTrackingBehavior.TRACKING_WITH_NO_SOURCES
 import com.squareup.anvil.compiler.internal.testing.SimpleSourceFileTrackingBehavior.TRACK_SOURCE_FILES
 import com.squareup.anvil.compiler.internal.testing.simpleCodeGenerator
 import com.squareup.anvil.compiler.isError
+import com.squareup.anvil.compiler.testing.AnvilEmbeddedCompilationTestEnvironment
 import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.COMPILATION_ERROR
 import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.OK
-import org.junit.Test
+import io.kotest.matchers.file.shouldExist
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
 
-class CodeGenerationExtensionTest {
+class CodeGenerationExtensionTest : HasTestEnvironmentFactory<AnvilEmbeddedCompilationTestEnvironment.Factory> {
 
-  @Test fun `generated files with the same path and different content are an error`() {
+  override val testEnvironmentFactory = AnvilEmbeddedCompilationTestEnvironment.Factory
+
+  @Test fun `generated files with the same path and different content are an error`() = test {
     val codeGenerator = simpleCodeGenerator { clazz ->
       clazz
         .takeIf { it.isInterface() }
@@ -57,7 +67,7 @@ class CodeGenerationExtensionTest {
     }
   }
 
-  @Test fun `generated files with the same path and same content are allowed`() {
+  @Test fun `generated files with the same path and same content are allowed`() = test {
     val codeGenerator = simpleCodeGenerator { clazz ->
       clazz
         .takeIf { it.isInterface() }
@@ -85,7 +95,7 @@ class CodeGenerationExtensionTest {
     }
   }
 
-  @Test fun `a code generator that is not applicable is never called`() {
+  @Test fun `a code generator that is not applicable is never called`() = test {
 
     val codeGenerator = simpleCodeGenerator(applicable = { false }) { null }
 
@@ -106,7 +116,7 @@ class CodeGenerationExtensionTest {
     }
   }
 
-  @Test fun `compiling with no source tracking and trackSourceFiles enabled throws an exception`() {
+  @Test fun `compiling with no source tracking and trackSourceFiles enabled throws an exception`() = test {
 
     val codeGenerator = simpleCodeGenerator(NO_SOURCE_TRACKING) { clazz ->
 
@@ -124,7 +134,7 @@ class CodeGenerationExtensionTest {
     //language=kotlin
     val componentInterface = """
       package com.squareup.test
-
+  
       interface ComponentInterface
     """.trimIndent()
 
@@ -168,7 +178,7 @@ class CodeGenerationExtensionTest {
     }
   }
 
-  @Test fun `a code generator that tracks an empty source list can use trackSourceFiles`() {
+  @Test fun `a code generator that tracks an empty source list can use trackSourceFiles`() = test {
 
     val codeGenerator = simpleCodeGenerator(TRACKING_WITH_NO_SOURCES) { clazz ->
 
@@ -204,7 +214,7 @@ class CodeGenerationExtensionTest {
   }
 
   @Test
-  fun `a code generator that tracks a single source per generated file can use trackSourceFiles`() {
+  fun `a code generator that tracks a single source per generated file can use trackSourceFiles`() = test {
 
     val codeGenerator = simpleCodeGenerator(TRACK_SOURCE_FILES) { clazz ->
 
@@ -240,7 +250,7 @@ class CodeGenerationExtensionTest {
   }
 
   @Test
-  fun `a code generator that does not track sources can compile with trackSourceFiles disabled`() {
+  fun `a code generator that does not track sources can compile with trackSourceFiles disabled`() = test {
     val codeGenerator = simpleCodeGenerator(NO_SOURCE_TRACKING) { clazz ->
 
       if (clazz.shortName == "Abc") {
@@ -257,7 +267,7 @@ class CodeGenerationExtensionTest {
     //language=kotlin
     val componentInterface = """
       package com.squareup.test
-
+  
       interface ComponentInterface
     """.trimIndent()
 
@@ -271,6 +281,163 @@ class CodeGenerationExtensionTest {
 
       assertThat(exitCode).isEqualTo(OK)
       assertThat(classLoader.loadClass("com.squareup.test.Abc")).isNotNull()
+    }
+  }
+
+  @Test
+  fun `a generated file can reference another generated file in an incremental build`() = test {
+
+    var replaceArgResolved = false
+
+    val codeGenerator = simpleCodeGenerator { codeGenDir, module, files ->
+
+      files.classAndInnerClassReferences(module)
+        .mapNotNull { clazz ->
+
+          if (clazz.shortName == "DebugTypeAExtraModule") {
+            val contributesToAnnotation = clazz.annotations
+              .single { it.fqName == contributesToFqName }
+
+            val replacedName = contributesToAnnotation.replaces().single().fqName.asString()
+
+            replacedName shouldBe "extra.anvil.RealTypeAExtraModule"
+            replaceArgResolved = true
+          }
+
+          clazz.annotations
+            .singleOrNull { it.fqName.asString() == "anvil.Trigger" }
+            ?.let { annotation -> clazz to annotation }
+        }
+        .map { (clazz, annotation) ->
+          val packageFqName = clazz.packageFqName
+          val shortName = clazz.shortName
+
+          val superRef = clazz.directSuperTypeReferences()
+            .single()
+            .asClassReference()
+
+          val packagePrefix = "extra"
+
+          val supPackage = superRef.packageFqName
+          val supSimpleName = superRef.shortName
+
+          val scope = annotation.scope().fqName
+          val replaces = annotation.replaces(1)
+
+          val replacesString = if (replaces.isEmpty()) {
+            ""
+          } else {
+            ", replaces = [${replaces.joinToString { "${it.shortName}ExtraModule::class" }}]"
+          }
+
+          //language=kotlin
+          val content = """
+            package $packagePrefix.$packageFqName
+              
+            import $packageFqName.$shortName
+            import $scope
+            import $supPackage.$supSimpleName
+            import com.squareup.anvil.annotations.ContributesTo
+            import dagger.Binds
+            import dagger.Module
+              
+            @Module
+            @ContributesTo(${scope.shortName()}::class$replacesString)
+            interface ${shortName}ExtraModule {
+              @Binds
+              fun bind(b: $shortName): $supSimpleName
+            }
+          """.trimIndent()
+          createGeneratedFile(
+            codeGenDir = codeGenDir,
+            packageName = "$packagePrefix.${packageFqName.asString()}",
+            fileName = "${shortName}ExtraModule",
+            content = content,
+            sourceFile = clazz.containingFileAsJavaFile,
+          )
+        }.toList()
+    }
+
+    //language=kotlin
+    val trigger = """
+      package anvil
+
+      import kotlin.reflect.KClass
+
+      annotation class Trigger(
+        val scope: KClass<*>,
+        val replaces: Array<KClass<*>> = []
+      ) 
+
+      interface TypeA
+    """.trimIndent()
+
+    //language=kotlin
+    val realTypeA = """
+      package anvil
+
+      import javax.inject.Inject
+    
+      @Trigger(Any::class)
+      class RealTypeA @Inject constructor() : TypeA
+    """.trimIndent()
+
+    val result1 = compile(
+      """
+        package anvil
+  
+        import javax.inject.Inject
+  
+        @Trigger(Any::class, replaces = [RealTypeA::class]) 
+        class DebugTypeA @Inject constructor() : TypeA
+      """,
+      trigger,
+      realTypeA,
+      codeGenerators = listOf(codeGenerator),
+      trackSourceFiles = true,
+    ) {
+
+      exitCode shouldBe OK
+      replaceArgResolved shouldBe true
+    }
+
+    val realExtraModule = workingDir.resolve("build/anvil")
+      .resolve("extra/anvil/RealTypeAExtraModule.kt")
+
+    realExtraModule.shouldExist()
+    realExtraModule.delete() shouldBe true
+
+    replaceArgResolved = false
+
+    // Build a second time, with a change to the DebugTypeA file.
+    // This is as close as we can get to an incremental build using KCT:
+    // - The earlier build result is included, so the .class files are in the classpath.
+    // - The other source files are unchanged, and not added to this compilation.
+    // - The unchanged files still exist, so Anvil's incremental logic will see them and restore
+    //   their associated generated files accordingly.
+    compile(
+      """
+        package anvil
+  
+        import javax.inject.Inject
+  
+        @Trigger(Any::class, replaces = [RealTypeA::class]) 
+        class DebugTypeA @Inject constructor() : TypeA {
+          fun noOp() = Unit
+        }
+      """.trimIndent(),
+      previousCompilationResult = result1,
+      codeGenerators = listOf(codeGenerator),
+      trackSourceFiles = true,
+    ) {
+      exitCode shouldBe OK
+      replaceArgResolved shouldBe true
+
+      classLoader.loadClass("extra.anvil.DebugTypeAExtraModule")
+        .getAnnotation(ContributesTo::class.java)
+        .replaces
+        .single()
+        .qualifiedName shouldBe "extra.anvil.RealTypeAExtraModule"
     }
   }
 

--- a/compiler/src/test/java/com/squareup/anvil/compiler/testing/AnvilCompilationModeTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/testing/AnvilCompilationModeTest.kt
@@ -1,0 +1,24 @@
+package com.squareup.anvil.compiler.testing
+
+import com.rickbusarow.kase.DefaultTestEnvironment
+import com.rickbusarow.kase.NoParamTestEnvironmentFactory
+import com.rickbusarow.kase.files.HasWorkingDir
+import com.rickbusarow.kase.files.TestLocation
+import com.squareup.anvil.compiler.internal.testing.AnvilCompilationMode
+
+class AnvilEmbeddedCompilationTestEnvironment(
+  hasWorkingDir: HasWorkingDir,
+) : DefaultTestEnvironment(hasWorkingDir),
+  CompilationEnvironment {
+
+  override val mode: AnvilCompilationMode = AnvilCompilationMode.Embedded()
+
+  companion object Factory : NoParamTestEnvironmentFactory<AnvilEmbeddedCompilationTestEnvironment> {
+    override fun create(
+      names: List<String>,
+      location: TestLocation,
+    ): AnvilEmbeddedCompilationTestEnvironment = AnvilEmbeddedCompilationTestEnvironment(
+      hasWorkingDir = HasWorkingDir(names, location),
+    )
+  }
+}

--- a/compiler/src/test/java/com/squareup/anvil/compiler/testing/CompilationEnvironment.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/testing/CompilationEnvironment.kt
@@ -1,0 +1,58 @@
+package com.squareup.anvil.compiler.testing
+
+import com.rickbusarow.kase.DefaultTestEnvironment
+import com.rickbusarow.kase.HasTestEnvironmentFactory
+import com.rickbusarow.kase.KaseTestFactory
+import com.rickbusarow.kase.ParamTestEnvironmentFactory
+import com.rickbusarow.kase.TestEnvironment
+import com.rickbusarow.kase.files.HasWorkingDir
+import com.squareup.anvil.compiler.WARNINGS_AS_ERRORS
+import com.squareup.anvil.compiler.api.CodeGenerator
+import com.squareup.anvil.compiler.internal.testing.AnvilCompilationMode
+import com.squareup.anvil.compiler.internal.testing.compileAnvil
+import com.tschuchort.compiletesting.JvmCompilationResult
+import org.intellij.lang.annotations.Language
+import java.io.File
+
+interface CompilationTest<PARAM, ENV : TestEnvironment> : KaseTestFactory<PARAM, ENV, ParamTestEnvironmentFactory<PARAM, ENV>>
+
+interface DefaultTestEnvironmentTest : HasTestEnvironmentFactory<DefaultTestEnvironment.Factory> {
+  override val testEnvironmentFactory: DefaultTestEnvironment.Factory
+    get() = DefaultTestEnvironment.Factory()
+}
+
+interface CompilationEnvironment : HasWorkingDir {
+  val mode: AnvilCompilationMode
+    get() = AnvilCompilationMode.Embedded(emptyList())
+
+  fun compile(
+    @Language("kotlin") vararg sources: String,
+    previousCompilationResult: JvmCompilationResult? = null,
+    enableDaggerAnnotationProcessor: Boolean = false,
+    trackSourceFiles: Boolean = true,
+    generateDaggerFactories: Boolean = false,
+    disableComponentMerging: Boolean = false,
+    codeGenerators: List<CodeGenerator> = emptyList(),
+    allWarningsAsErrors: Boolean = WARNINGS_AS_ERRORS,
+    mode: AnvilCompilationMode = modeDefault(codeGenerators),
+    workingDir: File? = this@CompilationEnvironment.workingDir,
+    block: JvmCompilationResult.() -> Unit = { },
+  ): JvmCompilationResult = compileAnvil(
+    sources = sources,
+    allWarningsAsErrors = allWarningsAsErrors,
+    previousCompilationResult = previousCompilationResult,
+    enableDaggerAnnotationProcessor = enableDaggerAnnotationProcessor,
+    generateDaggerFactories = generateDaggerFactories,
+    disableComponentMerging = disableComponentMerging,
+    trackSourceFiles = trackSourceFiles,
+    mode = mode,
+    workingDir = workingDir,
+    block = block,
+  )
+}
+
+private fun CompilationEnvironment.modeDefault(
+  codeGenerators: List<CodeGenerator>,
+): AnvilCompilationMode = (mode as? AnvilCompilationMode.Embedded)
+  ?.copy(codeGenerators = codeGenerators)
+  ?: mode


### PR DESCRIPTION
If the incremental syncing logic at the start of compilation results in any file changes, return early without actually generating code (in that round). The compiler will do another incremental compilation, returning an updated set of source files and a ModuleDescriptor that reflects any deleted or added files since the previous round.