### PR TITLE
handle GitHub's switch to M1 macs for `macos-latest` runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,7 +220,7 @@ jobs:
 
   instrumentation-tests:
     name: Instrumentation tests
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:
       # Allow tests to continue on other devices if they fail on one device.
@@ -238,23 +238,57 @@ jobs:
           java-version: '17'
           check-latest: true
 
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: AVD cache
+        uses: actions/cache/save@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+        id: avd-cache
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-${{ matrix.api-level }}
+
+      - name: create AVD and generate snapshot for caching
+        if: steps.avd-cache.outputs.cache-hit != 'true'
+        uses: reactivecircus/android-emulator-runner@6b0df4b0efb23bb0ec63d881db79aefbc976e4b2 # v2
+        with:
+          api-level: ${{ matrix.api-level }}
+          arch: x86_64
+          disable-animations: false
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          force-avd-creation: false
+          profile : Galaxy Nexus
+          ram-size : 4096M
+          target: default
+          script: echo "Generated AVD snapshot for caching."
+
       - name: Instrumentation Tests
         uses: reactivecircus/android-emulator-runner@6b0df4b0efb23bb0ec63d881db79aefbc976e4b2 # v2
         with:
           api-level: ${{ matrix.api-level }}
-          target: default
           arch: x86_64
+          disable-animations: true
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          force-avd-creation: false
+          profile : Galaxy Nexus
+          ram-size : 4096M
+          target: default
           script: ./gradlew connectedCheck --no-build-cache --no-daemon --stacktrace
 
       - name: Upload results
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4
         with:
-          name: insrumentation-test-results
+          name: instrumentation-test-results
           path: ./**/build/reports/androidTests/connected/**
 
   gradle-integration-tests:
     name: Gradle integration tests
-    runs-on: macos-14
+    runs-on: macos-latest
     timeout-minutes: 25
 
     steps:


### PR DESCRIPTION
M1 runners now seem to be the default for `macos-latest`:

[CI run](https://github.com/square/anvil/actions/runs/8808676517/job/24199009273?pr=979)
[logs](https://productionresultssa9.blob.core.windows.net/actions-results/c4ab73b8-2cb0-45d4-9053-d27cbdebbec4/workflow-job-run-e63755f8-096f-5d22-f83b-af41e271b2be/logs/job/job-logs.txt?rsct=text%2Fplain&se=2024-04-24T15%3A17%3A59Z&sig=S0BML9se1w5EGdNwc7rHup6Bur00%2B3qCkgYdCmc3OGo%3D&sp=r&spr=https&sr=b&st=2024-04-24T15%3A07%3A54Z&sv=2021-12-02)

```
Current runner version: '2.315.0'
Operating System
  macOS
  14.4.1
  23E224
Runner Image
  Image: macos-14-arm64
  Version: 20240415.6
  Included Software: https://github.com/actions/runner-images/blob/macos-14-arm64/20240415.6/images/macos/macos-14-arm64-Readme.md
  Image Release: https://github.com/actions/runner-images/releases/tag/macos-14-arm64%2F20240415.6
```

The x86_64 emulators don't work, naturally, but we can now enable virtualization on the ubuntu runners.  Enabling virtualization removes the longstanding requirement of using MacOS runners.