### PR TITLE
always use `-Werror` in internal KCT compilations

### DIFF
--- a/compiler/build.gradle.kts
+++ b/compiler/build.gradle.kts
@@ -10,7 +10,6 @@ buildConfig {
   packageName("com.squareup.anvil.compiler")
   useKotlinOutput { topLevelConstants = true }
 
-  buildConfigField("boolean", "WARNINGS_AS_ERRORS", libs.versions.config.warningsAsErrors.get())
   buildConfigField("boolean", "FULL_TEST_RUN", libs.versions.config.fullTestRun.get())
   buildConfigField("boolean", "INCLUDE_KSP_TESTS", libs.versions.config.includeKspTests.get())
 }

--- a/compiler/src/test/java/com/squareup/anvil/compiler/TestUtils.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/TestUtils.kt
@@ -41,7 +41,7 @@ internal fun compile(
   enableDaggerAnnotationProcessor: Boolean = false,
   trackSourceFiles: Boolean = true,
   codeGenerators: List<CodeGenerator> = emptyList(),
-  allWarningsAsErrors: Boolean = WARNINGS_AS_ERRORS,
+  allWarningsAsErrors: Boolean = true,
   mode: AnvilCompilationMode = AnvilCompilationMode.Embedded(codeGenerators),
   workingDir: File? = null,
   block: JvmCompilationResult.() -> Unit = { },

--- a/compiler/src/test/java/com/squareup/anvil/compiler/dagger/AnvilAnnotationDetectorCheckTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/dagger/AnvilAnnotationDetectorCheckTest.kt
@@ -1,7 +1,6 @@
 package com.squareup.anvil.compiler.dagger
 
 import com.google.common.truth.Truth.assertThat
-import com.squareup.anvil.compiler.WARNINGS_AS_ERRORS
 import com.squareup.anvil.compiler.internal.testing.compileAnvil
 import com.squareup.anvil.compiler.isError
 import com.tschuchort.compiletesting.JvmCompilationResult
@@ -146,7 +145,6 @@ class AnvilAnnotationDetectorCheckTest {
     sources = sources,
     generateDaggerFactories = true,
     generateDaggerFactoriesOnly = true,
-    allWarningsAsErrors = WARNINGS_AS_ERRORS,
     block = block,
   )
 }

--- a/compiler/src/test/java/com/squareup/anvil/compiler/dagger/AnvilMergeAnnotationDetectorCheckTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/dagger/AnvilMergeAnnotationDetectorCheckTest.kt
@@ -1,7 +1,6 @@
 package com.squareup.anvil.compiler.dagger
 
 import com.google.common.truth.Truth.assertThat
-import com.squareup.anvil.compiler.WARNINGS_AS_ERRORS
 import com.squareup.anvil.compiler.api.CodeGenerator
 import com.squareup.anvil.compiler.internal.testing.AnvilCompilationMode
 import com.squareup.anvil.compiler.internal.testing.compileAnvil
@@ -141,7 +140,6 @@ class AnvilMergeAnnotationDetectorCheckTest(
   ): JvmCompilationResult = compileAnvil(
     sources = sources,
     disableComponentMerging = true,
-    allWarningsAsErrors = WARNINGS_AS_ERRORS,
     block = block,
     mode = mode,
   )

--- a/compiler/src/test/java/com/squareup/anvil/compiler/dagger/AssistedFactoryGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/dagger/AssistedFactoryGeneratorTest.kt
@@ -1,7 +1,6 @@
 package com.squareup.anvil.compiler.dagger
 
 import com.google.common.truth.Truth.assertThat
-import com.squareup.anvil.compiler.WARNINGS_AS_ERRORS
 import com.squareup.anvil.compiler.assistedService
 import com.squareup.anvil.compiler.assistedServiceFactory
 import com.squareup.anvil.compiler.compilationErrorLine
