### PR TITLE
rename the new int-based priority to `rank`, restore the enum to `priority`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,10 @@
 
 ### Deprecated
 
-- `ContributesBinding.priority` has been deprecated (and renamed!) in favor of an int-value-based approach. This is a binary-compatible change but not a source-compatible change. The previous `ContributesBinding.priority: Priority` property has been renamed to `ContributesBinding.priorityDeprecated` and a new `ContributesBinding.priority: Int` has been introduced to replace it. This allows for more granular prioritization, rather than just the three enum entries that `ContributesBinding.Priority` offered. 
+- `ContributesBinding.priority` has been deprecated in favor of the int-value-based `ContributesBinding.priority`. This allows for more granular prioritization, rather than just the three enum entries that `ContributesBinding.Priority` offered.
+
+> [!IMPORTANT]
+> IDE auto-replace can auto-replace the enum entry with the corresponding integer, but not the named argument. Automatically-migrated code may wind up with something like `priority = RANK_NORMAL`. This is an IntelliJ limitation.
 
 ### Removed
 

--- a/annotations/api/annotations.api
+++ b/annotations/api/annotations.api
@@ -1,20 +1,20 @@
 public abstract interface annotation class com/squareup/anvil/annotations/ContributesBinding : java/lang/annotation/Annotation {
 	public static final field Companion Lcom/squareup/anvil/annotations/ContributesBinding$Companion;
-	public static final field PRIORITY_HIGH I
-	public static final field PRIORITY_HIGHEST I
-	public static final field PRIORITY_NORMAL I
+	public static final field RANK_HIGH I
+	public static final field RANK_HIGHEST I
+	public static final field RANK_NORMAL I
 	public abstract fun boundType ()Ljava/lang/Class;
 	public abstract fun ignoreQualifier ()Z
 	public abstract fun priority ()Lcom/squareup/anvil/annotations/ContributesBinding$Priority;
-	public abstract fun priorityInt ()I
+	public abstract fun rank ()I
 	public abstract fun replaces ()[Ljava/lang/Class;
 	public abstract fun scope ()Ljava/lang/Class;
 }
 
 public final class com/squareup/anvil/annotations/ContributesBinding$Companion {
-	public static final field PRIORITY_HIGH I
-	public static final field PRIORITY_HIGHEST I
-	public static final field PRIORITY_NORMAL I
+	public static final field RANK_HIGH I
+	public static final field RANK_HIGHEST I
+	public static final field RANK_NORMAL I
 }
 
 public abstract interface annotation class com/squareup/anvil/annotations/ContributesBinding$Container : java/lang/annotation/Annotation {
@@ -109,8 +109,8 @@ public abstract interface annotation class com/squareup/anvil/annotations/compat
 public abstract interface annotation class com/squareup/anvil/annotations/internal/InternalBindingMarker : java/lang/annotation/Annotation {
 	public abstract fun isMultibinding ()Z
 	public abstract fun originClass ()Ljava/lang/Class;
-	public abstract fun priority ()I
 	public abstract fun qualifierKey ()Ljava/lang/String;
+	public abstract fun rank ()I
 }
 
 public abstract interface annotation class com/squareup/anvil/annotations/internal/InternalBindingMarker$Container : java/lang/annotation/Annotation {

--- a/annotations/src/main/java/com/squareup/anvil/annotations/ContributesBinding.kt
+++ b/annotations/src/main/java/com/squareup/anvil/annotations/ContributesBinding.kt
@@ -1,5 +1,6 @@
 package com.squareup.anvil.annotations
 
+import com.squareup.anvil.annotations.ContributesBinding.Companion.RANK_NORMAL
 import kotlin.annotation.AnnotationRetention.RUNTIME
 import kotlin.annotation.AnnotationTarget.CLASS
 import kotlin.reflect.KClass
@@ -73,8 +74,8 @@ import kotlin.reflect.KClass
  * class FakeAuthenticator @Inject constructor() : Authenticator
  * ```
  * If you don't have access to the class of another contributed binding that you want to replace,
- * then you can change the [priority] of the bindings to avoid duplicate bindings. The contributed
- * binding with the higher priority will be used.
+ * then you can change the [rank] of the bindings to avoid duplicate bindings. The contributed
+ * binding with the higher rank will be used.
  *
  * [ContributesBinding] supports Kotlin objects, e.g.
  * ```
@@ -104,9 +105,8 @@ public annotation class ContributesBinding(
    */
   val replaces: Array<KClass<*>> = [],
   @Suppress("DEPRECATION")
-  @Deprecated("Use the new int-based priority", ReplaceWith("priority"))
-  @get:JvmName("priority")
-  val priorityDeprecated: Priority = Priority.NORMAL,
+  @Deprecated("Use the new int-based rank", ReplaceWith("rank"))
+  val priority: Priority = Priority.NORMAL,
   /**
    * Whether the qualifier for this class should be included in the generated binding method. This
    * parameter is only necessary to use when [ContributesBinding] and [ContributesMultibinding]
@@ -115,39 +115,62 @@ public annotation class ContributesBinding(
    */
   val ignoreQualifier: Boolean = false,
   /**
-   * The priority of this contributed binding. The priority should be changed only if you don't
+   * The rank of this contributed binding. The rank should be changed only if you don't
    * have access to the contributed binding class that you want to replace at compile time. If
    * you have access and can reference the other class, then it's highly suggested to
    * use [replaces] instead.
    *
-   * In case of a duplicate binding for multiple contributed bindings the binding with the highest
-   * priority will be used and replace other contributed bindings for the same type with a lower
-   * priority. If duplicate contributed bindings use the same priority, then there will be an
+   * In case of a duplicate binding for multiple contributed bindings, the binding with the highest
+   * rank will be used and replace other contributed bindings for the same type with a lower
+   * rank. If duplicate contributed bindings use the same rank, then there will be an
    * error for duplicate bindings.
    *
-   * Note that [replaces] takes precedence. If you explicitly replace a binding it won't be
-   * considered no matter what its priority is.
+   * Note that [replaces] takes precedence. If you explicitly replace a binding, it won't be
+   * considered no matter what its rank is.
    *
-   * All contributed bindings have a [PRIORITY_NORMAL] priority by default.
+   * All contributed bindings have a [RANK_NORMAL] rank by default.
    */
-  @get:JvmName("priorityInt")
-  val priority: Int = PRIORITY_NORMAL,
+  val rank: Int = RANK_NORMAL,
 ) {
 
   public companion object {
-    public const val PRIORITY_NORMAL: Int = Int.MIN_VALUE
-    public const val PRIORITY_HIGH: Int = 0
-    public const val PRIORITY_HIGHEST: Int = Int.MAX_VALUE
+    public const val RANK_NORMAL: Int = Int.MIN_VALUE
+    public const val RANK_HIGH: Int = 0
+    public const val RANK_HIGHEST: Int = Int.MAX_VALUE
   }
 
   /**
-   * The priority of a contributed binding.
+   * The rank of a contributed binding.
    */
-  @Deprecated("Use the new int-based priority")
   @Suppress("unused")
+  @Deprecated("Use the new int-based rank")
   public enum class Priority(public val value: Int) {
-    NORMAL(PRIORITY_NORMAL),
-    HIGH(PRIORITY_HIGH),
-    HIGHEST(PRIORITY_HIGHEST),
+
+    @Deprecated(
+      "Use RANK_NORMAL instead",
+      ReplaceWith(
+        "ContributesBinding.Companion.RANK_NORMAL",
+        "com.squareup.anvil.annotations.ContributesBinding",
+      ),
+    )
+    NORMAL(RANK_NORMAL),
+
+    @Deprecated(
+      "Use RANK_HIGH instead",
+      ReplaceWith(
+        "ContributesBinding.Companion.RANK_HIGH",
+        "com.squareup.anvil.annotations.ContributesBinding",
+      ),
+    )
+    HIGH(RANK_HIGH),
+
+    @Deprecated(
+      "Use RANK_HIGHEST instead",
+      ReplaceWith(
+        "ContributesBinding.Companion.RANK_HIGHEST",
+        "com.squareup.anvil.annotations.ContributesBinding",
+      ),
+    )
+    HIGHEST(RANK_HIGHEST),
   }
 }

--- a/annotations/src/main/java/com/squareup/anvil/annotations/internal/InternalBindingMarker.kt
+++ b/annotations/src/main/java/com/squareup/anvil/annotations/internal/InternalBindingMarker.kt
@@ -16,8 +16,7 @@ import kotlin.reflect.KClass
  *   because the contributed binding may be an `object` and cannot be specified as a
  *   binding parameter.
  * @param isMultibinding Whether this is a multibinding.
- * @param priority The priority of the contributed binding. Corresponds to a
- *   [ContributesBinding.priority].
+ * @param rank The rank of the contributed binding. Corresponds to a [ContributesBinding.rank].
  * @param qualifierKey The computed key of the qualifier annotation if present. Empty otherwise.
  */
 @Target(CLASS)
@@ -26,6 +25,6 @@ import kotlin.reflect.KClass
 public annotation class InternalBindingMarker(
   val originClass: KClass<*>,
   val isMultibinding: Boolean,
-  val priority: Int = Int.MIN_VALUE,
+  val rank: Int = Int.MIN_VALUE,
   val qualifierKey: String = "",
 )

--- a/compiler/src/main/java/com/squareup/anvil/compiler/IrContributionMerger.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/IrContributionMerger.kt
@@ -265,9 +265,9 @@ internal class IrContributionMerger(
             ?.value<Boolean>() == true
         val qualifierKey =
           internalBindingMarker.argumentOrNull("qualifierKey")?.value<String>().orEmpty()
-        val priority = internalBindingMarker.argumentOrNull("priority")
+        val rank = internalBindingMarker.argumentOrNull("rank")
           ?.value()
-          ?: ContributesBinding.PRIORITY_NORMAL
+          ?: ContributesBinding.RANK_NORMAL
         val scope = contributedAnnotation.scope
         ContributedBinding(
           scope = scope,
@@ -276,7 +276,7 @@ internal class IrContributionMerger(
           originClass = originClass,
           boundType = boundType,
           qualifierKey = qualifierKey,
-          priority = priority,
+          rank = rank,
         )
       }
       .let { ContributedBindings.from(it) }

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/AnnotationReferenceExtensions.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/AnnotationReferenceExtensions.kt
@@ -8,8 +8,6 @@ import com.squareup.anvil.compiler.daggerComponentFqName
 import com.squareup.anvil.compiler.daggerModuleFqName
 import com.squareup.anvil.compiler.daggerSubcomponentFqName
 import com.squareup.anvil.compiler.internal.reference.AnnotationReference
-import com.squareup.anvil.compiler.internal.reference.AnnotationReference.Descriptor
-import com.squareup.anvil.compiler.internal.reference.AnnotationReference.Psi
 import com.squareup.anvil.compiler.internal.reference.AnvilCompilationExceptionAnnotationReference
 import com.squareup.anvil.compiler.internal.reference.AnvilCompilationExceptionClassReference
 import com.squareup.anvil.compiler.internal.reference.ClassReference
@@ -44,37 +42,17 @@ internal fun ClassReference.qualifierAnnotation(): AnnotationReference? {
   return annotations.find { it.isQualifier() }
 }
 
-internal fun AnnotationReference.priority(): Int {
-  return priorityNew() ?: priorityLegacy() ?: ContributesBinding.PRIORITY_NORMAL
+internal fun AnnotationReference.rank(): Int {
+  return argumentAt("rank", index = 6)?.value()
+    ?: priorityLegacy()
+    ?: ContributesBinding.RANK_NORMAL
 }
 
 @Suppress("DEPRECATION")
 internal fun AnnotationReference.priorityLegacy(): Int? {
-  val priorityDeprecated = when (this) {
-    is Descriptor -> "priority"
-    is Psi -> "priorityDeprecated"
-  }
-  val priority = argumentAt(priorityDeprecated, index = 4)
+  return argumentAt("priority", index = 4)
     ?.value<FqName>()
-    ?.let { ContributesBinding.Priority.valueOf(it.shortName().asString()) }
-
-  return priority?.value
-}
-
-internal fun AnnotationReference.priorityNew(): Int? {
-  val priorityInt = when (this) {
-    is Descriptor -> "priorityInt"
-    is Psi -> "priority"
-  }
-  try {
-    return argumentAt(priorityInt, index = 6)
-      ?.value()
-  } catch (e: ClassCastException) {
-    throw AnvilCompilationExceptionAnnotationReference(
-      message = "Could not parse priority. This can happen if you haven't migrated to the new int-based priority API",
-      annotationReference = this,
-    )
-  }
+    ?.let { ContributesBinding.Priority.valueOf(it.shortName().asString()) }?.value
 }
 
 internal fun AnnotationReference.modules(

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesBindingCodeGen.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesBindingCodeGen.kt
@@ -26,8 +26,8 @@ import com.squareup.anvil.compiler.codegen.ksp.checkNotMoreThanOneQualifier
 import com.squareup.anvil.compiler.codegen.ksp.checkSingleSuperType
 import com.squareup.anvil.compiler.codegen.ksp.getKSAnnotationsByType
 import com.squareup.anvil.compiler.codegen.ksp.ignoreQualifier
-import com.squareup.anvil.compiler.codegen.ksp.priority
 import com.squareup.anvil.compiler.codegen.ksp.qualifierAnnotation
+import com.squareup.anvil.compiler.codegen.ksp.rank
 import com.squareup.anvil.compiler.codegen.ksp.replaces
 import com.squareup.anvil.compiler.codegen.ksp.resolveBoundType
 import com.squareup.anvil.compiler.codegen.ksp.scope
@@ -48,7 +48,7 @@ import kotlin.properties.Delegates
  * annotations, a binding module will be generated for each contribution. Each generated module is
  * annotated with [ContributesTo] for merging.
  *
- * [ContributesBinding.priority] is conveyed in the generated module via [InternalBindingMarker]
+ * [ContributesBinding.rank] is conveyed in the generated module via [InternalBindingMarker]
  * annotation generated onto the binding module.
  */
 internal object ContributesBindingCodeGen : AnvilApplicabilityChecker {
@@ -101,7 +101,7 @@ internal object ContributesBindingCodeGen : AnvilApplicabilityChecker {
               val boundTypeDeclaration = it.resolveBoundType(resolver, clazz)
               boundTypeDeclaration.checkNotGeneric(clazz)
               val boundType = boundTypeDeclaration.toClassName()
-              val priority = it.priority()
+              val rank = it.rank()
               val replaces = it.replaces().map { it.toClassName() }
               val qualifierData = if (it.ignoreQualifier()) {
                 null
@@ -117,7 +117,7 @@ internal object ContributesBindingCodeGen : AnvilApplicabilityChecker {
                 scope,
                 clazz.classKind == ClassKind.OBJECT,
                 boundType,
-                priority,
+                rank,
                 replaces,
                 qualifierData,
               )
@@ -175,7 +175,7 @@ internal object ContributesBindingCodeGen : AnvilApplicabilityChecker {
               val boundTypeReference = it.resolveBoundType()
               boundTypeReference.checkNotGeneric(clazz)
               val boundType = boundTypeReference.asClassName()
-              val priority = it.priority()
+              val rank = it.rank()
               val replaces = it.replaces().map { it.asClassName() }
               val qualifierData = if (it.ignoreQualifier()) {
                 null
@@ -187,13 +187,13 @@ internal object ContributesBindingCodeGen : AnvilApplicabilityChecker {
                 }
               }
               Contribution.Binding(
-                clazz.asClassName(),
-                scope,
-                clazz.isObject(),
-                boundType,
-                priority,
-                replaces,
-                qualifierData,
+                origin = clazz.asClassName(),
+                scope = scope,
+                isObject = clazz.isObject(),
+                boundType = boundType,
+                rank = rank,
+                replaces = replaces,
+                qualifier = qualifierData,
               )
             }
 

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/Contribution.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/Contribution.kt
@@ -92,8 +92,8 @@ internal sealed class Contribution {
             }
             if (contribution is Binding) {
               addMember(
-                "priority = %L",
-                contribution.priority,
+                "rank = %L",
+                contribution.rank,
               )
             }
           }
@@ -195,7 +195,7 @@ internal sealed class Contribution {
       it.scope.canonicalName
     }
       .thenComparing(compareBy { it.boundType.canonicalName })
-      .thenComparing(compareBy { if (it is Binding) it.priority else 0 })
+      .thenComparing(compareBy { if (it is Binding) it.rank else 0 })
       .thenComparing(compareBy { it.replaces.joinToString(transform = ClassName::canonicalName) })
   }
 
@@ -209,7 +209,7 @@ internal sealed class Contribution {
     override val scope: ClassName,
     override val isObject: Boolean,
     override val boundType: ClassName,
-    val priority: Int,
+    val rank: Int,
     override val replaces: List<ClassName>,
     override val qualifier: QualifierData?,
   ) : Contribution() {

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ksp/KSAnnotationExtensions.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ksp/KSAnnotationExtensions.kt
@@ -154,18 +154,16 @@ internal fun KSAnnotated.qualifierAnnotation(): KSAnnotation? =
 internal fun KSAnnotation.ignoreQualifier(): Boolean =
   argumentAt("ignoreQualifier")?.value as? Boolean? == true
 
-internal fun KSAnnotation.priority(): Int {
-  return priorityNew() ?: priorityLegacy() ?: ContributesBinding.PRIORITY_NORMAL
+internal fun KSAnnotation.rank(): Int {
+  return argumentAt("rank")?.value as Int?
+    ?: priorityLegacy()
+    ?: ContributesBinding.RANK_NORMAL
 }
 
 @Suppress("DEPRECATION")
 internal fun KSAnnotation.priorityLegacy(): Int? {
-  val priorityEntry = argumentAt("priorityDeprecated")?.value as KSType? ?: return null
+  val priorityEntry = argumentAt("priority")?.value as KSType? ?: return null
   val name = priorityEntry.resolveKSClassDeclaration()?.simpleName?.asString() ?: return null
   val priority = ContributesBinding.Priority.valueOf(name)
   return priority.value
-}
-
-internal fun KSAnnotation.priorityNew(): Int? {
-  return argumentAt("priority")?.value as Int?
 }

--- a/compiler/src/test/java/com/squareup/anvil/compiler/codegen/BindingModulePriorityTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/codegen/BindingModulePriorityTest.kt
@@ -1,6 +1,7 @@
 package com.squareup.anvil.compiler.codegen
 
 import com.google.common.truth.Truth.assertThat
+import com.squareup.anvil.annotations.ContributesBinding
 import com.squareup.anvil.annotations.MergeComponent
 import com.squareup.anvil.annotations.MergeSubcomponent
 import com.squareup.anvil.annotations.compat.MergeModules
@@ -20,7 +21,7 @@ import org.junit.runners.Parameterized.Parameters
 import kotlin.reflect.KClass
 
 @RunWith(Parameterized::class)
-class BindingModulePriorityTest(
+class BindingModuleRankTest(
   private val annotationClass: KClass<out Annotation>,
 ) {
 
@@ -41,22 +42,22 @@ class BindingModulePriorityTest(
     }
   }
 
-  @Test fun `the binding with the higher priority is used`() {
+  @Test fun `the binding with the higher rank is used`() {
     compile(
       """
       package com.squareup.test
       
       import com.squareup.anvil.annotations.ContributesBinding
-      import com.squareup.anvil.annotations.ContributesBinding.Companion.PRIORITY_HIGH
-      import com.squareup.anvil.annotations.ContributesBinding.Companion.PRIORITY_HIGHEST
+      import com.squareup.anvil.annotations.ContributesBinding.Companion.RANK_HIGH
+      import com.squareup.anvil.annotations.ContributesBinding.Companion.RANK_HIGHEST
       $import
       
       interface ParentInterface
       
-      @ContributesBinding(Any::class, priority = PRIORITY_HIGHEST)
+      @ContributesBinding(Any::class, rank = RANK_HIGHEST)
       interface ContributingInterface : ParentInterface
       
-      @ContributesBinding(Any::class, priority = PRIORITY_HIGH)
+      @ContributesBinding(Any::class, rank = RANK_HIGH)
       interface ContributingInterface2 : ParentInterface
       
       @ContributesBinding(Any::class)
@@ -77,22 +78,22 @@ class BindingModulePriorityTest(
     }
   }
 
-  @Test fun `the binding with the higher priority is used with one replaced binding`() {
+  @Test fun `the binding with the higher rank is used with one replaced binding`() {
     compile(
       """
       package com.squareup.test
       
       import com.squareup.anvil.annotations.ContributesBinding
-      import com.squareup.anvil.annotations.ContributesBinding.Companion.PRIORITY_HIGH
-      import com.squareup.anvil.annotations.ContributesBinding.Companion.PRIORITY_HIGHEST
+      import com.squareup.anvil.annotations.ContributesBinding.Companion.RANK_HIGH
+      import com.squareup.anvil.annotations.ContributesBinding.Companion.RANK_HIGHEST
       $import
       
       interface ParentInterface
       
-      @ContributesBinding(Any::class, priority = PRIORITY_HIGHEST)
+      @ContributesBinding(Any::class, rank = RANK_HIGHEST)
       interface ContributingInterface : ParentInterface
       
-      @ContributesBinding(Any::class, priority = PRIORITY_HIGH, replaces = [ContributingInterface::class])
+      @ContributesBinding(Any::class, rank = RANK_HIGH, replaces = [ContributingInterface::class])
       interface SecondContributingInterface : ParentInterface
       
       @ContributesBinding(Any::class)
@@ -113,7 +114,7 @@ class BindingModulePriorityTest(
     }
   }
 
-  @Test fun `bindings with the same priority throw an error`() {
+  @Test fun `bindings with the same rank throw an error`() {
     compile(
       """
       package com.squareup.test
@@ -136,8 +137,8 @@ class BindingModulePriorityTest(
       assertThat(exitCode).isError()
 
       assertThat(messages).contains(
-        "There are multiple contributed bindings with the same bound type and priority. The bound " +
-          "type is com.squareup.test.ParentInterface. The priority is NORMAL. The contributed " +
+        "There are multiple contributed bindings with the same bound type and rank. The bound " +
+          "type is com.squareup.test.ParentInterface. The rank is ${ContributesBinding.RANK_NORMAL}. The contributed " +
           "binding classes are: [",
       )
       // Check the contributed bindings separately, we cannot rely on the order in the string.
@@ -146,7 +147,7 @@ class BindingModulePriorityTest(
     }
   }
 
-  @Test fun `bindings with the same priority can be replaced and aren't duplicate bindings`() {
+  @Test fun `bindings with the same rank can be replaced and aren't duplicate bindings`() {
     compile(
       """
       package com.squareup.test
@@ -177,7 +178,7 @@ class BindingModulePriorityTest(
     }
   }
 
-  @Test fun `bindings with the same priority can be excluded and aren't duplicate bindings`() {
+  @Test fun `bindings with the same rank can be excluded and aren't duplicate bindings`() {
     compile(
       """
       package com.squareup.test
@@ -273,8 +274,8 @@ class BindingModulePriorityTest(
       assertThat(exitCode).isError()
 
       assertThat(messages).contains(
-        "There are multiple contributed bindings with the same bound type and priority. The bound " +
-          "type is com.squareup.test.ParentInterface. The priority is NORMAL. The contributed " +
+        "There are multiple contributed bindings with the same bound type and rank. The bound " +
+          "type is com.squareup.test.ParentInterface. The rank is ${ContributesBinding.RANK_NORMAL}. The contributed " +
           "binding classes are: [",
       )
       // Check the contributed bindings separately, we cannot rely on the order in the string.
@@ -309,8 +310,8 @@ class BindingModulePriorityTest(
       assertThat(exitCode).isError()
 
       assertThat(messages).contains(
-        "There are multiple contributed bindings with the same bound type and priority. The bound " +
-          "type is com.squareup.test.ParentInterface. The priority is NORMAL. The contributed " +
+        "There are multiple contributed bindings with the same bound type and rank. The bound " +
+          "type is com.squareup.test.ParentInterface. The rank is ${ContributesBinding.RANK_NORMAL}. The contributed " +
           "binding classes are: [",
       )
       // Check the contributed bindings separately, we cannot rely on the order in the string.
@@ -379,22 +380,22 @@ class BindingModulePriorityTest(
     }
   }
 
-  @Test fun `the binding with the higher priority is used with multiple contributions`() {
+  @Test fun `the binding with the higher rank is used with multiple contributions`() {
     compile(
       """
       package com.squareup.test
       
       import com.squareup.anvil.annotations.ContributesBinding
-      import com.squareup.anvil.annotations.ContributesBinding.Companion.PRIORITY_HIGH
-      import com.squareup.anvil.annotations.ContributesBinding.Companion.PRIORITY_HIGHEST
+      import com.squareup.anvil.annotations.ContributesBinding.Companion.RANK_HIGH
+      import com.squareup.anvil.annotations.ContributesBinding.Companion.RANK_HIGHEST
       $import
       
       interface ParentInterface
       
-      @ContributesBinding(Any::class, priority = PRIORITY_HIGHEST)
+      @ContributesBinding(Any::class, rank = RANK_HIGHEST)
       interface ContributingInterface : ParentInterface
       
-      @ContributesBinding(Any::class, priority = PRIORITY_HIGH)
+      @ContributesBinding(Any::class, rank = RANK_HIGH)
       interface ContributingInterface2 : ParentInterface
       
       @ContributesBinding(Any::class)

--- a/compiler/src/test/java/com/squareup/anvil/compiler/codegen/ContributesBindingGeneratorTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/codegen/ContributesBindingGeneratorTest.kt
@@ -615,30 +615,31 @@ class ContributesBindingGeneratorTest : AnvilCompilationModeTest(
       interface ParentInterface2
 
       @ContributesBinding(Any::class, boundType = ParentInterface1::class) // Default case is NORMAL
-      @ContributesBinding(Any::class, boundType = ParentInterface2::class, priority = ContributesBinding.PRIORITY_NORMAL)
-      @ContributesBinding(Unit::class, boundType = ParentInterface1::class, priority = ContributesBinding.PRIORITY_HIGH)
-      @ContributesBinding(Unit::class, boundType = ParentInterface2::class, priority = ContributesBinding.PRIORITY_HIGHEST)
+      @ContributesBinding(Any::class, boundType = ParentInterface2::class, priority = ContributesBinding.Priority.NORMAL)
+      @ContributesBinding(Unit::class, boundType = ParentInterface1::class, priority = ContributesBinding.Priority.HIGH)
+      @ContributesBinding(Unit::class, boundType = ParentInterface2::class, priority = ContributesBinding.Priority.HIGHEST)
       class ContributingInterface : ParentInterface1, ParentInterface2
       """,
       mode = mode,
+      allWarningsAsErrors = false,
     ) {
       val bindingModules = contributingInterface.generatedBindingModules()
         .associate { clazz ->
           val bindingMarker = clazz.getAnnotation(InternalBindingMarker::class.java)
-          clazz.simpleName to bindingMarker.priority
+          clazz.simpleName to bindingMarker.rank
         }
       assertThat(
         bindingModules["ContributingInterfaceAsComSquareupTestParentInterface1ToKotlinAnyBindingModule"],
-      ).isEqualTo(ContributesBinding.PRIORITY_NORMAL)
+      ).isEqualTo(ContributesBinding.RANK_NORMAL)
       assertThat(
         bindingModules["ContributingInterfaceAsComSquareupTestParentInterface2ToKotlinAnyBindingModule"],
-      ).isEqualTo(ContributesBinding.PRIORITY_NORMAL)
+      ).isEqualTo(ContributesBinding.RANK_NORMAL)
       assertThat(
         bindingModules["ContributingInterfaceAsComSquareupTestParentInterface1ToKotlinUnitBindingModule"],
-      ).isEqualTo(ContributesBinding.PRIORITY_HIGH)
+      ).isEqualTo(ContributesBinding.RANK_HIGH)
       assertThat(
         bindingModules["ContributingInterfaceAsComSquareupTestParentInterface2ToKotlinUnitBindingModule"],
-      ).isEqualTo(ContributesBinding.PRIORITY_HIGHEST)
+      ).isEqualTo(ContributesBinding.RANK_HIGHEST)
     }
   }
 

--- a/integration-tests/library/src/main/java/com/squareup/anvil/test/PriorityBindings.kt
+++ b/integration-tests/library/src/main/java/com/squareup/anvil/test/PriorityBindings.kt
@@ -1,15 +1,15 @@
 package com.squareup.anvil.test
 
 import com.squareup.anvil.annotations.ContributesBinding
-import com.squareup.anvil.annotations.ContributesBinding.Companion.PRIORITY_HIGH
+import com.squareup.anvil.annotations.ContributesBinding.Companion.RANK_HIGH
 
-public interface PriorityBinding
+public interface RankBinding
 
 @ContributesBinding(
   scope = AppScope::class,
-  priority = PRIORITY_HIGH,
+  rank = RANK_HIGH,
 )
-public object PriorityBindingHigh : PriorityBinding
+public object RankBindingHigh : RankBinding
 
 @ContributesBinding(AppScope::class)
-public object PriorityBindingNormal : PriorityBinding
+public object RankBindingNormal : RankBinding

--- a/integration-tests/tests/src/test/java/com/squareup/anvil/test/MergeComponentTest.kt
+++ b/integration-tests/tests/src/test/java/com/squareup/anvil/test/MergeComponentTest.kt
@@ -69,9 +69,9 @@ internal class MergeComponentTest {
     )
   }
 
-  @Test fun `the binding with the highest priority is bound`() {
+  @Test fun `the binding with the highest rank is bound`() {
     val appComponent = DaggerMergeComponentTest_AppComponent.create()
-    assertThat(appComponent.priorityBinding()).isEqualTo(PriorityBindingHigh)
+    assertThat(appComponent.priorityBinding()).isEqualTo(RankBindingHigh)
   }
 
   @MergeComponent(AppScope::class)
@@ -91,7 +91,7 @@ internal class MergeComponentTest {
 
     @Named("def")
     fun mapBindingsWrappedNamed(): Map<WrappedBindingKey, ParentType>
-    fun priorityBinding(): PriorityBinding
+    fun priorityBinding(): RankBinding
   }
 
   @MergeSubcomponent(SubScope::class)


### PR DESCRIPTION
This makes the broader `enum` -> `Int` change source-compatible.

The IDE's auto-replace only partly works, because the deprecated `ContributesBinding.priority` parameter only works as documentation. Devs can auto-replace the enum entry with the corresponding integer, but if they're using a named argument, it will wind up with something like `priority = RANK_NORMAL`.