### PR TITLE
Default to asserting that `exitCode == OK` in all internal tests

### DIFF
--- a/compiler/src/test/java/com/squareup/anvil/compiler/InterfaceMergerRepeatableTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/InterfaceMergerRepeatableTest.kt
@@ -5,6 +5,7 @@ import com.squareup.anvil.annotations.MergeComponent
 import com.squareup.anvil.annotations.MergeSubcomponent
 import com.squareup.anvil.annotations.compat.MergeInterfaces
 import com.squareup.anvil.compiler.internal.testing.extends
+import com.tschuchort.compiletesting.KotlinCompilation.ExitCode
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
@@ -44,8 +45,8 @@ class InterfaceMergerRepeatableTest(
       $annotation(Any::class)
       interface ComponentInterface
       """,
+      expectExitCode = ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
       assertThat(messages).contains(
         "com.squareup.test.ComponentInterface merges multiple times to the same scope: [Any]. " +
           "Merging multiple times to the same scope is forbidden and all scopes must be distinct.",
@@ -67,8 +68,8 @@ class InterfaceMergerRepeatableTest(
       @MergeSubcomponent(Unit::class)
       interface ComponentInterface
       """,
+      expectExitCode = ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
       assertThat(messages).contains(
         "It's only allowed to have one single type of @Merge* annotation, however multiple " +
           "instances of the same annotation are allowed. You mix " +

--- a/compiler/src/test/java/com/squareup/anvil/compiler/InterfaceMergerTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/InterfaceMergerTest.kt
@@ -6,6 +6,7 @@ import com.squareup.anvil.annotations.MergeSubcomponent
 import com.squareup.anvil.annotations.compat.MergeInterfaces
 import com.squareup.anvil.compiler.internal.testing.AnvilCompilation
 import com.squareup.anvil.compiler.internal.testing.extends
+import com.tschuchort.compiletesting.KotlinCompilation.ExitCode
 import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.OK
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -147,8 +148,8 @@ class InterfaceMergerTest(
       $annotation(Any::class)
       abstract class MergingClass
       """,
+      expectExitCode = ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
       // Position to the class.
       assertThat(messages).contains("Source0.kt:6:16")
     }
@@ -200,8 +201,8 @@ class InterfaceMergerTest(
       $annotation(Any::class)
       interface ComponentInterface
       """,
+      expectExitCode = ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
       // Position to the class. Unfortunately, a different error is reported that the class is
       // missing an @Module annotation.
       assertThat(messages).contains("Source0.kt:7:7")
@@ -229,8 +230,8 @@ class InterfaceMergerTest(
       $annotation(Any::class)
       interface ComponentInterface
       """,
+      expectExitCode = ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
       // Position to the class. Unfortunately, a different error is reported that the class is
       // missing an @Module annotation.
       assertThat(messages).contains("Source0.kt:14:11")
@@ -318,8 +319,8 @@ class InterfaceMergerTest(
       )
       interface ComponentInterface
       """,
+      expectExitCode = ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
       // Position to the class.
       assertThat(messages).contains("Source0.kt:18:11")
       assertThat(messages).contains(
@@ -355,8 +356,8 @@ class InterfaceMergerTest(
       )
       interface ComponentInterface : ContributingInterface, OtherInterface
       """,
+      expectExitCode = ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
       // Position to the class.
       assertThat(messages).contains(
         "ComponentInterface excludes types that it implements or extends. These types cannot " +
@@ -449,8 +450,8 @@ class InterfaceMergerTest(
         $annotation(Any::class)
         interface ComponentInterface
         """,
+        expectExitCode = ExitCode.COMPILATION_ERROR,
       ) {
-        assertThat(exitCode).isError()
         // Position to the class.
         assertThat(messages).contains("Source0.kt:7")
       }
@@ -721,8 +722,8 @@ class InterfaceMergerTest(
       $annotation(Int::class)
       interface SubcomponentInterface2
       """,
+      expectExitCode = ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
       assertThat(messages).contains(
         "com.squareup.test.SecondContributingInterface with scopes [kotlin.Int] wants to " +
           "replace com.squareup.test.ContributingInterface, but the replaced class isn't " +

--- a/compiler/src/test/java/com/squareup/anvil/compiler/MergeModulesTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/MergeModulesTest.kt
@@ -4,6 +4,7 @@ import com.google.common.truth.Truth.assertThat
 import com.squareup.anvil.annotations.compat.MergeModules
 import com.squareup.anvil.compiler.internal.testing.daggerModule
 import com.squareup.anvil.compiler.internal.testing.withoutAnvilModules
+import com.tschuchort.compiletesting.KotlinCompilation.ExitCode
 import org.junit.Test
 
 class MergeModulesTest {
@@ -84,8 +85,8 @@ class MergeModulesTest {
       @dagger.Module
       class DaggerModule1
       """,
+      expectExitCode = ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
       // Position to the class.
       assertThat(messages).contains("Source0.kt:7:7")
     }
@@ -153,8 +154,8 @@ class MergeModulesTest {
       @MergeModules(Any::class)
       class DaggerModule1
       """,
+      expectExitCode = ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
       // Position to the class.
       assertThat(messages).contains("Source0.kt:7:16")
     }
@@ -284,8 +285,8 @@ class MergeModulesTest {
       @MergeModules(Any::class)
       class DaggerModule1
       """,
+      expectExitCode = ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
       // Position to the class.
       assertThat(messages).contains("Source0.kt:17:16")
       assertThat(messages).contains(
@@ -320,8 +321,8 @@ class MergeModulesTest {
       @MergeModules(Any::class)
       class DaggerModule1
       """,
+      expectExitCode = ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
       // Position to the class.
       assertThat(messages).contains("Source0.kt:17:16")
       assertThat(messages).contains(
@@ -424,8 +425,8 @@ class MergeModulesTest {
       @MergeModules(Any::class)
       class DaggerModule1
       """,
+      expectExitCode = ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
       // Position to the class.
       assertThat(messages).contains("Source0.kt:17:11")
       assertThat(messages).contains(
@@ -460,8 +461,8 @@ class MergeModulesTest {
       @MergeModules(Any::class)
       class DaggerModule1
       """,
+      expectExitCode = ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
       // Position to the class.
       assertThat(messages).contains("Source0.kt:17:11")
       assertThat(messages).contains(
@@ -492,8 +493,8 @@ class MergeModulesTest {
       @MergeModules(Any::class)
       class DaggerModule1
       """,
+      expectExitCode = ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
       // Position to the class.
       assertThat(messages).contains("Source0.kt:13:16")
     }
@@ -521,8 +522,8 @@ class MergeModulesTest {
       @MergeModules(Any::class)
       class DaggerModule1
       """,
+      expectExitCode = ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
       // Position to the class.
       assertThat(messages).contains("Source0.kt:15:16")
       assertThat(messages).contains(
@@ -616,8 +617,8 @@ class MergeModulesTest {
       )
       class DaggerModule1
       """,
+      expectExitCode = ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
       // Position to the class.
       assertThat(messages).contains("Source0.kt:16:7")
       assertThat(messages).contains(
@@ -709,8 +710,8 @@ class MergeModulesTest {
       )
       interface ComponentInterface
       """,
+      expectExitCode = ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
       // Position to the class.
       assertThat(messages).contains("Source0.kt:17:11")
       assertThat(messages).contains(
@@ -742,8 +743,8 @@ class MergeModulesTest {
       )
       interface ComponentInterface
       """,
+      expectExitCode = ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
       // Position to the class.
       assertThat(messages).contains("Source0.kt:17:11")
       assertThat(messages).contains(
@@ -806,8 +807,8 @@ class MergeModulesTest {
         @MergeModules(Any::class)
         class DaggerModule1
         """,
+        expectExitCode = ExitCode.COMPILATION_ERROR,
       ) {
-        assertThat(exitCode).isError()
         // Position to the class.
         assertThat(messages).contains("Source0.kt:8:")
       }
@@ -907,8 +908,8 @@ class MergeModulesTest {
       )
       interface ComponentInterface
       """,
+      expectExitCode = ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
       assertThat(messages).contains("Source0.kt:19:11")
     }
   }

--- a/compiler/src/test/java/com/squareup/anvil/compiler/ModuleMergerRepeatableTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/ModuleMergerRepeatableTest.kt
@@ -7,6 +7,7 @@ import com.squareup.anvil.annotations.compat.MergeModules
 import com.squareup.anvil.compiler.internal.testing.anyDaggerComponent
 import com.squareup.anvil.compiler.internal.testing.daggerComponent
 import com.squareup.anvil.compiler.internal.testing.withoutAnvilModules
+import com.tschuchort.compiletesting.KotlinCompilation.ExitCode
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
@@ -46,8 +47,8 @@ class ModuleMergerRepeatableTest(
       $annotation(Any::class)
       interface ComponentInterface
       """,
+      expectExitCode = ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
       assertThat(messages).contains(
         "com.squareup.test.ComponentInterface merges multiple times to the same scope: [Any]. " +
           "Merging multiple times to the same scope is forbidden and all scopes must be distinct.",
@@ -69,8 +70,8 @@ class ModuleMergerRepeatableTest(
       @MergeSubcomponent(Unit::class)
       interface ComponentInterface
       """,
+      expectExitCode = ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
       assertThat(messages).contains(
         "It's only allowed to have one single type of @Merge* annotation, however multiple " +
           "instances of the same annotation are allowed. You mix " +

--- a/compiler/src/test/java/com/squareup/anvil/compiler/ModuleMergerTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/ModuleMergerTest.kt
@@ -10,6 +10,7 @@ import com.squareup.anvil.compiler.internal.testing.daggerComponent
 import com.squareup.anvil.compiler.internal.testing.daggerModule
 import com.squareup.anvil.compiler.internal.testing.daggerSubcomponent
 import com.squareup.anvil.compiler.internal.testing.withoutAnvilModules
+import com.tschuchort.compiletesting.KotlinCompilation.ExitCode
 import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.OK
 import dagger.Component
 import dagger.Subcomponent
@@ -132,8 +133,8 @@ class ModuleMergerTest(
       @${daggerComponentClass.java.canonicalName}
       interface ComponentInterface
       """,
+      expectExitCode = ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
       assertThat(messages).contains("Source0.kt:7:11")
     }
   }
@@ -222,8 +223,8 @@ class ModuleMergerTest(
       $annotation(Any::class)
       interface ComponentInterface
       """,
+      expectExitCode = ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
       assertThat(messages).contains("Source0.kt:7:16")
     }
   }
@@ -352,8 +353,8 @@ class ModuleMergerTest(
       $annotation(Any::class)
       interface ComponentInterface
       """,
+      expectExitCode = ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
       assertThat(messages).contains("Source0.kt:17:16")
       assertThat(messages).contains(
         "com.squareup.test.DaggerModule1 with scopes [kotlin.Any] wants to replace " +
@@ -387,8 +388,8 @@ class ModuleMergerTest(
       $annotation(Any::class)
       interface ComponentInterface
       """,
+      expectExitCode = ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
       assertThat(messages).contains("Source0.kt:17:16")
       assertThat(messages).contains(
         "com.squareup.test.DaggerModule1 with scopes [kotlin.Any] wants to replace " +
@@ -490,8 +491,8 @@ class ModuleMergerTest(
       $annotation(Any::class)
       interface ComponentInterface
       """,
+      expectExitCode = ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
       assertThat(messages).contains("Source0.kt:17:11")
       assertThat(messages).contains(
         "com.squareup.test.ContributingInterface with scopes [kotlin.Any] wants to replace " +
@@ -525,8 +526,8 @@ class ModuleMergerTest(
       $annotation(Any::class)
       interface ComponentInterface
       """,
+      expectExitCode = ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
       assertThat(messages).contains("Source0.kt:17:11")
       assertThat(messages).contains(
         "com.squareup.test.ContributingInterface with scopes [kotlin.Any] wants to replace " +
@@ -556,8 +557,8 @@ class ModuleMergerTest(
       $annotation(Any::class)
       interface ComponentInterface
       """,
+      expectExitCode = ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
       assertThat(messages).contains("Source0.kt:13:16")
     }
   }
@@ -584,8 +585,8 @@ class ModuleMergerTest(
       $annotation(Any::class)
       interface ComponentInterface
       """,
+      expectExitCode = ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
       assertThat(messages).contains("Source0.kt:15:16")
       assertThat(messages).contains(
         "com.squareup.test.DaggerModule2 with scopes [kotlin.Any] wants to replace " +
@@ -683,8 +684,8 @@ class ModuleMergerTest(
       )
       interface ComponentInterface
       """,
+      expectExitCode = ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
       assertThat(messages).contains("Source0.kt:20:11")
       assertThat(messages).contains(
         "com.squareup.test.ComponentInterface with scopes [kotlin.Any] wants to exclude " +
@@ -840,8 +841,8 @@ class ModuleMergerTest(
       )
       interface ComponentInterface
       """,
+      expectExitCode = ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
       assertThat(messages).contains("Source0.kt:17:11")
       assertThat(messages).contains(
         "com.squareup.test.ComponentInterface with scopes [kotlin.Any] wants to exclude " +
@@ -872,8 +873,8 @@ class ModuleMergerTest(
       )
       interface ComponentInterface
       """,
+      expectExitCode = ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
       assertThat(messages).contains("Source0.kt:17:11")
       assertThat(messages).contains(
         "com.squareup.test.ComponentInterface with scopes [kotlin.Any] wants to exclude " +
@@ -968,8 +969,8 @@ class ModuleMergerTest(
         $annotation(Any::class)
         interface ComponentInterface
         """,
+        expectExitCode = ExitCode.COMPILATION_ERROR,
       ) {
-        assertThat(exitCode).isError()
         assertThat(messages).contains("Source0.kt:8:")
       }
     }
@@ -1068,8 +1069,8 @@ class ModuleMergerTest(
       )
       interface ComponentInterface
       """,
+      expectExitCode = ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
       assertThat(messages).contains("Source0.kt:19:11")
     }
   }
@@ -1084,8 +1085,8 @@ class ModuleMergerTest(
       $annotation
       interface ComponentInterface
       """,
+      expectExitCode = ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
       assertThat(messages).contains(
         "Couldn't find scope for ${annotationClass.java.canonicalName}",
       )
@@ -1301,8 +1302,8 @@ class ModuleMergerTest(
       $annotation(Int::class)
       interface SubcomponentInterface2
       """,
+      expectExitCode = ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
       assertThat(messages).contains(
         "com.squareup.test.DaggerModule2 with scopes [kotlin.Int] wants to replace " +
           "com.squareup.test.DaggerModule1, but the replaced class isn't contributed to the " +

--- a/compiler/src/test/java/com/squareup/anvil/compiler/codegen/BindingModuleCodegenTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/codegen/BindingModuleCodegenTest.kt
@@ -13,7 +13,6 @@ import com.squareup.anvil.compiler.generatedBindingModule
 import com.squareup.anvil.compiler.internal.testing.AnyDaggerComponent
 import com.squareup.anvil.compiler.internal.testing.anyDaggerComponent
 import com.squareup.anvil.compiler.internal.testing.isAbstract
-import com.squareup.anvil.compiler.isError
 import com.squareup.anvil.compiler.isFullTestRun
 import com.squareup.anvil.compiler.mergedModules
 import com.squareup.anvil.compiler.parentInterface
@@ -21,6 +20,7 @@ import com.squareup.anvil.compiler.parentInterface1
 import com.squareup.anvil.compiler.parentInterface2
 import com.squareup.anvil.compiler.secondContributingInterface
 import com.squareup.anvil.compiler.subcomponentInterface
+import com.tschuchort.compiletesting.KotlinCompilation.ExitCode
 import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.OK
 import dagger.Binds
 import dagger.Provides
@@ -276,8 +276,8 @@ class BindingModuleCodegenTest(
       $annotation(Any::class)
       interface ComponentInterface
       """,
+      expectExitCode = ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
 
       assertThat(messages).contains("Source0.kt:6:11")
       assertThat(messages).contains(
@@ -308,8 +308,8 @@ class BindingModuleCodegenTest(
       $annotation(Any::class)
       interface ComponentInterface
       """,
+      expectExitCode = ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
 
       assertThat(messages).contains("Source0.kt:6:11")
       assertThat(messages).contains(

--- a/compiler/src/test/java/com/squareup/anvil/compiler/codegen/BindingModuleMultibindingMapTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/codegen/BindingModuleMultibindingMapTest.kt
@@ -13,10 +13,10 @@ import com.squareup.anvil.compiler.internal.testing.AnyDaggerComponent
 import com.squareup.anvil.compiler.internal.testing.anyDaggerComponent
 import com.squareup.anvil.compiler.internal.testing.getValue
 import com.squareup.anvil.compiler.internal.testing.isAbstract
-import com.squareup.anvil.compiler.isError
 import com.squareup.anvil.compiler.isFullTestRun
 import com.squareup.anvil.compiler.mergedModules
 import com.squareup.anvil.compiler.parentInterface
+import com.tschuchort.compiletesting.KotlinCompilation
 import dagger.Binds
 import dagger.Provides
 import dagger.multibindings.IntoMap
@@ -270,8 +270,8 @@ class BindingModuleMultibindingMapTest(
       $annotation(Any::class)
       interface ComponentInterface
       """,
+      expectExitCode = KotlinCompilation.ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
       assertThat(messages).contains(
         "Classes annotated with @ContributesMultibinding may not use more than one @MapKey.",
       )

--- a/compiler/src/test/java/com/squareup/anvil/compiler/codegen/BindingModuleMultibindingSetTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/codegen/BindingModuleMultibindingSetTest.kt
@@ -12,7 +12,6 @@ import com.squareup.anvil.compiler.internal.testing.AnyDaggerComponent
 import com.squareup.anvil.compiler.internal.testing.anyDaggerComponent
 import com.squareup.anvil.compiler.internal.testing.daggerModule
 import com.squareup.anvil.compiler.internal.testing.isAbstract
-import com.squareup.anvil.compiler.isError
 import com.squareup.anvil.compiler.isFullTestRun
 import com.squareup.anvil.compiler.mergedModules
 import com.squareup.anvil.compiler.parentInterface
@@ -20,6 +19,8 @@ import com.squareup.anvil.compiler.parentInterface1
 import com.squareup.anvil.compiler.parentInterface2
 import com.squareup.anvil.compiler.secondContributingInterface
 import com.squareup.anvil.compiler.subcomponentInterface
+import com.tschuchort.compiletesting.KotlinCompilation
+import com.tschuchort.compiletesting.KotlinCompilation.ExitCode
 import dagger.Binds
 import dagger.Provides
 import dagger.multibindings.IntoSet
@@ -268,8 +269,8 @@ class BindingModuleMultibindingSetTest(
       $annotation(Any::class)
       interface ComponentInterface
       """,
+      expectExitCode = KotlinCompilation.ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
 
       assertThat(messages).contains("Source0.kt:6:11")
       assertThat(messages).contains(

--- a/compiler/src/test/java/com/squareup/anvil/compiler/codegen/BindingModulePriorityTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/codegen/BindingModulePriorityTest.kt
@@ -8,12 +8,12 @@ import com.squareup.anvil.annotations.compat.MergeModules
 import com.squareup.anvil.compiler.compile
 import com.squareup.anvil.compiler.componentInterface
 import com.squareup.anvil.compiler.contributingInterface
-import com.squareup.anvil.compiler.isError
 import com.squareup.anvil.compiler.isFullTestRun
 import com.squareup.anvil.compiler.mergedModules
 import com.squareup.anvil.compiler.parentInterface
 import com.squareup.anvil.compiler.secondContributingInterface
 import com.squareup.anvil.compiler.subcomponentInterface
+import com.tschuchort.compiletesting.KotlinCompilation.ExitCode
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
@@ -133,8 +133,8 @@ class BindingModuleRankTest(
       $annotation(Any::class)
       interface ComponentInterface
       """,
+      expectExitCode = ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
 
       assertThat(messages).contains(
         "There are multiple contributed bindings with the same bound type and rank. The bound " +
@@ -270,8 +270,8 @@ class BindingModuleRankTest(
       $annotation(Any::class)
       interface ComponentInterface
       """,
+      expectExitCode = ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
 
       assertThat(messages).contains(
         "There are multiple contributed bindings with the same bound type and rank. The bound " +
@@ -306,8 +306,8 @@ class BindingModuleRankTest(
       $annotation(Any::class)
       interface ComponentInterface
       """,
+      expectExitCode = ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
 
       assertThat(messages).contains(
         "There are multiple contributed bindings with the same bound type and rank. The bound " +

--- a/compiler/src/test/java/com/squareup/anvil/compiler/codegen/CodeGenerationExtensionTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/codegen/CodeGenerationExtensionTest.kt
@@ -12,7 +12,6 @@ import com.squareup.anvil.compiler.internal.testing.SimpleSourceFileTrackingBeha
 import com.squareup.anvil.compiler.internal.testing.SimpleSourceFileTrackingBehavior.TRACKING_WITH_NO_SOURCES
 import com.squareup.anvil.compiler.internal.testing.SimpleSourceFileTrackingBehavior.TRACK_SOURCE_FILES
 import com.squareup.anvil.compiler.internal.testing.simpleCodeGenerator
-import com.squareup.anvil.compiler.isError
 import com.squareup.anvil.compiler.testing.AnvilEmbeddedCompilationTestEnvironment
 import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.COMPILATION_ERROR
 import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.OK
@@ -49,8 +48,8 @@ class CodeGenerationExtensionTest : HasTestEnvironmentFactory<AnvilEmbeddedCompi
       interface ComponentInterface2
       """,
       codeGenerators = listOf(codeGenerator),
+      expectExitCode = COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
 
       val abcPath = outputDirectory
         .resolveSibling("build/anvil/generated/com/squareup/test/Abc.kt")
@@ -142,11 +141,10 @@ class CodeGenerationExtensionTest : HasTestEnvironmentFactory<AnvilEmbeddedCompi
       componentInterface,
       codeGenerators = listOf(codeGenerator),
       trackSourceFiles = true,
+      expectExitCode = COMPILATION_ERROR,
     ) {
       assertThat(codeGenerator.isApplicableCalls).isEqualTo(1)
       assertThat(codeGenerator.getGenerateCallsForInputFileContent(componentInterface)).isEqualTo(1)
-
-      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
 
       val abcPath = outputDirectory
         .resolveSibling("build/anvil/com/squareup/test/Abc.kt")

--- a/compiler/src/test/java/com/squareup/anvil/compiler/codegen/ContributesBindingGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/codegen/ContributesBindingGeneratorTest.kt
@@ -18,10 +18,10 @@ import com.squareup.anvil.compiler.generatedFileOrNull
 import com.squareup.anvil.compiler.injectClass
 import com.squareup.anvil.compiler.internal.testing.AnvilCompilationMode
 import com.squareup.anvil.compiler.internal.testing.moduleFactoryClass
-import com.squareup.anvil.compiler.isError
 import com.squareup.anvil.compiler.parentInterface
 import com.squareup.anvil.compiler.testing.AnvilCompilationModeTest
 import com.squareup.anvil.compiler.testing.AnvilCompilationModeTestEnvironment
+import com.tschuchort.compiletesting.KotlinCompilation.ExitCode
 import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.OK
 import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.DynamicNode
@@ -307,8 +307,8 @@ class ContributesBindingGeneratorTest : AnvilCompilationModeTest(
         $visibility class ContributingInterface : ParentInterface
         """,
         mode = mode,
+        expectExitCode = ExitCode.COMPILATION_ERROR,
       ) {
-        assertThat(exitCode).isError()
         // Position to the class.
         assertThat(messages).contains("Source0.kt:8")
         assertThat(messages).contains(
@@ -340,8 +340,8 @@ class ContributesBindingGeneratorTest : AnvilCompilationModeTest(
       @AnyQualifier2
       interface ContributingInterface : ParentInterface
       """,
+        expectExitCode = ExitCode.COMPILATION_ERROR,
       ) {
-        assertThat(exitCode).isError()
         assertThat(messages).contains(
           "Classes annotated with @ContributesBinding may not use more than one @Qualifier.",
         )
@@ -361,8 +361,8 @@ class ContributesBindingGeneratorTest : AnvilCompilationModeTest(
       @ContributesBinding(Any::class)
       interface ContributingInterface : ParentInterface, CharSequence
       """,
+        expectExitCode = ExitCode.COMPILATION_ERROR,
       ) {
-        assertThat(exitCode).isError()
         assertThat(messages).contains(
           "com.squareup.test.ContributingInterface contributes a binding, but does not specify " +
             "the bound type. This is only allowed with exactly one direct super type. If there " +
@@ -387,8 +387,8 @@ class ContributesBindingGeneratorTest : AnvilCompilationModeTest(
       @ContributesBinding(Any::class)
       interface ContributingInterface : Abc(), ParentInterface
       """,
+        expectExitCode = ExitCode.COMPILATION_ERROR,
       ) {
-        assertThat(exitCode).isError()
         assertThat(messages).contains(
           "com.squareup.test.ContributingInterface contributes a binding, but does not specify " +
             "the bound type. This is only allowed with exactly one direct super type. If there " +
@@ -409,8 +409,8 @@ class ContributesBindingGeneratorTest : AnvilCompilationModeTest(
       @ContributesBinding(Any::class)
       object ContributingInterface
       """,
+        expectExitCode = ExitCode.COMPILATION_ERROR,
       ) {
-        assertThat(exitCode).isError()
         assertThat(messages).contains(
           "com.squareup.test.ContributingInterface contributes a binding, but does not specify " +
             "the bound type. This is only allowed with exactly one direct super type. If there " +
@@ -450,8 +450,8 @@ class ContributesBindingGeneratorTest : AnvilCompilationModeTest(
       @ContributesBinding(Any::class, ParentInterface::class)
       interface ContributingInterface : CharSequence
       """,
+      expectExitCode = ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
       assertThat(messages).contains(
         "com.squareup.test.ContributingInterface contributes a binding for " +
           "com.squareup.test.ParentInterface, but doesn't extend this type.",
@@ -568,8 +568,8 @@ class ContributesBindingGeneratorTest : AnvilCompilationModeTest(
       @ContributesBinding(Unit::class, replaces = [Int::class])
       class ContributingInterface : ParentInterface
       """,
+        expectExitCode = ExitCode.COMPILATION_ERROR,
       ) {
-        assertThat(exitCode).isError()
         assertThat(messages).contains(
           "com.squareup.test.ContributingInterface contributes multiple times to the same scope " +
             "using the same bound type: [ParentInterface]. Contributing multiple times to the " +

--- a/compiler/src/test/java/com/squareup/anvil/compiler/codegen/ContributesMultibindingGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/codegen/ContributesMultibindingGeneratorTest.kt
@@ -14,7 +14,6 @@ import com.squareup.anvil.compiler.injectClass
 import com.squareup.anvil.compiler.internal.testing.AnvilCompilationMode
 import com.squareup.anvil.compiler.internal.testing.moduleFactoryClass
 import com.squareup.anvil.compiler.internal.testing.simpleCodeGenerator
-import com.squareup.anvil.compiler.isError
 import com.squareup.anvil.compiler.mergeComponentFqName
 import com.squareup.anvil.compiler.multibindingModuleScope
 import com.squareup.anvil.compiler.multibindingModuleScopes
@@ -22,6 +21,7 @@ import com.squareup.anvil.compiler.multibindingOriginClass
 import com.squareup.anvil.compiler.parentInterface
 import com.squareup.anvil.compiler.testing.AnvilCompilationModeTest
 import com.squareup.anvil.compiler.testing.AnvilCompilationModeTestEnvironment
+import com.tschuchort.compiletesting.KotlinCompilation.ExitCode
 import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.OK
 import dagger.multibindings.StringKey
 import io.kotest.matchers.shouldBe
@@ -198,8 +198,8 @@ class ContributesMultibindingGeneratorTest : AnvilCompilationModeTest(
         @ContributesMultibinding(Any::class, ParentInterface::class)
         $visibility class ContributingInterface : ParentInterface
         """,
+        expectExitCode = ExitCode.COMPILATION_ERROR,
       ) {
-        assertThat(exitCode).isError()
         // Position to the class.
         assertThat(messages).contains("Source0.kt:8")
         assertThat(messages).contains(
@@ -359,8 +359,8 @@ class ContributesMultibindingGeneratorTest : AnvilCompilationModeTest(
       interface ContributingInterface : ParentInterface
       """,
         mode = mode,
+        expectExitCode = ExitCode.COMPILATION_ERROR,
       ) {
-        assertThat(exitCode).isError()
         assertThat(messages).contains(
           "Classes annotated with @ContributesMultibinding may not use more than one @Qualifier.",
         )
@@ -381,8 +381,8 @@ class ContributesMultibindingGeneratorTest : AnvilCompilationModeTest(
       interface ContributingInterface : ParentInterface, CharSequence
       """,
         mode = mode,
+        expectExitCode = ExitCode.COMPILATION_ERROR,
       ) {
-        assertThat(exitCode).isError()
         assertThat(messages).contains(
           "com.squareup.test.ContributingInterface contributes a binding, but does not specify " +
             "the bound type. This is only allowed with exactly one direct super type. If there " +
@@ -408,8 +408,8 @@ class ContributesMultibindingGeneratorTest : AnvilCompilationModeTest(
       interface ContributingInterface : Abc(), ParentInterface
       """,
         mode = mode,
+        expectExitCode = ExitCode.COMPILATION_ERROR,
       ) {
-        assertThat(exitCode).isError()
         assertThat(messages).contains(
           "com.squareup.test.ContributingInterface contributes a binding, but does not specify " +
             "the bound type. This is only allowed with exactly one direct super type. If there " +
@@ -431,8 +431,8 @@ class ContributesMultibindingGeneratorTest : AnvilCompilationModeTest(
       object ContributingInterface
       """,
         mode = mode,
+        expectExitCode = ExitCode.COMPILATION_ERROR,
       ) {
-        assertThat(exitCode).isError()
         assertThat(messages).contains(
           "com.squareup.test.ContributingInterface contributes a binding, but does not specify " +
             "the bound type. This is only allowed with exactly one direct super type. If there " +
@@ -480,8 +480,8 @@ class ContributesMultibindingGeneratorTest : AnvilCompilationModeTest(
       interface ContributingInterface : CharSequence
       """,
       mode = mode,
+      expectExitCode = ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
       assertThat(messages).contains(
         "com.squareup.test.ContributingInterface contributes a binding for " +
           "com.squareup.test.ParentInterface, but doesn't extend this type.",
@@ -691,8 +691,8 @@ class ContributesMultibindingGeneratorTest : AnvilCompilationModeTest(
       class ContributingInterface : ParentInterface
       """,
         mode = mode,
+        expectExitCode = ExitCode.COMPILATION_ERROR,
       ) {
-        assertThat(exitCode).isError()
         assertThat(messages).contains(
           "com.squareup.test.ContributingInterface contributes multiple times to the same scope " +
             "using the same bound type: [ParentInterface]. Contributing multiple times to the " +

--- a/compiler/src/test/java/com/squareup/anvil/compiler/codegen/ContributesSubcomponentGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/codegen/ContributesSubcomponentGeneratorTest.kt
@@ -6,10 +6,10 @@ import com.squareup.anvil.compiler.compile
 import com.squareup.anvil.compiler.hintSubcomponent
 import com.squareup.anvil.compiler.hintSubcomponentParentScope
 import com.squareup.anvil.compiler.internal.testing.AnvilCompilationMode
-import com.squareup.anvil.compiler.isError
 import com.squareup.anvil.compiler.subcomponentInterface
 import com.squareup.anvil.compiler.walkGeneratedFiles
 import com.tschuchort.compiletesting.JvmCompilationResult
+import com.tschuchort.compiletesting.KotlinCompilation.ExitCode
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
@@ -173,8 +173,8 @@ class ContributesSubcomponentGeneratorTest(
       class SubcomponentInterface
       """,
       mode = mode,
+      expectExitCode = ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
       // Position to the class.
       assertThat(messages).contains("Source0.kt:6:")
       assertThat(messages).contains(
@@ -193,8 +193,8 @@ class ContributesSubcomponentGeneratorTest(
       object SubcomponentInterface
       """,
       mode = mode,
+      expectExitCode = ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
       // Position to the class.
       assertThat(messages).contains("Source0.kt:6:")
       assertThat(messages).contains(
@@ -222,8 +222,8 @@ class ContributesSubcomponentGeneratorTest(
         $visibility interface SubcomponentInterface
         """,
         mode = mode,
+        expectExitCode = ExitCode.COMPILATION_ERROR,
       ) {
-        assertThat(exitCode).isError()
         // Position to the class.
         assertThat(messages).contains("Source0.kt:6:")
         assertThat(messages).contains(
@@ -283,8 +283,8 @@ class ContributesSubcomponentGeneratorTest(
         }
       """,
       mode = mode,
+      expectExitCode = ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
       assertThat(messages).contains("Source0.kt:7:")
       assertThat(messages).contains(
         "Expected zero or one parent component interface within " +
@@ -312,8 +312,8 @@ class ContributesSubcomponentGeneratorTest(
         }
       """,
       mode = mode,
+      expectExitCode = ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
       assertThat(messages).contains("Source0.kt:9:")
       assertThat(messages).contains(
         "Expected zero or one function returning the subcomponent " +
@@ -345,8 +345,8 @@ class ContributesSubcomponentGeneratorTest(
         }
       """,
       mode = mode,
+      expectExitCode = ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
       assertThat(messages).contains("Source0.kt:8:")
       assertThat(messages).contains(
         "Expected zero or one factory within com.squareup.test.SubcomponentInterface.",
@@ -373,8 +373,8 @@ class ContributesSubcomponentGeneratorTest(
         }
       """,
       mode = mode,
+      expectExitCode = ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
       assertThat(messages).contains("Source0.kt:10:")
       assertThat(messages).contains("A factory must be an interface or an abstract class.")
     }
@@ -396,8 +396,8 @@ class ContributesSubcomponentGeneratorTest(
         }
       """,
       mode = mode,
+      expectExitCode = ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
       assertThat(messages).contains("Source0.kt:10:")
       assertThat(messages).contains("A factory must be an interface or an abstract class.")
     }
@@ -420,8 +420,8 @@ class ContributesSubcomponentGeneratorTest(
         }
       """,
       mode = mode,
+      expectExitCode = ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
       assertThat(messages).contains("Source0.kt:10:")
       assertThat(messages).contains(
         "A factory must have exactly one abstract function returning the subcomponent " +
@@ -450,8 +450,8 @@ class ContributesSubcomponentGeneratorTest(
         }
       """,
       mode = mode,
+      expectExitCode = ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
       assertThat(messages).contains("Source0.kt:10:")
       assertThat(messages).contains(
         "A factory must have exactly one abstract function returning the subcomponent " +
@@ -479,8 +479,8 @@ class ContributesSubcomponentGeneratorTest(
         }
       """,
       mode = mode,
+      expectExitCode = ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
       assertThat(messages).contains("Source0.kt:10:")
       assertThat(messages).contains(
         "A factory must have exactly one abstract function returning the subcomponent " +
@@ -507,8 +507,8 @@ class ContributesSubcomponentGeneratorTest(
         }
       """,
       mode = mode,
+      expectExitCode = ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
       assertThat(messages).contains("Source0.kt:9:")
       assertThat(messages).contains(
         "Within a class using @ContributesSubcomponent you must use " +
@@ -536,8 +536,8 @@ class ContributesSubcomponentGeneratorTest(
         }
       """,
       mode = mode,
+      expectExitCode = ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
       assertThat(messages).contains("Source0.kt:9:")
       assertThat(messages).contains(
         "Within a class using @ContributesSubcomponent you must use " +
@@ -598,8 +598,8 @@ class ContributesSubcomponentGeneratorTest(
       interface SubcomponentInterface2
       """,
       mode = mode,
+      expectExitCode = ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
       assertThat(messages).contains("Source0.kt:16:")
       assertThat(messages).contains(
         "com.squareup.test.SubcomponentInterface2 with scope kotlin.Any wants to replace " +

--- a/compiler/src/test/java/com/squareup/anvil/compiler/codegen/ContributesSubcomponentHandlerGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/codegen/ContributesSubcomponentHandlerGeneratorTest.kt
@@ -16,11 +16,11 @@ import com.squareup.anvil.compiler.internal.testing.extends
 import com.squareup.anvil.compiler.internal.testing.packageName
 import com.squareup.anvil.compiler.internal.testing.simpleCodeGenerator
 import com.squareup.anvil.compiler.internal.testing.use
-import com.squareup.anvil.compiler.isError
 import com.squareup.anvil.compiler.mergeComponentFqName
 import com.squareup.anvil.compiler.secondContributingInterface
 import com.squareup.anvil.compiler.subcomponentInterface
 import com.tschuchort.compiletesting.JvmCompilationResult
+import com.tschuchort.compiletesting.KotlinCompilation.ExitCode
 import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.OK
 import dagger.Component
 import org.junit.Test
@@ -869,8 +869,8 @@ class ContributesSubcomponentHandlerGeneratorTest {
       )
       interface ComponentInterface
       """,
+      expectExitCode = ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
       assertThat(messages).contains(
         "com.squareup.test.ComponentInterface with scopes [kotlin.Any] wants to exclude " +
           "com.squareup.test.SubcomponentInterface, but the excluded class isn't contributed " +
@@ -1929,8 +1929,6 @@ class ContributesSubcomponentHandlerGeneratorTest {
       """,
       codeGenerators = listOf(codeGenerator),
     ) {
-      assertThat(exitCode).isEqualTo(OK)
-
       val parentComponentInterface2 = subcomponentInterface2
         .anvilComponent(componentInterface)
         .parentComponentInterface

--- a/compiler/src/test/java/com/squareup/anvil/compiler/codegen/ContributesToCodeGenTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/codegen/ContributesToCodeGenTest.kt
@@ -12,13 +12,12 @@ import com.squareup.anvil.compiler.hintContributesScopes
 import com.squareup.anvil.compiler.innerInterface
 import com.squareup.anvil.compiler.innerModule
 import com.squareup.anvil.compiler.internal.testing.AnvilCompilationMode
-import com.squareup.anvil.compiler.isError
 import com.squareup.anvil.compiler.walkGeneratedFiles
+import com.tschuchort.compiletesting.KotlinCompilation.ExitCode
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 
-@Suppress("RemoveRedundantQualifierName")
 @RunWith(Parameterized::class)
 class ContributesToCodeGenTest(
   private val mode: AnvilCompilationMode,
@@ -188,8 +187,8 @@ class ContributesToCodeGenTest(
       abstract class DaggerModule1
       """,
       mode = mode,
+      expectExitCode = ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
       assertThat(messages).contains(
         "com.squareup.test.DaggerModule1 contributes multiple times to the same scope: " +
           "[Any, Unit]. Contributing multiple times to the same scope is forbidden and all " +
@@ -308,8 +307,8 @@ class ContributesToCodeGenTest(
       abstract class DaggerModule1
       """,
       mode = mode,
+      expectExitCode = ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
       // Position to the class.
       assertThat(messages).contains("Source0.kt:6")
       assertThat(messages).contains(
@@ -338,8 +337,8 @@ class ContributesToCodeGenTest(
         $visibility abstract class DaggerModule1
         """,
         mode = mode,
+        expectExitCode = ExitCode.COMPILATION_ERROR,
       ) {
-        assertThat(exitCode).isError()
         // Position to the class.
         assertThat(messages).contains("Source0.kt:7")
         assertThat(messages).contains(
@@ -368,8 +367,8 @@ class ContributesToCodeGenTest(
         $visibility interface ContributingInterface
         """,
         mode = mode,
+        expectExitCode = ExitCode.COMPILATION_ERROR,
       ) {
-        assertThat(exitCode).isError()
         // Position to the class.
         assertThat(messages).contains("Source0.kt:6")
         assertThat(messages).contains(

--- a/compiler/src/test/java/com/squareup/anvil/compiler/dagger/AssistedFactoryGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/dagger/AssistedFactoryGeneratorTest.kt
@@ -14,9 +14,9 @@ import com.squareup.anvil.compiler.internal.testing.implClass
 import com.squareup.anvil.compiler.internal.testing.isStatic
 import com.squareup.anvil.compiler.internal.testing.moduleFactoryClass
 import com.squareup.anvil.compiler.internal.testing.use
-import com.squareup.anvil.compiler.isError
 import com.squareup.anvil.compiler.useDaggerAndKspParams
 import com.tschuchort.compiletesting.JvmCompilationResult
+import com.tschuchort.compiletesting.KotlinCompilation.ExitCode
 import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.OK
 import org.intellij.lang.annotations.Language
 import org.junit.Test
@@ -1287,8 +1287,8 @@ public final class AssistedServiceFactory_Impl implements AssistedServiceFactory
         fun create(string: String): AssistedService
       }
       """,
+      expectExitCode = ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
       assertThat(messages).contains(
         "Invalid return type: com.squareup.test.AssistedService. An assisted factory's " +
           "abstract method must return a type with an @AssistedInject-annotated constructor.",
@@ -1313,8 +1313,8 @@ public final class AssistedServiceFactory_Impl implements AssistedServiceFactory
         fun create(string: String)
       }
       """,
+      expectExitCode = ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
       assertThat(messages).contains("Invalid return type:")
       assertThat(messages).contains(
         "An assisted factory's abstract method must return a type with an " +
@@ -1342,8 +1342,8 @@ public final class AssistedServiceFactory_Impl implements AssistedServiceFactory
         fun create(charSequence: CharSequence, other: String): AssistedService
       }
       """,
+      expectExitCode = ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
       assertThat(messages).contains(
         "The parameters in the factory method must match the @Assisted parameters " +
           "in com.squareup.test.AssistedService.",
@@ -1370,8 +1370,8 @@ public final class AssistedServiceFactory_Impl implements AssistedServiceFactory
         fun create(charSequence: CharSequence, other: String): AssistedService
       }
       """,
+      expectExitCode = ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
       assertThat(messages).contains(
         "The parameters in the factory method must match the @Assisted parameters " +
           "in com.squareup.test.AssistedService.",
@@ -1719,8 +1719,8 @@ public final class AssistedServiceFactory_Impl implements AssistedServiceFactory
         ): AssistedService
       }
       """,
+      expectExitCode = ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
       assertThat(messages).contains(
         "@AssistedFactory method has duplicate @Assisted types: " +
           "@Assisted(\"one\") com.squareup.test.Type",
@@ -1748,8 +1748,8 @@ public final class AssistedServiceFactory_Impl implements AssistedServiceFactory
         fun create2(string: String): AssistedService
       }
       """,
+      expectExitCode = ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
       assertThat(
         compilationErrorLine()
           .removeParametersAndSort()
@@ -1785,8 +1785,8 @@ public final class AssistedServiceFactory_Impl implements AssistedServiceFactory
         fun create(string: String): AssistedService
       }
       """,
+      expectExitCode = ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
       assertThat(
         compilationErrorLine()
           .removeParametersAndSort()
@@ -1819,8 +1819,8 @@ public final class AssistedServiceFactory_Impl implements AssistedServiceFactory
         fun create(string: String): AssistedService
       }
       """,
+      expectExitCode = ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
       assertThat(
         compilationErrorLine()
           .removeParametersAndSort()
@@ -1834,7 +1834,13 @@ public final class AssistedServiceFactory_Impl implements AssistedServiceFactory
   }
 
   @Test fun `default functions do not count against SAM requirement`() {
-    prepareCompilation()
+
+    AnvilCompilation()
+      .configureAnvil(
+        enableDaggerAnnotationProcessor = useDagger,
+        generateDaggerFactories = !useDagger,
+        mode = mode,
+      )
       .apply {
         // Necessary so Dagger-compiler recognizes default functions too
         kotlinCompilation.kotlincArguments += "-Xjvm-default=all"
@@ -1862,6 +1868,7 @@ public final class AssistedServiceFactory_Impl implements AssistedServiceFactory
           }
         }
         """,
+        expectExitCode = ExitCode.OK,
       ) {
         assertThat(exitCode).isEqualTo(OK)
       }
@@ -1884,8 +1891,8 @@ public final class AssistedServiceFactory_Impl implements AssistedServiceFactory
       @AssistedFactory
       interface AssistedServiceFactory
       """,
+      expectExitCode = ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
       assertThat(messages).contains(
         "The @AssistedFactory-annotated type is missing an abstract, non-default method " +
           "whose return type matches the assisted injection type.",
@@ -1912,8 +1919,8 @@ public final class AssistedServiceFactory_Impl implements AssistedServiceFactory
         fun create(string: String): AssistedService = throw NotImplementedError()
       }
       """,
+      expectExitCode = ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
       assertThat(messages).contains(
         "The @AssistedFactory-annotated type is missing an abstract, non-default method " +
           "whose return type matches the assisted injection type.",
@@ -2177,30 +2184,21 @@ public final class AssistedServiceFactory_Impl implements AssistedServiceFactory
     }
   }
 
-  private fun prepareCompilation(
-    previousCompilationResult: JvmCompilationResult? = null,
-  ): AnvilCompilation {
-    return AnvilCompilation()
-      .apply {
-        if (previousCompilationResult != null) {
-          addPreviousCompilationResult(previousCompilationResult)
-        }
-      }
-      .configureAnvil(
-        enableDaggerAnnotationProcessor = useDagger,
-        generateDaggerFactories = !useDagger,
-        mode = mode,
-      )
-  }
-
   private fun compile(
     @Language("kotlin") vararg sources: String,
     previousCompilationResult: JvmCompilationResult? = null,
+    expectExitCode: ExitCode = ExitCode.OK,
     block: JvmCompilationResult.() -> Unit = { },
   ): JvmCompilationResult {
-    return prepareCompilation(previousCompilationResult = previousCompilationResult)
-      .compile(*sources)
-      .apply(block)
+    return com.squareup.anvil.compiler.compile(
+      *sources,
+      previousCompilationResult = previousCompilationResult,
+      expectExitCode = expectExitCode,
+      enableDaggerAnnotationProcessor = useDagger,
+      generateDaggerFactories = !useDagger,
+      mode = mode,
+      block = block,
+    )
   }
 
   /**

--- a/compiler/src/test/java/com/squareup/anvil/compiler/dagger/AssistedInjectGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/dagger/AssistedInjectGeneratorTest.kt
@@ -4,13 +4,12 @@ import com.google.common.truth.Truth.assertThat
 import com.squareup.anvil.compiler.assistedService
 import com.squareup.anvil.compiler.compilationErrorLine
 import com.squareup.anvil.compiler.internal.testing.AnvilCompilationMode
-import com.squareup.anvil.compiler.internal.testing.compileAnvil
 import com.squareup.anvil.compiler.internal.testing.factoryClass
 import com.squareup.anvil.compiler.internal.testing.invokeGet
 import com.squareup.anvil.compiler.internal.testing.isStatic
-import com.squareup.anvil.compiler.isError
 import com.squareup.anvil.compiler.useDaggerAndKspParams
 import com.tschuchort.compiletesting.JvmCompilationResult
+import com.tschuchort.compiletesting.KotlinCompilation
 import org.intellij.lang.annotations.Language
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -247,8 +246,8 @@ public final class AssistedService_Factory {
         @Assisted val type2: SomeType
       )
       """,
+      expectExitCode = KotlinCompilation.ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
       assertThat(messages).contains(
         "@AssistedInject constructor has duplicate @Assisted type: " +
           "@Assisted com.squareup.test.SomeType",
@@ -271,8 +270,8 @@ public final class AssistedService_Factory {
         @Assisted(value = "one") val type2: SomeType
       )
       """,
+      expectExitCode = KotlinCompilation.ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
       assertThat(messages).contains(
         "@AssistedInject constructor has duplicate @Assisted type: " +
           "@Assisted(\"one\") com.squareup.test.SomeType",
@@ -629,8 +628,8 @@ public final class AssistedService_Factory {
         @AssistedInject constructor(@Assisted string: String)
       }
       """,
+      expectExitCode = KotlinCompilation.ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
       assertThat(
         compilationErrorLine()
           .removeParametersAndSort(),
@@ -658,8 +657,8 @@ public final class AssistedService_Factory {
         @Inject constructor(@Assisted string: String)
       }
       """,
+      expectExitCode = KotlinCompilation.ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
       assertThat(
         compilationErrorLine()
           .removeParametersAndSort(),
@@ -673,12 +672,16 @@ public final class AssistedService_Factory {
 
   private fun compile(
     @Language("kotlin") vararg sources: String,
+    expectExitCode: KotlinCompilation.ExitCode = KotlinCompilation.ExitCode.OK,
     block: JvmCompilationResult.() -> Unit = { },
-  ): JvmCompilationResult = compileAnvil(
-    sources = sources,
-    enableDaggerAnnotationProcessor = useDagger,
-    generateDaggerFactories = !useDagger,
-    mode = mode,
-    block = block,
-  )
+  ): JvmCompilationResult {
+    return com.squareup.anvil.compiler.compile(
+      *sources,
+      expectExitCode = expectExitCode,
+      enableDaggerAnnotationProcessor = useDagger,
+      generateDaggerFactories = !useDagger,
+      mode = mode,
+      block = block,
+    )
+  }
 }

--- a/compiler/src/test/java/com/squareup/anvil/compiler/dagger/BindsMethodValidatorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/dagger/BindsMethodValidatorTest.kt
@@ -3,10 +3,9 @@ package com.squareup.anvil.compiler.dagger
 import com.google.common.truth.Truth.assertThat
 import com.squareup.anvil.compiler.internal.testing.AnvilCompilationMode
 import com.squareup.anvil.compiler.internal.testing.compileAnvil
-import com.squareup.anvil.compiler.isError
 import com.squareup.anvil.compiler.useDaggerAndKspParams
 import com.tschuchort.compiletesting.JvmCompilationResult
-import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.COMPILATION_ERROR
+import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.OK
 import org.intellij.lang.annotations.Language
 import org.junit.Test
@@ -47,8 +46,8 @@ class BindsMethodValidatorTest(
         abstract fun bindsBar(impl: Foo): Bar
       }
       """,
+      expectExitCode = KotlinCompilation.ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
       assertThat(messages).contains(
         "@Binds methods' parameter type must be assignable to the return type",
       )
@@ -80,8 +79,8 @@ class BindsMethodValidatorTest(
         abstract fun bindsBar(impl: Foo): Bar
       }
       """,
+      expectExitCode = KotlinCompilation.ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
       assertThat(messages).contains(
         "@Binds methods' parameter type must be assignable to the return type",
       )
@@ -114,8 +113,8 @@ class BindsMethodValidatorTest(
         }
       }
       """,
+      expectExitCode = KotlinCompilation.ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
       assertThat(messages).contains("@Binds methods must be abstract")
     }
   }
@@ -139,8 +138,8 @@ class BindsMethodValidatorTest(
         abstract fun bindsBar(): Bar
       }
       """,
+      expectExitCode = KotlinCompilation.ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
       assertThat(messages).contains(
         "@Binds methods must have exactly one parameter, " +
           "whose type is assignable to the return type",
@@ -168,8 +167,8 @@ class BindsMethodValidatorTest(
         abstract fun bindsBar(impl1: Foo, impl2: Hammer): Bar
       }
       """,
+      expectExitCode = KotlinCompilation.ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
       assertThat(messages).contains(
         "@Binds methods must have exactly one parameter, " +
           "whose type is assignable to the return type",
@@ -196,8 +195,8 @@ class BindsMethodValidatorTest(
         abstract fun bindsBar(impl1: Foo)
       }
       """,
+      expectExitCode = KotlinCompilation.ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
       assertThat(messages).contains(
         "@Binds methods must return a value (not void)",
       )
@@ -223,8 +222,8 @@ class BindsMethodValidatorTest(
         abstract fun Foo.bindsBar(): Bar
       }
       """,
+      expectExitCode = KotlinCompilation.ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
       assertThat(messages).contains("@Binds methods can not be an extension function")
     }
   }
@@ -308,8 +307,8 @@ class BindsMethodValidatorTest(
         }
       }
       """,
+      expectExitCode = KotlinCompilation.ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isEqualTo(COMPILATION_ERROR)
       assertThat(messages).contains("@Binds methods can not be an extension function")
     }
   }
@@ -344,12 +343,14 @@ class BindsMethodValidatorTest(
     enableDagger: Boolean = useDagger,
     // Used to enable the dagger compiler even in KSP mode, which is necessary for some multi-round tests
     forceEmbeddedMode: Boolean = false,
+    expectExitCode: KotlinCompilation.ExitCode = KotlinCompilation.ExitCode.OK,
     block: JvmCompilationResult.() -> Unit = { },
   ): JvmCompilationResult = compileAnvil(
     sources = sources,
+    previousCompilationResult = previousCompilationResult,
+    expectExitCode = expectExitCode,
     enableDaggerAnnotationProcessor = enableDagger,
     generateDaggerFactories = !enableDagger,
-    previousCompilationResult = previousCompilationResult,
     mode = if (forceEmbeddedMode) AnvilCompilationMode.Embedded(emptyList()) else mode,
     block = block,
   )

--- a/compiler/src/test/java/com/squareup/anvil/compiler/dagger/ComponentDetectorCheckTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/dagger/ComponentDetectorCheckTest.kt
@@ -4,8 +4,9 @@ import com.google.common.truth.Truth.assertThat
 import com.squareup.anvil.compiler.api.CodeGenerator
 import com.squareup.anvil.compiler.internal.testing.AnvilCompilationMode
 import com.squareup.anvil.compiler.internal.testing.compileAnvil
-import com.squareup.anvil.compiler.isError
 import com.tschuchort.compiletesting.JvmCompilationResult
+import com.tschuchort.compiletesting.KotlinCompilation
+import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.COMPILATION_ERROR
 import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.OK
 import org.intellij.lang.annotations.Language
 import org.junit.Test
@@ -36,8 +37,8 @@ class ComponentDetectorCheckTest(
       interface ComponentInterface
       """,
       mode = mode,
+      expectExitCode = COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
       // Position to the class. )
       assertThat(messages).contains("Source0.kt:6")
       assertThat(messages).contains(
@@ -78,8 +79,8 @@ class ComponentDetectorCheckTest(
         }
         """,
       mode = mode,
+      expectExitCode = COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
       // Position to the class.
       assertThat(messages).contains("Source0.kt:7")
       assertThat(messages).contains(
@@ -112,11 +113,13 @@ class ComponentDetectorCheckTest(
   private fun compile(
     @Language("kotlin") vararg sources: String,
     codeGenerators: List<CodeGenerator> = emptyList(),
+    expectExitCode: KotlinCompilation.ExitCode = KotlinCompilation.ExitCode.OK,
     mode: AnvilCompilationMode = AnvilCompilationMode.Embedded(codeGenerators),
     block: JvmCompilationResult.() -> Unit = { },
   ): JvmCompilationResult = compileAnvil(
     sources = sources,
     generateDaggerFactories = true,
+    expectExitCode = expectExitCode,
     block = block,
     mode = mode,
   )

--- a/compiler/src/test/java/com/squareup/anvil/compiler/dagger/InjectConstructorFactoryGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/dagger/InjectConstructorFactoryGeneratorTest.kt
@@ -9,9 +9,9 @@ import com.squareup.anvil.compiler.internal.testing.createInstance
 import com.squareup.anvil.compiler.internal.testing.factoryClass
 import com.squareup.anvil.compiler.internal.testing.getPropertyValue
 import com.squareup.anvil.compiler.internal.testing.isStatic
-import com.squareup.anvil.compiler.isError
 import com.squareup.anvil.compiler.useDaggerAndKspParams
 import com.tschuchort.compiletesting.JvmCompilationResult
+import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.OK
 import dagger.Lazy
 import dagger.internal.Factory
@@ -2550,8 +2550,8 @@ public class InjectClass_Factory<T : List<String>>(
         @Inject constructor(string: String)
       }
       """,
+      expectExitCode = KotlinCompilation.ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
       assertThat(
         compilationErrorLine()
           .removeParametersAndSort(),
@@ -2737,11 +2737,13 @@ public final class InjectClass_Factory implements Factory<InjectClass> {
   private fun compile(
     @Language("kotlin") vararg sources: String,
     previousCompilationResult: JvmCompilationResult? = null,
+    expectExitCode: KotlinCompilation.ExitCode = KotlinCompilation.ExitCode.OK,
     block: JvmCompilationResult.() -> Unit = { },
   ): JvmCompilationResult = compileAnvil(
     sources = sources,
     enableDaggerAnnotationProcessor = useDagger,
     generateDaggerFactories = !useDagger,
+    expectExitCode = expectExitCode,
     // Many constructor parameters are unused.
     allWarningsAsErrors = false,
     previousCompilationResult = previousCompilationResult,

--- a/compiler/src/test/java/com/squareup/anvil/compiler/dagger/MembersInjectorGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/dagger/MembersInjectorGeneratorTest.kt
@@ -10,10 +10,10 @@ import com.squareup.anvil.compiler.internal.testing.getPropertyValue
 import com.squareup.anvil.compiler.internal.testing.getValue
 import com.squareup.anvil.compiler.internal.testing.isStatic
 import com.squareup.anvil.compiler.internal.testing.membersInjector
-import com.squareup.anvil.compiler.isError
 import com.squareup.anvil.compiler.nestedInjectClass
 import com.squareup.anvil.compiler.useDaggerAndKspParams
 import com.tschuchort.compiletesting.JvmCompilationResult
+import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.OK
 import dagger.Lazy
 import dagger.MembersInjector
@@ -1237,69 +1237,69 @@ public final class OuterClass_InjectClass_MembersInjector implements MembersInje
 
   @Test
   fun `a factory class is generated for a field injection on a super class`() {
-/*
-package com.squareup.test;
+    /*
+    package com.squareup.test;
 
-import dagger.MembersInjector;
-import dagger.internal.DaggerGenerated;
-import dagger.internal.InjectedFieldSignature;
-import java.util.List;
-import java.util.Set;
-import javax.annotation.processing.Generated;
-import javax.inject.Provider;
+    import dagger.MembersInjector;
+    import dagger.internal.DaggerGenerated;
+    import dagger.internal.InjectedFieldSignature;
+    import java.util.List;
+    import java.util.Set;
+    import javax.annotation.processing.Generated;
+    import javax.inject.Provider;
 
-@DaggerGenerated
-@Generated(
-    value = "dagger.internal.codegen.ComponentProcessor",
-    comments = "https://dagger.dev"
-)
-@SuppressWarnings({
-    "unchecked",
-    "rawtypes"
-})
-public final class InjectClass_MembersInjector implements MembersInjector<InjectClass> {
-  private final Provider<List<Integer>> base1Provider;
+    @DaggerGenerated
+    @Generated(
+        value = "dagger.internal.codegen.ComponentProcessor",
+        comments = "https://dagger.dev"
+    )
+    @SuppressWarnings({
+        "unchecked",
+        "rawtypes"
+    })
+    public final class InjectClass_MembersInjector implements MembersInjector<InjectClass> {
+      private final Provider<List<Integer>> base1Provider;
 
-  private final Provider<List<String>> base2Provider;
+      private final Provider<List<String>> base2Provider;
 
-  private final Provider<Set<Integer>> middle1Provider;
+      private final Provider<Set<Integer>> middle1Provider;
 
-  private final Provider<Set<String>> middle2Provider;
+      private final Provider<Set<String>> middle2Provider;
 
-  private final Provider<String> nameProvider;
+      private final Provider<String> nameProvider;
 
-  public InjectClass_MembersInjector(Provider<List<Integer>> base1Provider,
-      Provider<List<String>> base2Provider, Provider<Set<Integer>> middle1Provider,
-      Provider<Set<String>> middle2Provider, Provider<String> nameProvider) {
-    this.base1Provider = base1Provider;
-    this.base2Provider = base2Provider;
-    this.middle1Provider = middle1Provider;
-    this.middle2Provider = middle2Provider;
-    this.nameProvider = nameProvider;
-  }
+      public InjectClass_MembersInjector(Provider<List<Integer>> base1Provider,
+          Provider<List<String>> base2Provider, Provider<Set<Integer>> middle1Provider,
+          Provider<Set<String>> middle2Provider, Provider<String> nameProvider) {
+        this.base1Provider = base1Provider;
+        this.base2Provider = base2Provider;
+        this.middle1Provider = middle1Provider;
+        this.middle2Provider = middle2Provider;
+        this.nameProvider = nameProvider;
+      }
 
-  public static MembersInjector<InjectClass> create(Provider<List<Integer>> base1Provider,
-      Provider<List<String>> base2Provider, Provider<Set<Integer>> middle1Provider,
-      Provider<Set<String>> middle2Provider, Provider<String> nameProvider) {
-    return new InjectClass_MembersInjector(base1Provider, base2Provider, middle1Provider, middle2Provider, nameProvider);
-  }
+      public static MembersInjector<InjectClass> create(Provider<List<Integer>> base1Provider,
+          Provider<List<String>> base2Provider, Provider<Set<Integer>> middle1Provider,
+          Provider<Set<String>> middle2Provider, Provider<String> nameProvider) {
+        return new InjectClass_MembersInjector(base1Provider, base2Provider, middle1Provider, middle2Provider, nameProvider);
+      }
 
-  @Override
-  public void injectMembers(InjectClass instance) {
-    Base_MembersInjector.injectBase1(instance, base1Provider.get());
-    Base_MembersInjector.injectBase2(instance, base2Provider.get());
-    Middle_MembersInjector.injectMiddle1(instance, middle1Provider.get());
-    Middle_MembersInjector.injectMiddle2(instance, middle2Provider.get());
-    injectName(instance, nameProvider.get());
-  }
+      @Override
+      public void injectMembers(InjectClass instance) {
+        Base_MembersInjector.injectBase1(instance, base1Provider.get());
+        Base_MembersInjector.injectBase2(instance, base2Provider.get());
+        Middle_MembersInjector.injectMiddle1(instance, middle1Provider.get());
+        Middle_MembersInjector.injectMiddle2(instance, middle2Provider.get());
+        injectName(instance, nameProvider.get());
+      }
 
-  @InjectedFieldSignature("com.squareup.test.InjectClass.name")
-  public static void injectName(InjectClass instance, String name) {
-    instance.name = name;
-  }
-}
+      @InjectedFieldSignature("com.squareup.test.InjectClass.name")
+      public static void injectName(InjectClass instance, String name) {
+        instance.name = name;
+      }
+    }
 
- */
+     */
     compile(
       """
       package com.squareup.test
@@ -2425,8 +2425,8 @@ public final class InjectClass_MembersInjector<T, U, V> implements MembersInject
         var injected: String? = null
       }
       """,
+      expectExitCode = KotlinCompilation.ExitCode.COMPILATION_ERROR,
     ) {
-      assertThat(exitCode).isError()
       assertThat(messages).contains("Dagger does not support injection into private fields")
 
       assertFailsWith<ClassNotFoundException> {
@@ -2555,12 +2555,14 @@ public final class InjectClass_MembersInjector<T, U, V> implements MembersInject
   private fun compile(
     @Language("kotlin") vararg sources: String,
     previousCompilationResult: JvmCompilationResult? = null,
+    expectExitCode: KotlinCompilation.ExitCode = KotlinCompilation.ExitCode.OK,
     block: JvmCompilationResult.() -> Unit = { },
   ): JvmCompilationResult = compileAnvil(
     sources = sources,
     enableDaggerAnnotationProcessor = useDagger,
     generateDaggerFactories = !useDagger,
     previousCompilationResult = previousCompilationResult,
+    expectExitCode = expectExitCode,
     mode = mode,
     block = block,
   )

--- a/compiler/src/test/java/com/squareup/anvil/compiler/testing/CompilationEnvironment.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/testing/CompilationEnvironment.kt
@@ -10,6 +10,7 @@ import com.squareup.anvil.compiler.api.CodeGenerator
 import com.squareup.anvil.compiler.internal.testing.AnvilCompilationMode
 import com.squareup.anvil.compiler.internal.testing.compileAnvil
 import com.tschuchort.compiletesting.JvmCompilationResult
+import com.tschuchort.compiletesting.KotlinCompilation
 import org.intellij.lang.annotations.Language
 import java.io.File
 
@@ -35,6 +36,7 @@ interface CompilationEnvironment : HasWorkingDir {
     allWarningsAsErrors: Boolean = true,
     mode: AnvilCompilationMode = modeDefault(codeGenerators),
     workingDir: File? = this@CompilationEnvironment.workingDir,
+    expectExitCode: KotlinCompilation.ExitCode = KotlinCompilation.ExitCode.OK,
     block: JvmCompilationResult.() -> Unit = { },
   ): JvmCompilationResult = compileAnvil(
     sources = sources,
@@ -46,6 +48,7 @@ interface CompilationEnvironment : HasWorkingDir {
     trackSourceFiles = trackSourceFiles,
     mode = mode,
     workingDir = workingDir,
+    expectExitCode = expectExitCode,
     block = block,
   )
 }


### PR DESCRIPTION
The published `AnvilCompilation` logic gets a new `expectExitCode: ExitCode? = null` parameter.  If a value is specified, the assertion is done before executing the `block` lambda.

In our internal delegating `compile(...)` functions, the parameter becomes non-nullable and defaults to `ExitCode.OK`.

This is done in follow-up to [this](https://github.com/square/anvil/pull/934#discussion_r1544638830) comment.