@@ -2183,8 +2182,6 @@ public final class AssistedServiceFactory_Impl implements AssistedServiceFactory
   ): AnvilCompilation {
     return AnvilCompilation()
       .apply {
-        kotlinCompilation.allWarningsAsErrors = WARNINGS_AS_ERRORS
-
         if (previousCompilationResult != null) {
           addPreviousCompilationResult(previousCompilationResult)
         }

--- a/compiler/src/test/java/com/squareup/anvil/compiler/dagger/AssistedInjectGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/dagger/AssistedInjectGeneratorTest.kt
@@ -1,7 +1,6 @@
 package com.squareup.anvil.compiler.dagger
 
 import com.google.common.truth.Truth.assertThat
-import com.squareup.anvil.compiler.WARNINGS_AS_ERRORS
 import com.squareup.anvil.compiler.assistedService
 import com.squareup.anvil.compiler.compilationErrorLine
 import com.squareup.anvil.compiler.internal.testing.AnvilCompilationMode
@@ -679,7 +678,6 @@ public final class AssistedService_Factory {
     sources = sources,
     enableDaggerAnnotationProcessor = useDagger,
     generateDaggerFactories = !useDagger,
-    allWarningsAsErrors = WARNINGS_AS_ERRORS,
     mode = mode,
     block = block,
   )

--- a/compiler/src/test/java/com/squareup/anvil/compiler/dagger/BindsMethodValidatorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/dagger/BindsMethodValidatorTest.kt
@@ -1,7 +1,6 @@
 package com.squareup.anvil.compiler.dagger
 
 import com.google.common.truth.Truth.assertThat
-import com.squareup.anvil.compiler.WARNINGS_AS_ERRORS
 import com.squareup.anvil.compiler.internal.testing.AnvilCompilationMode
 import com.squareup.anvil.compiler.internal.testing.compileAnvil
 import com.squareup.anvil.compiler.isError
@@ -350,7 +349,6 @@ class BindsMethodValidatorTest(
     sources = sources,
     enableDaggerAnnotationProcessor = enableDagger,
     generateDaggerFactories = !enableDagger,
-    allWarningsAsErrors = WARNINGS_AS_ERRORS,
     previousCompilationResult = previousCompilationResult,
     mode = if (forceEmbeddedMode) AnvilCompilationMode.Embedded(emptyList()) else mode,
     block = block,

--- a/compiler/src/test/java/com/squareup/anvil/compiler/dagger/ComponentDetectorCheckTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/dagger/ComponentDetectorCheckTest.kt
@@ -1,7 +1,6 @@
 package com.squareup.anvil.compiler.dagger
 
 import com.google.common.truth.Truth.assertThat
-import com.squareup.anvil.compiler.WARNINGS_AS_ERRORS
 import com.squareup.anvil.compiler.api.CodeGenerator
 import com.squareup.anvil.compiler.internal.testing.AnvilCompilationMode
 import com.squareup.anvil.compiler.internal.testing.compileAnvil
@@ -118,7 +117,6 @@ class ComponentDetectorCheckTest(
   ): JvmCompilationResult = compileAnvil(
     sources = sources,
     generateDaggerFactories = true,
-    allWarningsAsErrors = WARNINGS_AS_ERRORS,
     block = block,
     mode = mode,
   )

--- a/compiler/src/test/java/com/squareup/anvil/compiler/dagger/MapKeyCreatorGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/dagger/MapKeyCreatorGeneratorTest.kt
@@ -1,7 +1,6 @@
 package com.squareup.anvil.compiler.dagger
 
 import com.google.common.truth.Truth.assertThat
-import com.squareup.anvil.compiler.WARNINGS_AS_ERRORS
 import com.squareup.anvil.compiler.internal.testing.AnvilCompilationMode
 import com.squareup.anvil.compiler.internal.testing.compileAnvil
 import com.squareup.anvil.compiler.internal.testing.isStatic
@@ -250,7 +249,6 @@ class MapKeyCreatorGeneratorTest(
     sources = sources,
     enableDaggerAnnotationProcessor = useDagger,
     generateDaggerFactories = !useDagger,
-    allWarningsAsErrors = WARNINGS_AS_ERRORS,
     mode = mode,
     block = block,
   )

--- a/compiler/src/test/java/com/squareup/anvil/compiler/dagger/MembersInjectorGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/dagger/MembersInjectorGeneratorTest.kt
@@ -1,7 +1,6 @@
 package com.squareup.anvil.compiler.dagger
 
 import com.google.common.truth.Truth.assertThat
-import com.squareup.anvil.compiler.WARNINGS_AS_ERRORS
 import com.squareup.anvil.compiler.injectClass
 import com.squareup.anvil.compiler.internal.capitalize
 import com.squareup.anvil.compiler.internal.testing.AnvilCompilationMode
@@ -2561,7 +2560,6 @@ public final class InjectClass_MembersInjector<T, U, V> implements MembersInject
     sources = sources,
     enableDaggerAnnotationProcessor = useDagger,
     generateDaggerFactories = !useDagger,
-    allWarningsAsErrors = WARNINGS_AS_ERRORS,
     previousCompilationResult = previousCompilationResult,
     mode = mode,
     block = block,

--- a/compiler/src/test/java/com/squareup/anvil/compiler/dagger/ProvidesMethodFactoryGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/dagger/ProvidesMethodFactoryGeneratorTest.kt
@@ -2,7 +2,6 @@ package com.squareup.anvil.compiler.dagger
 
 import com.google.common.truth.Truth.assertThat
 import com.squareup.anvil.annotations.MergeComponent
-import com.squareup.anvil.compiler.WARNINGS_AS_ERRORS
 import com.squareup.anvil.compiler.componentInterface
 import com.squareup.anvil.compiler.dagger.UppercasePackage.OuterClass.InnerClass
 import com.squareup.anvil.compiler.dagger.UppercasePackage.TestClassInUppercasePackage
@@ -3554,7 +3553,6 @@ public final class DaggerModule1_ProvideFunctionFactory implements Factory<Set<S
     sources = sources,
     enableDaggerAnnotationProcessor = enableDagger,
     generateDaggerFactories = !enableDagger,
-    allWarningsAsErrors = WARNINGS_AS_ERRORS,
     block = block,
     mode = mode,
     previousCompilationResult = previousCompilationResult,

--- a/compiler/src/test/java/com/squareup/anvil/compiler/testing/CompilationEnvironment.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/testing/CompilationEnvironment.kt
@@ -6,7 +6,6 @@ import com.rickbusarow.kase.KaseTestFactory
 import com.rickbusarow.kase.ParamTestEnvironmentFactory
 import com.rickbusarow.kase.TestEnvironment
 import com.rickbusarow.kase.files.HasWorkingDir
-import com.squareup.anvil.compiler.WARNINGS_AS_ERRORS
 import com.squareup.anvil.compiler.api.CodeGenerator
 import com.squareup.anvil.compiler.internal.testing.AnvilCompilationMode
 import com.squareup.anvil.compiler.internal.testing.compileAnvil
@@ -33,7 +32,7 @@ interface CompilationEnvironment : HasWorkingDir {
     generateDaggerFactories: Boolean = false,
     disableComponentMerging: Boolean = false,
     codeGenerators: List<CodeGenerator> = emptyList(),
-    allWarningsAsErrors: Boolean = WARNINGS_AS_ERRORS,
+    allWarningsAsErrors: Boolean = true,
     mode: AnvilCompilationMode = modeDefault(codeGenerators),
     workingDir: File? = this@CompilationEnvironment.workingDir,
     block: JvmCompilationResult.() -> Unit = { },


### PR DESCRIPTION
prompted by https://github.com/square/anvil/pull/934#discussion_r1544638830

Before this change, `allWarningsAsErrors` defaulted to `false` locally but `true` in CI.  We don't really gain anything by ignoring those warnings locally, since the relevant code is so isolated.

Note that the public `compileAnvil(...)` function in our test fixtures ([link](https://github.com/square/anvil/blob/a1def6af59ec11b9d92426947f8c833fb27e7bde/compiler-utils/src/testFixtures/java/com/squareup/anvil/compiler/internal/testing/AnvilCompilation.kt#L251)) defaults to `false`, but now our internal `compile(...)` from `TestUtils` now defaults to `true`.  That avoids a breaking change.