### PR TITLE
Remove comment

### DIFF
--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesSubcomponentCodeGen.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesSubcomponentCodeGen.kt
@@ -146,7 +146,6 @@ internal object ContributesSubcomponentCodeGen : AnvilApplicabilityChecker {
         )
       }
 
-      // TODO could just declared functions work?
       val functions = componentInterface.getAllFunctions()
         .filter {
           it.returnType?.resolve()?.resolveKSClassDeclaration() == this


### PR DESCRIPTION
After looking further, it's not possible to use just declared functions. Fortunately the pathological case (traversing lots of supertypes) is probably also an error case