### PR TITLE
Set branch-specific SNAPSHOT version names in non-main snapshot releases

### DIFF
--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -14,6 +14,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+
+      - name: Set version for non-main branch
+        if: ${{ github.ref_name != 'main' && !startsWith(github.ref, 'refs/tags/') }}
+        run: |
+          echo "ORG_GRADLE_PROJECT_VERION_NAME=${{ github.ref_name }}-SNAPSHOT" | sed 's/\//-/g' >> $GITHUB_ENV
+
       - uses: gradle/actions/wrapper-validation@6cec5d49d4d6d4bb982fbed7047db31ea6d38f11 # v3
       - uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4
         with:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -24,7 +24,12 @@
 
 # Snapshot Releases
 
-Snapshot releases are automatically created whenever a commit to the `main` branch is pushed.  
+Snapshot releases are automatically created whenever a commit to the `main` branch is pushed.
+
+For other branches, maintainers can manually trigger a snapshot release from
+the [publish-snapshot](https://github.com/square/anvil/actions/workflows/publish-snapshot.yml)
+workflow. The version of that snapshot corresponds to the branch name. For example, a branch
+named `feature/branch` will have a snapshot version of `feature-branch-SNAPSHOT`.
 
 # Manually uploading a release
 


### PR DESCRIPTION
The suggestion came from @gabrielittner here: https://github.com/square/anvil/pull/866#discussion_r1484817963