### PR TITLE
pass files with only top-level function/property declarations to `CodeGenerator` implementations

### DIFF
--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/reference/RealAnvilModuleDescriptor.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/reference/RealAnvilModuleDescriptor.kt
@@ -58,13 +58,15 @@ public class RealAnvilModuleDescriptor private constructor(
   private val resolveClassIdCache = mutableMapOf<ClassId, FqName?>()
   private val classReferenceCache = mutableMapOf<ClassReferenceCacheKey, ClassReference>()
 
+  private val fileIdToKtFileMap: MutableMap<String, KtFile> = mutableMapOf()
   internal val allFiles: Sequence<KtFile>
-    get() = allPsiClassReferences
-      .map { it.clazz.containingKtFile }
-      .distinctBy { it.identifier }
+    get() = fileIdToKtFileMap.values.asSequence()
 
   public fun addFiles(files: Collection<KtFile>) {
     files.forEach { ktFile ->
+
+      fileIdToKtFileMap[ktFile.identifier] = ktFile
+
       val classReferences = ktFile.classesAndInnerClasses().map { ktClass ->
         Psi(ktClass, ktClass.toClassId(), this)
       }

--- a/compiler/src/test/java/com/squareup/anvil/compiler/codegen/ContributesSubcomponentHandlerGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/codegen/ContributesSubcomponentHandlerGeneratorTest.kt
@@ -1890,7 +1890,7 @@ class ContributesSubcomponentHandlerGeneratorTest {
   }
 
   @Test
-  fun `a previously generated contributed subcomponent cannot be replaced in a later round of generations`() {
+  fun `a previously generated contributed subcomponent can be replaced in a later round of generations`() {
     val codeGenerator = simpleCodeGenerator { clazz ->
       clazz
         .takeIf { it.isAnnotatedWith(mergeComponentFqName) }

--- a/compiler/src/test/java/com/squareup/anvil/compiler/internal/reference/AnnotationReferenceTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/internal/reference/AnnotationReferenceTest.kt
@@ -189,7 +189,7 @@ class AnnotationReferenceTest : ReferenceTests {
         .toAnnotationSpec()
         .toString()
 
-      val SomeClass1 by classReferenceMap
+      val SomeClass1 by classReferences
 
       SomeClass1.stringValue() shouldBe "abc.1"
       SomeClass1.stringAnnotationSpec() shouldBe "@com.squareup.test.StringQualifier(str = \"abc.1\")"
@@ -197,7 +197,7 @@ class AnnotationReferenceTest : ReferenceTests {
       SomeClass1.intValue() shouldBe 2
       SomeClass1.intAnnotationSpec() shouldBe "@com.squareup.test.IntQualifier(num = 2)"
 
-      val SomeClass2 by classReferenceMap
+      val SomeClass2 by classReferences
 
       SomeClass2.stringValue() shouldBe "def.1"
       SomeClass2.stringAnnotationSpec() shouldBe "@com.squareup.test.StringQualifier(str = \"def.1\")"
@@ -205,7 +205,7 @@ class AnnotationReferenceTest : ReferenceTests {
       SomeClass2.intValue() shouldBe 3
       SomeClass2.intAnnotationSpec() shouldBe "@com.squareup.test.IntQualifier(num = 3)"
 
-      val SomeClass3 by classReferenceMap
+      val SomeClass3 by classReferences
 
       SomeClass3.stringValue() shouldBe "ghi.1"
       SomeClass3.stringAnnotationSpec() shouldBe "@com.squareup.test.StringQualifier(str = \"ghi.1\")"
@@ -213,7 +213,7 @@ class AnnotationReferenceTest : ReferenceTests {
       SomeClass3.intValue() shouldBe 4
       SomeClass3.intAnnotationSpec() shouldBe "@com.squareup.test.IntQualifier(num = 4)"
 
-      val SomeClass4 by classReferenceMap
+      val SomeClass4 by classReferences
 
       SomeClass4.stringValue() shouldBe "ghi.1"
       SomeClass4.stringAnnotationSpec() shouldBe "@com.squareup.test.StringQualifier(str = \"ghi.1\")"
@@ -221,7 +221,7 @@ class AnnotationReferenceTest : ReferenceTests {
       SomeClass4.intValue() shouldBe 4
       SomeClass4.intAnnotationSpec() shouldBe "@com.squareup.test.IntQualifier(num = 4)"
 
-      val SomeClass5 by classReferenceMap
+      val SomeClass5 by classReferences
 
       SomeClass5.stringValue() shouldBe "jkl.1"
       SomeClass5.stringAnnotationSpec() shouldBe "@com.squareup.test.StringQualifier(str = \"jkl.1\")"
@@ -229,7 +229,7 @@ class AnnotationReferenceTest : ReferenceTests {
       SomeClass5.intValue() shouldBe 5
       SomeClass5.intAnnotationSpec() shouldBe "@com.squareup.test.IntQualifier(num = 5)"
 
-      val SomeClass6 by classReferenceMap
+      val SomeClass6 by classReferences
 
       SomeClass6.stringValue() shouldBe "jkl.1"
       SomeClass6.stringAnnotationSpec() shouldBe "@com.squareup.test.StringQualifier(str = \"jkl.1\")"
@@ -368,54 +368,54 @@ class AnnotationReferenceTest : ReferenceTests {
       fun ClassReference.annotationArg() = annotations.single().arguments.single().value<Int>()
       fun ClassReference.annotationSpec() = annotations.single().toAnnotationSpec().toString()
 
-      val SomeClass1 by classReferenceMap
+      val SomeClass1 by classReferences
       SomeClass1.annotationArg() shouldBe 1
       SomeClass1.annotationSpec() shouldBe "@com.squareup.test.BindingKey(value = 1)"
 
-      val SomeClass2 by classReferenceMap
+      val SomeClass2 by classReferences
       SomeClass2.annotationArg() shouldBe 1
       SomeClass2.annotationSpec() shouldBe "@com.squareup.test.BindingKey(value = 1)"
 
-      val SomeClass3 by classReferenceMap
+      val SomeClass3 by classReferences
       SomeClass3.annotationArg() shouldBe -5
       SomeClass3.annotationSpec() shouldBe "@com.squareup.test.BindingKey(value = -5)"
 
       forAll(
-        row(classReferenceMap.getValue("SomeClass4")),
-        row(classReferenceMap.getValue("SomeClass5")),
-        row(classReferenceMap.getValue("SomeClass6")),
+        row(classReferences.getValue("SomeClass4")),
+        row(classReferences.getValue("SomeClass5")),
+        row(classReferences.getValue("SomeClass6")),
       ) { ref ->
         ref.annotationArg() shouldBe Int.MAX_VALUE
         ref.annotationSpec() shouldBe "@com.squareup.test.BindingKey(value = 2147483647)"
       }
 
       forAll(
-        row(classReferenceMap.getValue("SomeClass7")),
-        row(classReferenceMap.getValue("SomeClass8")),
+        row(classReferences.getValue("SomeClass7")),
+        row(classReferences.getValue("SomeClass8")),
       ) { ref ->
         ref.annotationArg() shouldBe 2
         ref.annotationSpec() shouldBe "@com.squareup.test.BindingKey(value = 2)"
       }
 
       forAll(
-        row(classReferenceMap.getValue("SomeClass9")),
-        row(classReferenceMap.getValue("SomeClass10")),
-        row(classReferenceMap.getValue("SomeClass11")),
+        row(classReferences.getValue("SomeClass9")),
+        row(classReferences.getValue("SomeClass10")),
+        row(classReferences.getValue("SomeClass11")),
       ) { ref ->
         ref.annotationArg() shouldBe 3
         ref.annotationSpec() shouldBe "@com.squareup.test.BindingKey(value = 3)"
       }
 
       forAll(
-        row(classReferenceMap.getValue("SomeClass12")),
-        row(classReferenceMap.getValue("SomeClass13")),
-        row(classReferenceMap.getValue("SomeClass14")),
+        row(classReferences.getValue("SomeClass12")),
+        row(classReferences.getValue("SomeClass13")),
+        row(classReferences.getValue("SomeClass14")),
       ) { ref ->
         ref.annotationArg() shouldBe 4
         ref.annotationSpec() shouldBe "@com.squareup.test.BindingKey(value = 4)"
       }
 
-      val SomeClass15 by classReferenceMap
+      val SomeClass15 by classReferences
       SomeClass15.annotationArg() shouldBe 5
       SomeClass15.annotationSpec() shouldBe "@com.squareup.test.BindingKey(value = 5)"
     }

--- a/compiler/src/test/java/com/squareup/anvil/compiler/internal/reference/RealAnvilModuleDescriptorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/internal/reference/RealAnvilModuleDescriptorTest.kt
@@ -1,0 +1,83 @@
+package com.squareup.anvil.compiler.internal.reference
+
+import com.rickbusarow.kase.Kase1
+import com.rickbusarow.kase.kase
+import com.rickbusarow.kase.stdlib.div
+import com.rickbusarow.kase.wrap
+import com.squareup.anvil.compiler.api.createGeneratedFile
+import com.squareup.anvil.compiler.internal.containingFileAsJavaFile
+import com.squareup.anvil.compiler.internal.reference.ReferencesTestEnvironment.ReferenceType.Psi
+import com.squareup.anvil.compiler.internal.testing.simpleCodeGenerator
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.TestFactory
+import java.io.File
+
+class RealAnvilModuleDescriptorTest : ReferenceTests {
+
+  @TestFactory
+  fun `a file without type declarations only a typealias declaration is passed to a code generator`() =
+    listOf<Kase1<(String) -> String>>(
+      kase("top-level property") { "val $it = Unit" },
+      kase("top-level function") { "fun $it() = Unit" },
+      kase("typealias") { "typealias $it = Unit" },
+      kase("just a comment") { "// this is a comment" },
+      kase("only the package declaration") { "" },
+    )
+      .asTests(testEnvironmentFactory = testEnvironmentFactory.wrap(Psi)) { (declaration) ->
+        val extraGenerator = simpleCodeGenerator { codeGenDir, _, files ->
+
+          val singleSource = files.single()
+          val sourceAsJava = singleSource.containingFileAsJavaFile()
+
+          val newGenerated = sourceAsJava.resolveSibling("Generated.kt")
+
+          // Don't generate the same file again.
+          if (newGenerated == sourceAsJava) {
+            return@simpleCodeGenerator emptyList()
+          }
+
+          listOf(
+            createGeneratedFile(
+              codeGenDir = codeGenDir,
+              packageName = singleSource.packageFqName.asString(),
+              fileName = newGenerated.nameWithoutExtension,
+              content = """
+                package com.squareup.test
+
+                ${declaration("b")}
+              """.trimIndent(),
+              sourceFile = sourceAsJava,
+            ),
+          )
+        }
+
+        // Use regular Java files because the Psi objects are disposed when the compilation ends.
+        val allProjectFiles = mutableListOf<File>()
+        val allFilesFromModule = mutableSetOf<File>()
+
+        compile(
+          """
+          package com.squareup.test
+        
+          ${declaration("a")}
+          """.trimIndent(),
+          codeGenerators = listOf(extraGenerator),
+        ) {
+
+          allProjectFiles.addAll(projectFiles.map { it.containingFileAsJavaFile() })
+          allFilesFromModule.addAll(module.allFiles.map { it.containingFileAsJavaFile() })
+        }
+
+        // These are the files that are passed to the code generator.
+        allProjectFiles shouldBe listOf(
+          workingDir / "sources" / "src/main/java" / "com/squareup/test/Source0.kt",
+          workingDir / "build/anvil" / "com/squareup/test/Generated.kt",
+        )
+
+        // These are the files returned by the module descriptor instance itself.
+        allFilesFromModule shouldBe listOf(
+          workingDir / "sources" / "src/main/java" / "com/squareup/test/Source0.kt",
+          workingDir / "build/anvil" / "com/squareup/test/Generated.kt",
+        )
+      }
+}


### PR DESCRIPTION
fixes #955