### PR TITLE
Fix dagger-compiler lookup in useKsp()

### DIFF
--- a/gradle-plugin/src/main/java/com/squareup/anvil/plugin/AnvilExtension.kt
+++ b/gradle-plugin/src/main/java/com/squareup/anvil/plugin/AnvilExtension.kt
@@ -207,7 +207,14 @@ public abstract class AnvilExtension @Inject constructor(
         .filter { it.isSupportedType() }
         .any { target ->
           target.compilations.any { c ->
-            c.kspConfigOrNull(project)?.hasDaggerCompilerDependency() == true
+            val targetConfig = if (componentMerging) {
+              // Look for dagger-compiiler in the ksp config
+              c.kspConfigOrNull(project)
+            } else {
+              // Assume they're using kapt for dagger-compiler in this case
+              c.kaptConfigOrNull(project)
+            }
+            targetConfig?.hasDaggerCompilerDependency() == true
           }
         }
     }


### PR DESCRIPTION
When not using KSP for component merging, we should look in the kapt configuration instead of KSP for the dagger-compiler dep.