### PR TITLE
Implement contribution merging in KSP

### DIFF
--- a/compiler-api/api/compiler-api.api
+++ b/compiler-api/api/compiler-api.api
@@ -39,6 +39,7 @@ public final class com/squareup/anvil/compiler/api/AnvilCompilationException$Com
 }
 
 public abstract interface class com/squareup/anvil/compiler/api/AnvilContext {
+	public abstract fun getComponentMergingBackend ()Lcom/squareup/anvil/compiler/api/ComponentMergingBackend;
 	public abstract fun getDisableComponentMerging ()Z
 	public abstract fun getGenerateFactories ()Z
 	public abstract fun getGenerateFactoriesOnly ()Z
@@ -59,11 +60,16 @@ public final class com/squareup/anvil/compiler/api/CodeGeneratorKt {
 }
 
 public final class com/squareup/anvil/compiler/api/ComponentMergingBackend : java/lang/Enum {
+	public static final field Companion Lcom/squareup/anvil/compiler/api/ComponentMergingBackend$Companion;
 	public static final field IR Lcom/squareup/anvil/compiler/api/ComponentMergingBackend;
 	public static final field KSP Lcom/squareup/anvil/compiler/api/ComponentMergingBackend;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lcom/squareup/anvil/compiler/api/ComponentMergingBackend;
 	public static fun values ()[Lcom/squareup/anvil/compiler/api/ComponentMergingBackend;
+}
+
+public final class com/squareup/anvil/compiler/api/ComponentMergingBackend$Companion {
+	public final fun fromString (Ljava/lang/String;)Lcom/squareup/anvil/compiler/api/ComponentMergingBackend;
 }
 
 public abstract interface class com/squareup/anvil/compiler/api/FileWithContent : java/lang/Comparable {

--- a/compiler-api/src/main/java/com/squareup/anvil/compiler/api/AnvilApplicabilityChecker.kt
+++ b/compiler-api/src/main/java/com/squareup/anvil/compiler/api/AnvilApplicabilityChecker.kt
@@ -1,6 +1,6 @@
 package com.squareup.anvil.compiler.api
 
-public interface AnvilApplicabilityChecker {
+public fun interface AnvilApplicabilityChecker {
   /**
    * Returns true if this code generator is applicable for the given [context] or false if not. This
    * will only be called _once_.

--- a/compiler-api/src/main/java/com/squareup/anvil/compiler/api/AnvilContext.kt
+++ b/compiler-api/src/main/java/com/squareup/anvil/compiler/api/AnvilContext.kt
@@ -65,6 +65,12 @@ public interface AnvilContext {
   public val willHaveDaggerFactories: Boolean
 
   /**
+   * The backend that should be used for component merging. This is only relevant if component
+   * merging is not disabled (i.e. [disableComponentMerging] is false).
+   */
+  public val componentMergingBackend: ComponentMergingBackend
+
+  /**
    * The module of the current compilation.
    */
   public val module: ModuleDescriptor

--- a/compiler-api/src/main/java/com/squareup/anvil/compiler/api/ComponentMergingBackend.kt
+++ b/compiler-api/src/main/java/com/squareup/anvil/compiler/api/ComponentMergingBackend.kt
@@ -1,5 +1,7 @@
 package com.squareup.anvil.compiler.api
 
+import java.util.Locale
+
 /** Possible modes of component merging. */
 public enum class ComponentMergingBackend {
   /** Component merging runs as an IR plugin during kapt stub generation. */
@@ -7,4 +9,13 @@ public enum class ComponentMergingBackend {
 
   /** Component merging runs as a Kotlin Symbol Processor (KSP) with dagger KSP. */
   KSP,
+
+  ;
+
+  public companion object {
+    public fun fromString(value: String): ComponentMergingBackend? {
+      val uppercase = value.uppercase(Locale.US)
+      return ComponentMergingBackend.entries.find { it.name == uppercase }
+    }
+  }
 }

--- a/compiler/src/main/java/com/squareup/anvil/compiler/AnvilComponentRegistrar.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/AnvilComponentRegistrar.kt
@@ -54,7 +54,7 @@ public class AnvilComponentRegistrar : ComponentRegistrar {
           IrContributionMerger(scanner, moduleDescriptorFactory),
         )
       } else {
-        // TODO in dagger-ksp support
+        // KSP support is all wired up at the Gradle level, nothing to do here
       }
     }
 

--- a/compiler/src/main/java/com/squareup/anvil/compiler/ClassScannerKsp.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/ClassScannerKsp.kt
@@ -1,0 +1,121 @@
+package com.squareup.anvil.compiler
+
+import com.google.devtools.ksp.KspExperimental
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSPropertyDeclaration
+import com.google.devtools.ksp.symbol.KSType
+import com.squareup.anvil.compiler.ClassScannerKsp.GeneratedProperty.ReferenceProperty
+import com.squareup.anvil.compiler.ClassScannerKsp.GeneratedProperty.ScopeProperty
+import com.squareup.anvil.compiler.api.AnvilCompilationException
+import com.squareup.anvil.compiler.codegen.ksp.resolveKSClassDeclaration
+import com.squareup.anvil.compiler.codegen.ksp.scope
+import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.ksp.toClassName
+import org.jetbrains.kotlin.name.FqName
+
+internal class ClassScannerKsp {
+
+  private val cache = mutableMapOf<CacheKey, Collection<List<GeneratedProperty>>>()
+
+  /**
+   * Returns a sequence of contributed classes from the dependency graph. Note that the result
+   * includes inner classes already.
+   */
+  @OptIn(KspExperimental::class)
+  fun findContributedClasses(
+    resolver: Resolver,
+    annotation: FqName,
+    scope: KSType?,
+  ): Sequence<KSClassDeclaration> {
+    val propertyGroups: Collection<List<GeneratedProperty>> =
+      cache.getOrPut(CacheKey(annotation, resolver.hashCode())) {
+        resolver.getDeclarationsFromPackage(HINT_PACKAGE)
+          .filterIsInstance<KSPropertyDeclaration>()
+          .mapNotNull { GeneratedProperty.from(it) }
+          .groupBy { property -> property.baseName }
+          .values
+      }
+
+    return propertyGroups
+      .asSequence()
+      .mapNotNull { properties ->
+        val reference = properties.filterIsInstance<ReferenceProperty>()
+          // In some rare cases we can see a generated property for the same identifier.
+          // Filter them just in case, see https://github.com/square/anvil/issues/460 and
+          // https://github.com/square/anvil/issues/565
+          .distinctBy { it.baseName }
+          .singleOrEmpty()
+          ?: throw AnvilCompilationException(
+            message = "Couldn't find the reference for a generated hint: ${properties[0].baseName}.",
+          )
+
+        val scopes = properties.filterIsInstance<ScopeProperty>()
+          .ifEmpty {
+            throw AnvilCompilationException(
+              message = "Couldn't find any scope for a generated hint: ${properties[0].baseName}.",
+            )
+          }
+          .map { it.declaration.type.resolve() }
+
+        // Look for the right scope even before resolving the class and resolving all its super
+        // types.
+        if (scope != null && scope !in scopes) return@mapNotNull null
+
+        reference.declaration.type
+          .resolve().resolveKSClassDeclaration()
+      }
+      .filter { clazz ->
+        // Check that the annotation really is present. It should always be the case, but it's
+        // a safetynet in case the generated properties are out of sync.
+        clazz.annotations.any {
+          it.annotationType.resolve() == annotation && (scope == null || it.scope() == scope)
+        }
+      }
+  }
+
+  private sealed class GeneratedProperty(
+    val declaration: KSPropertyDeclaration,
+    val baseName: String,
+  ) {
+    class ReferenceProperty(
+      declaration: KSPropertyDeclaration,
+      baseName: String,
+    ) : GeneratedProperty(declaration, baseName)
+
+    class ScopeProperty(
+      declaration: KSPropertyDeclaration,
+      baseName: String,
+    ) : GeneratedProperty(declaration, baseName)
+
+    companion object {
+      fun from(declaration: KSPropertyDeclaration): GeneratedProperty? {
+        // For each contributed hint there are several properties, e.g. the reference itself
+        // and the scopes. Group them by their common name without the suffix.
+        val name = declaration.simpleName.asString()
+
+        return when {
+          name.endsWith(REFERENCE_SUFFIX) ->
+            ReferenceProperty(declaration, name.substringBeforeLast(REFERENCE_SUFFIX))
+          name.contains(SCOPE_SUFFIX) -> {
+            // The old scope hint didn't have a number. Now that there can be multiple scopes
+            // we append a number for all scopes, but we still need to support the old format.
+            val indexString = name.substringAfterLast(SCOPE_SUFFIX)
+            if (indexString.toIntOrNull() != null || indexString.isEmpty()) {
+              ScopeProperty(declaration, name.substringBeforeLast(SCOPE_SUFFIX))
+            } else {
+              null
+            }
+          }
+          else -> null
+        }
+      }
+    }
+  }
+
+  private data class CacheKey(
+    val fqName: FqName,
+    val resolverHash: Int,
+  )
+}
+

--- a/compiler/src/main/java/com/squareup/anvil/compiler/ClassScannerKsp.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/ClassScannerKsp.kt
@@ -10,8 +10,6 @@ import com.squareup.anvil.compiler.ClassScannerKsp.GeneratedProperty.ScopeProper
 import com.squareup.anvil.compiler.api.AnvilCompilationException
 import com.squareup.anvil.compiler.codegen.ksp.resolveKSClassDeclaration
 import com.squareup.anvil.compiler.codegen.ksp.scope
-import com.squareup.kotlinpoet.ClassName
-import com.squareup.kotlinpoet.ksp.toClassName
 import org.jetbrains.kotlin.name.FqName
 
 internal class ClassScannerKsp {
@@ -118,4 +116,3 @@ internal class ClassScannerKsp {
     val resolverHash: Int,
   )
 }
-

--- a/compiler/src/main/java/com/squareup/anvil/compiler/ClassScannerKsp.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/ClassScannerKsp.kt
@@ -10,6 +10,7 @@ import com.squareup.anvil.compiler.ClassScannerKsp.GeneratedProperty.ScopeProper
 import com.squareup.anvil.compiler.api.AnvilCompilationException
 import com.squareup.anvil.compiler.codegen.ksp.resolveKSClassDeclaration
 import com.squareup.anvil.compiler.codegen.ksp.scope
+import com.squareup.kotlinpoet.ksp.toClassName
 import org.jetbrains.kotlin.name.FqName
 
 internal class ClassScannerKsp {
@@ -67,7 +68,7 @@ internal class ClassScannerKsp {
         // Check that the annotation really is present. It should always be the case, but it's
         // a safetynet in case the generated properties are out of sync.
         clazz.annotations.any {
-          it.annotationType.resolve() == annotation && (scope == null || it.scope() == scope)
+          it.annotationType.resolve().toClassName().fqName == annotation && (scope == null || it.scope() == scope)
         }
       }
   }

--- a/compiler/src/main/java/com/squareup/anvil/compiler/CommandLineOptions.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/CommandLineOptions.kt
@@ -36,10 +36,7 @@ public class CommandLineOptions private constructor(
 
     private fun CompilerConfiguration.parseComponentMergingBackend(): ComponentMergingBackend {
       val config = get(mergingBackendKey, ComponentMergingBackend.IR.name)
-      return config
-        .uppercase(Locale.US)
-        .let { value -> ComponentMergingBackend.entries.find { it.name == value } }
-        ?: error("Unknown backend option: '$config'")
+      return ComponentMergingBackend.fromString(config) ?: error("Unknown backend option: '$config'")
     }
   }
 }

--- a/compiler/src/main/java/com/squareup/anvil/compiler/ContributedBinding.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/ContributedBinding.kt
@@ -15,12 +15,13 @@ import com.squareup.anvil.compiler.internal.reference.ClassReference
 import com.squareup.anvil.compiler.internal.reference.ClassReference.Descriptor
 import com.squareup.anvil.compiler.internal.reference.ClassReference.Psi
 import com.squareup.anvil.compiler.internal.requireFqName
+import com.squareup.kotlinpoet.ClassName
 import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
 import org.jetbrains.kotlin.types.KotlinType
 
-private typealias Scope = ClassReferenceIr
-private typealias BindingModule = ClassReferenceIr
-private typealias OriginClass = ClassReferenceIr
+private typealias Scope = ClassName
+private typealias BindingModule = ClassName
+private typealias OriginClass = ClassName
 
 internal data class BindingKey<T>(
   val scope: Scope,
@@ -109,10 +110,9 @@ internal data class ContributedBinding<T>(
   val boundType: T,
   val qualifierKey: String,
   val rank: Int,
+  val replaces: List<ClassName>
 ) {
   val bindingKey = BindingKey(scope, boundType, qualifierKey)
-  val replaces = bindingModule.annotations.find(contributesToFqName).single()
-    .replacedClasses
 }
 
 internal fun List<ContributedBinding<*>>.findHighestPriorityBinding(): ContributedBinding<*> {
@@ -132,7 +132,7 @@ internal fun List<ContributedBinding<*>>.findHighestPriorityBinding(): Contribut
         bindings.joinToString(
           prefix = "[",
           postfix = "]",
-        ) { it.originClass.fqName.asString() }
+        ) { it.originClass.canonicalName }
     }
 
     when (boundType) {

--- a/compiler/src/main/java/com/squareup/anvil/compiler/ContributedBinding.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/ContributedBinding.kt
@@ -9,7 +9,6 @@ import com.squareup.anvil.compiler.codegen.ksp.KspAnvilException
 import com.squareup.anvil.compiler.codegen.ksp.resolveKSClassDeclaration
 import com.squareup.anvil.compiler.codegen.reference.AnvilCompilationExceptionClassReferenceIr
 import com.squareup.anvil.compiler.codegen.reference.ClassReferenceIr
-import com.squareup.anvil.compiler.codegen.reference.find
 import com.squareup.anvil.compiler.internal.reference.AnnotationReference
 import com.squareup.anvil.compiler.internal.reference.ClassReference
 import com.squareup.anvil.compiler.internal.reference.ClassReference.Descriptor
@@ -110,7 +109,7 @@ internal data class ContributedBinding<T>(
   val boundType: T,
   val qualifierKey: String,
   val rank: Int,
-  val replaces: List<ClassName>
+  val replaces: List<ClassName>,
 ) {
   val bindingKey = BindingKey(scope, boundType, qualifierKey)
 }
@@ -128,7 +127,7 @@ internal fun List<ContributedBinding<*>>.findHighestPriorityBinding(): Contribut
     val boundType = bindings[0].boundType
     fun message(boundTypeName: String?): String {
       return "There are multiple contributed bindings with the same bound type and rank. The bound type is " +
-        "${boundTypeName}. The rank is $rankName. The contributed binding classes are: " +
+        "$boundTypeName. The rank is $rankName. The contributed binding classes are: " +
         bindings.joinToString(
           prefix = "[",
           postfix = "]",
@@ -145,7 +144,9 @@ internal fun List<ContributedBinding<*>>.findHighestPriorityBinding(): Contribut
       is KSTypeReference -> {
         throw KspAnvilException(
           node = boundType,
-          message = message(boundType.resolve().resolveKSClassDeclaration()?.qualifiedName?.asString()),
+          message = message(
+            boundType.resolve().resolveKSClassDeclaration()?.qualifiedName?.asString(),
+          ),
         )
       }
       else -> error("Not possible")

--- a/compiler/src/main/java/com/squareup/anvil/compiler/IrContributionMerger.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/IrContributionMerger.kt
@@ -280,7 +280,7 @@ internal class IrContributionMerger(
           rank = rank,
           replaces = moduleClass.annotations.find(contributesToFqName).single()
             .replacedClasses
-            .map { it.classId.asClassName() }
+            .map { it.classId.asClassName() },
         )
       }
       .let { ContributedBindings.from(it) }
@@ -307,7 +307,13 @@ internal class IrContributionMerger(
     val contributedModules = contributesAnnotations
       .asSequence()
       .map { it.declaringClass }
-      .plus(bindings.bindings.values.flatMap { it.values }.flatten().map { it.bindingModule }.map { pluginContext.requireReferenceClass(it.fqName).toClassReference(pluginContext) })
+      .plus(
+        bindings.bindings.values.flatMap {
+          it.values
+        }.flatten().map {
+          it.bindingModule
+        }.map { pluginContext.requireReferenceClass(it.fqName).toClassReference(pluginContext) },
+      )
       .minus(replacedModules)
       .minus(excludedModules)
       .plus(predefinedModules)

--- a/compiler/src/main/java/com/squareup/anvil/compiler/KspContributionMerger.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/KspContributionMerger.kt
@@ -583,6 +583,7 @@ internal class KspContributionMerger(override val env: SymbolProcessorEnvironmen
         val componentOrFactory = mergeAnnotatedClass.declarations
           .filterIsInstance<KSClassDeclaration>()
           .single {
+            // TODO does dagger also use these names? Or are they lowercase versions of the simple class name?
             if (it.isAnnotationPresent<Component.Factory>()) {
               factoryOrBuilderFunSpec = FunSpec.builder("factory")
                 .returns(generatedComponentClassName.nestedClass(it.simpleName.asString()))

--- a/compiler/src/main/java/com/squareup/anvil/compiler/KspContributionMerger.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/KspContributionMerger.kt
@@ -584,6 +584,7 @@ internal class KspContributionMerger(override val env: SymbolProcessorEnvironmen
           .filterIsInstance<KSClassDeclaration>()
           .single {
             // TODO does dagger also use these names? Or are they lowercase versions of the simple class name?
+            // TODO remap create() and build() return types to the generated component? Not sure what Dagger checks here.
             if (it.isAnnotationPresent<Component.Factory>()) {
               factoryOrBuilderFunSpec = FunSpec.builder("factory")
                 .returns(generatedComponentClassName.nestedClass(it.simpleName.asString()))

--- a/compiler/src/main/java/com/squareup/anvil/compiler/KspContributionMerger.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/KspContributionMerger.kt
@@ -1,0 +1,156 @@
+package com.squareup.anvil.compiler
+
+import com.google.auto.service.AutoService
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
+import com.google.devtools.ksp.processing.SymbolProcessorProvider
+import com.google.devtools.ksp.symbol.KSAnnotated
+import com.google.devtools.ksp.symbol.KSAnnotation
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.squareup.anvil.compiler.codegen.ksp.AnvilSymbolProcessor
+import com.squareup.anvil.compiler.codegen.ksp.AnvilSymbolProcessorProvider
+import com.squareup.anvil.compiler.codegen.ksp.KspAnvilException
+import com.squareup.anvil.compiler.codegen.ksp.findAll
+import com.squareup.anvil.compiler.codegen.ksp.getSymbolsWithAnnotations
+import com.squareup.anvil.compiler.codegen.ksp.isInterface
+import com.squareup.kotlinpoet.AnnotationSpec
+
+/**
+ * A [com.google.devtools.ksp.processing.SymbolProcessor] that performs the two types of merging
+ * Anvil supports.
+ *
+ * 1. **Module merging**: This step sources from `@MergeComponent`, `@MergeSubcomponent`, and
+ * `@MergeModules` to merge all contributed modules on the classpath to the generated element.
+ *
+ * 2. **Interface merging**: This step finds all contributed component interfaces and adds them
+ * as supertypes to generated Dagger components from interfaces annotated with `@MergeComponent`
+ * or `@MergeSubcomponent`. This also supports arbitrary interface merging on interfaces annotated
+ * with `@MergeInterfaces`.
+ */
+internal class KspContributionMerger(override val env: SymbolProcessorEnvironment) :
+  AnvilSymbolProcessor() {
+
+  @AutoService(SymbolProcessorProvider::class)
+  class Provider : AnvilSymbolProcessorProvider(
+    { context -> !context.disableComponentMerging && !context.generateFactories },
+    ::KspContributionMerger,
+  )
+
+  override fun processChecked(
+    resolver: Resolver
+  ): List<KSAnnotated> {
+    // TODO how do we ensure this runs last?
+    //  - run all other processors first?
+    //  - check no *Contributes symbols are left?
+
+    val deferred = resolver.getSymbolsWithAnnotations(
+      mergeComponentFqName,
+      mergeSubcomponentFqName,
+      mergeModulesFqName,
+      mergeInterfacesFqName,
+    ).validate { deferred -> return deferred }
+      .mapNotNull { annotated ->
+        processClass(resolver, annotated)
+      }
+
+    return deferred
+  }
+
+  /**
+   * Returns non-null if the given [annotated] could not be processed.
+   */
+  private fun processClass(
+    resolver: Resolver,
+    mergeAnnotatedClass: KSClassDeclaration
+  ): KSAnnotated? {
+    val mergeComponentAnnotations = mergeAnnotatedClass
+      .findAll(mergeComponentFqName, mergeSubcomponentFqName)
+
+    val mergeModulesAnnotations = mergeAnnotatedClass
+      .findAll(mergeModulesFqName)
+
+    val moduleMergerAnnotations = mergeComponentAnnotations + mergeModulesAnnotations
+
+    val daggerAnnotation = if (moduleMergerAnnotations.isNotEmpty()) {
+      generateDaggerAnnotation(
+        annotations = moduleMergerAnnotations,
+        resolver = resolver,
+        declaration = mergeAnnotatedClass,
+      )
+    } else {
+      null
+    }
+
+    val mergeInterfacesAnnotations = mergeAnnotatedClass
+      .findAll(mergeInterfacesFqName)
+
+    val interfaceMergerAnnotations = mergeComponentAnnotations + mergeInterfacesAnnotations
+
+    val contributedInterfaces = if (interfaceMergerAnnotations.isNotEmpty()) {
+      if (!mergeAnnotatedClass.isInterface()) {
+        throw KspAnvilException(
+          node = mergeAnnotatedClass,
+          message = "Dagger components (or classes annotated with @MergeInterfaces)" +
+            " must be interfaces.",
+        )
+      }
+
+      contributedInterfaces(
+        mergeAnnotations = interfaceMergerAnnotations,
+        resolver = resolver,
+        mergeAnnotatedClass = mergeAnnotatedClass,
+      )
+    } else {
+      null
+    }
+
+    if (contributedInterfaces != null || daggerAnnotation != null) {
+      generateMergedComponent(
+        mergeAnnotatedClass = mergeAnnotatedClass,
+        daggerAnnotation = daggerAnnotation,
+        contributedInterfaces = contributedInterfaces,
+        resolver = resolver,
+      )
+    }
+    return null
+  }
+
+  private fun generateDaggerAnnotation(
+    annotations: List<KSAnnotation>,
+    resolver: Resolver,
+    declaration: KSClassDeclaration,
+  ): AnnotationSpec {
+    TODO()
+  }
+
+  private fun contributedInterfaces(
+    mergeAnnotations: List<KSAnnotation>,
+    resolver: Resolver,
+    mergeAnnotatedClass: KSClassDeclaration,
+  ): List<KSClassDeclaration> {
+    TODO()
+  }
+
+  private fun generateMergedComponent(
+    mergeAnnotatedClass: KSClassDeclaration,
+    daggerAnnotation: AnnotationSpec?,
+    contributedInterfaces: List<KSClassDeclaration>?,
+    resolver: Resolver,
+  ) {
+    TODO()
+  }
+
+  private inline fun Sequence<KSAnnotated>.validate(
+    escape: (List<KSAnnotated>) -> Nothing
+  ): List<KSClassDeclaration> {
+    val (valid, deferred) = filterIsInstance<KSClassDeclaration>().partition { annotated ->
+      // TODO check error types in annotations props
+      !annotated.superTypes.any { it.resolve().isError }
+    }
+    return if (deferred.isNotEmpty()) {
+      escape(deferred)
+    } else {
+      valid
+    }
+  }
+}

--- a/compiler/src/main/java/com/squareup/anvil/compiler/KspContributionMerger.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/KspContributionMerger.kt
@@ -1,19 +1,37 @@
 package com.squareup.anvil.compiler
 
 import com.google.auto.service.AutoService
+import com.google.devtools.ksp.getAllSuperTypes
+import com.google.devtools.ksp.getVisibility
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
 import com.google.devtools.ksp.processing.SymbolProcessorProvider
+import com.google.devtools.ksp.processing.impl.KSNameImpl
 import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.KSAnnotation
 import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSName
+import com.google.devtools.ksp.symbol.KSType
+import com.google.devtools.ksp.symbol.Visibility
+import com.squareup.anvil.compiler.codegen.generatedAnvilSubcomponentClassId
 import com.squareup.anvil.compiler.codegen.ksp.AnvilSymbolProcessor
 import com.squareup.anvil.compiler.codegen.ksp.AnvilSymbolProcessorProvider
 import com.squareup.anvil.compiler.codegen.ksp.KspAnvilException
+import com.squareup.anvil.compiler.codegen.ksp.atLeastOneAnnotation
+import com.squareup.anvil.compiler.codegen.ksp.declaringClass
+import com.squareup.anvil.compiler.codegen.ksp.exclude
 import com.squareup.anvil.compiler.codegen.ksp.findAll
 import com.squareup.anvil.compiler.codegen.ksp.getSymbolsWithAnnotations
 import com.squareup.anvil.compiler.codegen.ksp.isInterface
+import com.squareup.anvil.compiler.codegen.ksp.parentScope
+import com.squareup.anvil.compiler.codegen.ksp.replaces
+import com.squareup.anvil.compiler.codegen.ksp.resolveKSClassDeclaration
+import com.squareup.anvil.compiler.codegen.ksp.scope
+import com.squareup.anvil.compiler.codegen.ksp.superTypesExcludingAny
+import com.squareup.anvil.compiler.internal.reference.asClassId
 import com.squareup.kotlinpoet.AnnotationSpec
+import com.squareup.kotlinpoet.ksp.toClassName
+import org.jetbrains.kotlin.name.Name
 
 /**
  * A [com.google.devtools.ksp.processing.SymbolProcessor] that performs the two types of merging
@@ -35,6 +53,8 @@ internal class KspContributionMerger(override val env: SymbolProcessorEnvironmen
     { context -> !context.disableComponentMerging && !context.generateFactories },
     ::KspContributionMerger,
   )
+
+  private val classScanner = ClassScannerKsp()
 
   override fun processChecked(
     resolver: Resolver
@@ -64,10 +84,10 @@ internal class KspContributionMerger(override val env: SymbolProcessorEnvironmen
     mergeAnnotatedClass: KSClassDeclaration
   ): KSAnnotated? {
     val mergeComponentAnnotations = mergeAnnotatedClass
-      .findAll(mergeComponentFqName, mergeSubcomponentFqName)
+      .findAll(mergeComponentFqName.asString(), mergeSubcomponentFqName.asString())
 
     val mergeModulesAnnotations = mergeAnnotatedClass
-      .findAll(mergeModulesFqName)
+      .findAll(mergeModulesFqName.asString())
 
     val moduleMergerAnnotations = mergeComponentAnnotations + mergeModulesAnnotations
 
@@ -82,7 +102,7 @@ internal class KspContributionMerger(override val env: SymbolProcessorEnvironmen
     }
 
     val mergeInterfacesAnnotations = mergeAnnotatedClass
-      .findAll(mergeInterfacesFqName)
+      .findAll(mergeInterfacesFqName.asString())
 
     val interfaceMergerAnnotations = mergeComponentAnnotations + mergeInterfacesAnnotations
 
@@ -127,14 +147,171 @@ internal class KspContributionMerger(override val env: SymbolProcessorEnvironmen
     mergeAnnotations: List<KSAnnotation>,
     resolver: Resolver,
     mergeAnnotatedClass: KSClassDeclaration,
-  ): List<KSClassDeclaration> {
-    TODO()
+  ): List<KSType> {
+    val scopes = mergeAnnotations.map { it.scope() }
+    val contributesAnnotations = mergeAnnotations
+      .flatMap { annotation ->
+        classScanner
+          .findContributedClasses(
+            resolver = resolver,
+            annotation = contributesToFqName,
+            scope = annotation.scope(),
+          )
+      }
+      .asSequence()
+      .filter { clazz ->
+        clazz.isInterface() && clazz.findAll(daggerModuleFqName.asString()).singleOrNull() == null
+      }
+      .flatMap { clazz ->
+        clazz
+          .findAll(contributesToFqName.asString())
+          .filter { it.scope() in scopes }
+      }
+      .onEach { contributeAnnotation ->
+        val contributedClass = contributeAnnotation.declaringClass
+        if (contributedClass.getVisibility() != Visibility.PUBLIC) {
+          throw KspAnvilException(
+            node = contributedClass,
+            message = "${contributedClass.qualifiedName?.asString()} is contributed to the Dagger graph, but the " +
+              "interface is not public. Only public interfaces are supported.",
+          )
+        }
+      }
+      // Convert the sequence to a list to avoid iterating it twice. We use the result twice
+      // for replaced classes and the final result.
+      .toList()
+
+    val replacedClasses = contributesAnnotations
+      .flatMap { contributeAnnotation ->
+        val contributedClass = contributeAnnotation.declaringClass
+        contributedClass
+          .atLeastOneAnnotation(
+            contributeAnnotation.annotationType.resolve()
+              .resolveKSClassDeclaration()!!.qualifiedName!!.asString(),
+          )
+          .asSequence()
+          .flatMap { it.replaces() }
+          .onEach { classToReplace ->
+            // Verify the other class is an interface. It doesn't make sense for a contributed
+            // interface to replace a class that is not an interface.
+            if (!classToReplace.isInterface()) {
+              throw KspAnvilException(
+                node = contributedClass,
+                message = "${contributedClass.qualifiedName?.asString()} wants to replace " +
+                  "${classToReplace.qualifiedName?.asString()}, but the class being " +
+                  "replaced is not an interface.",
+              )
+            }
+
+            val contributesToOurScope = classToReplace
+              .findAll(
+                contributesToFqName.asString(),
+                contributesBindingFqName.asString(),
+                contributesMultibindingFqName.asString(),
+              )
+              .map { it.scope() }
+              .any { scope -> scope in scopes }
+
+            if (!contributesToOurScope) {
+              throw KspAnvilException(
+                node = contributedClass,
+                message = "${contributedClass.qualifiedName?.asString()} with scopes " +
+                  "${
+                    scopes.joinToString(
+                      prefix = "[",
+                      postfix = "]",
+                    ) { it.resolveKSClassDeclaration()?.qualifiedName?.asString()!! }
+                  } " +
+                  "wants to replace ${classToReplace.qualifiedName?.asString()}, but the replaced class isn't " +
+                  "contributed to the same scope.",
+              )
+            }
+          }
+      }
+      .toSet()
+
+    val excludedClasses = mergeAnnotations
+      .asSequence()
+      .flatMap { it.exclude() }
+      .filter { it.isInterface() }
+      .onEach { excludedClass ->
+        // Verify that the replaced classes use the same scope.
+        val contributesToOurScope = excludedClass
+          .findAll(
+            contributesToFqName.asString(),
+            contributesBindingFqName.asString(),
+            contributesMultibindingFqName.asString(),
+          )
+          .map { it.scope() }
+          .plus(
+            excludedClass.findAll(contributesSubcomponentFqName.asString())
+              .map { it.parentScope() },
+          )
+          .any { scope -> scope in scopes }
+
+        if (!contributesToOurScope) {
+          throw KspAnvilException(
+            message = "${mergeAnnotatedClass.qualifiedName?.asString()} with scopes " +
+              "${
+                scopes.joinToString(
+                  prefix = "[",
+                  postfix = "]",
+                ) { it.resolveKSClassDeclaration()?.qualifiedName?.asString()!! }
+              } " +
+              "wants to exclude ${excludedClass.qualifiedName?.asString()}, but the excluded class isn't " +
+              "contributed to the same scope.",
+            node = mergeAnnotatedClass,
+          )
+        }
+      }
+      .toList()
+
+    val supertypes = mergeAnnotatedClass.superTypesExcludingAny(resolver)
+    if (excludedClasses.isNotEmpty()) {
+      val intersect = supertypes
+        .mapNotNull { it.resolve().resolveKSClassDeclaration() }
+        .flatMap {
+          it.getAllSuperTypes()
+        }
+        .mapNotNull { it.resolveKSClassDeclaration() }
+        .toSet()
+        .intersect(excludedClasses.toSet())
+
+      if (intersect.isNotEmpty()) {
+        throw KspAnvilException(
+          node = mergeAnnotatedClass,
+          message = "${mergeAnnotatedClass.qualifiedName?.asString()} excludes types that it implements or " +
+            "extends. These types cannot be excluded. Look at all the super types to find these " +
+            "classes: ${intersect.joinToString { it.qualifiedName?.asString()!! }}.",
+        )
+      }
+    }
+
+    val supertypesToAdd = contributesAnnotations
+      .asSequence()
+      .map { it.declaringClass }
+      .filter { clazz ->
+        clazz !in replacedClasses && clazz !in excludedClasses
+      }
+      .plus(
+        findContributedSubcomponentParentInterfaces(
+          clazz = mergeAnnotatedClass,
+          scopes = scopes,
+          resolver = resolver,
+        ),
+      )
+      // Avoids an error for repeated interfaces.
+      .distinct()
+      .map { it.asType(emptyList()) }
+      .toList()
+
+    return supertypesToAdd
   }
 
   private fun generateMergedComponent(
     mergeAnnotatedClass: KSClassDeclaration,
     daggerAnnotation: AnnotationSpec?,
-    contributedInterfaces: List<KSClassDeclaration>?,
+    contributedInterfaces: List<KSType>?,
     resolver: Resolver,
   ) {
     TODO()
@@ -152,5 +329,35 @@ internal class KspContributionMerger(override val env: SymbolProcessorEnvironmen
     } else {
       valid
     }
+  }
+
+  private fun findContributedSubcomponentParentInterfaces(
+    clazz: KSClassDeclaration,
+    scopes: Collection<KSType>,
+    resolver: Resolver,
+  ): Sequence<KSClassDeclaration> {
+    return classScanner
+      .findContributedClasses(
+        resolver = resolver,
+        annotation = contributesSubcomponentFqName,
+        scope = null,
+      )
+      .filter {
+        it.atLeastOneAnnotation(contributesSubcomponentFqName.asString()).single()
+          .parentScope().asType(emptyList()) in scopes
+      }
+      .mapNotNull { contributedSubcomponent ->
+        contributedSubcomponent.toClassName().asClassId()
+          .generatedAnvilSubcomponentClassId(clazz.toClassName().asClassId())
+          .createNestedClassId(Name.identifier(PARENT_COMPONENT))
+          .let { classId ->
+            resolver.getClassDeclarationByName(
+              resolver.getKSNameFromString(
+                classId.asSingleFqName()
+                  .toString(),
+              ),
+            )
+          }
+      }
   }
 }

--- a/compiler/src/main/java/com/squareup/anvil/compiler/KspContributionMerger.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/KspContributionMerger.kt
@@ -142,13 +142,11 @@ internal class KspContributionMerger(override val env: SymbolProcessorEnvironmen
       null
     }
 
-    if (contributedInterfaces != null || daggerAnnotation != null) {
-      generateMergedComponent(
-        mergeAnnotatedClass = mergeAnnotatedClass,
-        daggerAnnotation = daggerAnnotation,
-        contributedInterfaces = contributedInterfaces,
-      )
-    }
+    generateMergedComponent(
+      mergeAnnotatedClass = mergeAnnotatedClass,
+      daggerAnnotation = daggerAnnotation,
+      contributedInterfaces = contributedInterfaces,
+    )
     return null
   }
 
@@ -575,6 +573,7 @@ internal class KspContributionMerger(override val env: SymbolProcessorEnvironmen
       "Anvil${mergeAnnotatedClass.simpleName.asString().capitalize()}",
     )
       .apply {
+        addSuperinterface(mergeAnnotatedClass.toClassName())
         daggerAnnotation?.let { addAnnotation(it) }
 
         contributedInterfaces?.forEach { contributedInterface ->

--- a/compiler/src/main/java/com/squareup/anvil/compiler/KspContributionMerger.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/KspContributionMerger.kt
@@ -99,7 +99,7 @@ internal class KspContributionMerger(override val env: SymbolProcessorEnvironmen
   }
 
   /**
-   * Returns non-null if the given [annotated] could not be processed.
+   * Returns non-null if the given [mergeAnnotatedClass] could not be processed.
    */
   private fun processClass(
     resolver: Resolver,

--- a/compiler/src/main/java/com/squareup/anvil/compiler/KspContributionMerger.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/KspContributionMerger.kt
@@ -586,7 +586,7 @@ internal class KspContributionMerger(override val env: SymbolProcessorEnvironmen
 
         val componentOrFactory = mergeAnnotatedClass.declarations
           .filterIsInstance<KSClassDeclaration>()
-          .single {
+          .singleOrNull {
             // TODO does dagger also use these names? Or are they lowercase versions of the simple class name?
             if (it.isAnnotationPresent<Component.Factory>()) {
               factoryOrBuilderFunSpec = FunSpec.builder("factory")
@@ -595,7 +595,7 @@ internal class KspContributionMerger(override val env: SymbolProcessorEnvironmen
                   "return Dagger${mergeAnnotatedClass.simpleName.asString().capitalize()}.factory()",
                 )
                 .build()
-              return@single true
+              return@singleOrNull true
             }
             if (it.isAnnotationPresent<Component.Builder>()) {
               factoryOrBuilderFunSpec = FunSpec.builder("builder")
@@ -604,16 +604,18 @@ internal class KspContributionMerger(override val env: SymbolProcessorEnvironmen
                   "return Dagger${mergeAnnotatedClass.simpleName.asString().capitalize()}.builder()",
                 )
                 .build()
-              return@single true
+              return@singleOrNull true
             }
             false
           }
 
-        val factoryOrBuilder = componentOrFactory.extendFactoryOrBuilder(
-          mergeAnnotatedClass.toClassName(),
-          generatedComponentClassName,
-        )
-        addType(factoryOrBuilder)
+        componentOrFactory?.let {
+          val factoryOrBuilder = it.extendFactoryOrBuilder(
+            mergeAnnotatedClass.toClassName(),
+            generatedComponentClassName,
+          )
+          addType(factoryOrBuilder)
+        }
       }
       .build()
 

--- a/compiler/src/main/java/com/squareup/anvil/compiler/KspContributionMerger.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/KspContributionMerger.kt
@@ -6,31 +6,40 @@ import com.google.devtools.ksp.getVisibility
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
 import com.google.devtools.ksp.processing.SymbolProcessorProvider
-import com.google.devtools.ksp.processing.impl.KSNameImpl
 import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.KSAnnotation
 import com.google.devtools.ksp.symbol.KSClassDeclaration
-import com.google.devtools.ksp.symbol.KSName
 import com.google.devtools.ksp.symbol.KSType
 import com.google.devtools.ksp.symbol.Visibility
+import com.google.devtools.ksp.symbol.impl.hasAnnotation
+import com.squareup.anvil.annotations.ContributesBinding
+import com.squareup.anvil.annotations.ContributesTo
 import com.squareup.anvil.compiler.codegen.generatedAnvilSubcomponentClassId
 import com.squareup.anvil.compiler.codegen.ksp.AnvilSymbolProcessor
 import com.squareup.anvil.compiler.codegen.ksp.AnvilSymbolProcessorProvider
 import com.squareup.anvil.compiler.codegen.ksp.KspAnvilException
+import com.squareup.anvil.compiler.codegen.ksp.argumentAt
 import com.squareup.anvil.compiler.codegen.ksp.atLeastOneAnnotation
+import com.squareup.anvil.compiler.codegen.ksp.classId
 import com.squareup.anvil.compiler.codegen.ksp.declaringClass
 import com.squareup.anvil.compiler.codegen.ksp.exclude
+import com.squareup.anvil.compiler.codegen.ksp.find
 import com.squareup.anvil.compiler.codegen.ksp.findAll
 import com.squareup.anvil.compiler.codegen.ksp.getSymbolsWithAnnotations
 import com.squareup.anvil.compiler.codegen.ksp.isInterface
+import com.squareup.anvil.compiler.codegen.ksp.modules
 import com.squareup.anvil.compiler.codegen.ksp.parentScope
 import com.squareup.anvil.compiler.codegen.ksp.replaces
 import com.squareup.anvil.compiler.codegen.ksp.resolveKSClassDeclaration
+import com.squareup.anvil.compiler.codegen.ksp.returnTypeOrNull
 import com.squareup.anvil.compiler.codegen.ksp.scope
 import com.squareup.anvil.compiler.codegen.ksp.superTypesExcludingAny
-import com.squareup.anvil.compiler.internal.reference.asClassId
 import com.squareup.kotlinpoet.AnnotationSpec
+import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.CodeBlock
+import com.squareup.kotlinpoet.joinToCode
 import com.squareup.kotlinpoet.ksp.toClassName
+import dagger.Module
 import org.jetbrains.kotlin.name.Name
 
 /**
@@ -140,7 +149,235 @@ internal class KspContributionMerger(override val env: SymbolProcessorEnvironmen
     resolver: Resolver,
     declaration: KSClassDeclaration,
   ): AnnotationSpec {
-    TODO()
+    val daggerAnnotationClassName = annotations[0].daggerAnnotationClassName
+
+    val scopes = annotations.map { it.scope() }
+    val predefinedModules = annotations.flatMap { it.modules() }
+
+    val allContributesAnnotations: List<KSAnnotation> = annotations
+      .asSequence()
+      .flatMap { annotation ->
+        classScanner
+          .findContributedClasses(
+            resolver = resolver,
+            annotation = contributesToFqName,
+            scope = annotation.scope(),
+          )
+      }
+      .flatMap { contributedClass ->
+        contributedClass
+          .find(annotationName = contributesToFqName.asString())
+          .filter { it.scope() in scopes }
+      }
+      .filter { contributesAnnotation ->
+        val contributedClass = contributesAnnotation.declaringClass
+        val moduleAnnotation = contributedClass.find(daggerModuleFqName.asString()).singleOrNull()
+        val mergeModulesAnnotation =
+          contributedClass.find(mergeModulesFqName.asString()).singleOrNull()
+
+        if (!contributedClass.isInterface() &&
+          moduleAnnotation == null &&
+          mergeModulesAnnotation == null
+        ) {
+          throw KspAnvilException(
+            message = "${contributedClass.qualifiedName?.asString()} is annotated with " +
+              "@${ContributesTo::class.simpleName}, but this class is neither an interface " +
+              "nor a Dagger module. Did you forget to add @${Module::class.simpleName}?",
+            node = contributedClass,
+          )
+        }
+
+        moduleAnnotation != null || mergeModulesAnnotation != null
+      }
+      .onEach { contributesAnnotation ->
+        val contributedClass = contributesAnnotation.declaringClass
+        if (contributedClass.getVisibility() != Visibility.PUBLIC) {
+          throw KspAnvilException(
+            message = "${contributedClass.qualifiedName?.asString()} is contributed to the Dagger graph, but the " +
+              "module is not public. Only public modules are supported.",
+            node = contributedClass,
+          )
+        }
+      }
+      // Convert the sequence to a list to avoid iterating it twice. We use the result twice
+      // for replaced classes and the final result.
+      .toList()
+
+    val (bindingModuleContributesAnnotations, contributesAnnotations) = allContributesAnnotations.partition {
+      it.declaringClass.hasAnnotation(internalBindingMarkerFqName.asString())
+    }
+
+    val excludedModules = annotations
+      .flatMap { it.exclude() }
+      .onEach { excludedClass ->
+
+        // Verify that the replaced classes use the same scope.
+        val contributesToOurScope = excludedClass
+          .findAll(
+                  contributesToFqName.asString(),
+                  contributesBindingFqName.asString(),
+                  contributesMultibindingFqName.asString(),
+          )
+          .map { it.scope() }
+          .plus(
+            excludedClass
+              .find(contributesSubcomponentFqName.asString())
+              .map { it.parentScope() },
+          )
+          .any { scope -> scope in scopes }
+
+        if (!contributesToOurScope) {
+          val origin = declaration.originClass()
+          throw KspAnvilException(
+            message = "${origin.qualifiedName?.asString()} with scopes " +
+              "${
+                scopes.joinToString(
+                        prefix = "[",
+                        postfix = "]",
+                ) { it.resolveKSClassDeclaration()?.qualifiedName?.asString()!! }
+              } " +
+              "wants to exclude ${excludedClass.qualifiedName?.asString()}, but the excluded class isn't " +
+              "contributed to the same scope.",
+            node = origin,
+          )
+        }
+      }
+      .toSet()
+
+    val replacedModules = allContributesAnnotations
+      // Ignore replaced modules or bindings specified by excluded modules.
+      .filter { contributesAnnotation ->
+        contributesAnnotation.declaringClass !in excludedModules
+      }
+      .flatMap { contributesAnnotation ->
+        val contributedClass = contributesAnnotation.declaringClass
+        contributesAnnotation.replaces()
+          .onEach { classToReplace ->
+            // Verify has @Module annotation. It doesn't make sense for a Dagger module to
+            // replace a non-Dagger module.
+            if (!classToReplace.hasAnnotation(daggerModuleFqName.asString()) &&
+              !classToReplace.hasAnnotation(contributesBindingFqName.asString()) &&
+              !classToReplace.hasAnnotation(contributesMultibindingFqName.asString())
+            ) {
+              val origin = contributedClass.originClass()
+              throw KspAnvilException(
+                message = "${origin.qualifiedName?.asString()} wants to replace " +
+                  "${classToReplace.qualifiedName?.asString()}, but the class being " +
+                  "replaced is not a Dagger module.",
+                node = origin,
+              )
+            }
+
+            checkSameScope(contributedClass, classToReplace, scopes)
+          }
+      }
+      .toSet()
+
+    val bindings = bindingModuleContributesAnnotations
+      .mapNotNull { contributedAnnotation ->
+        val moduleClass = contributedAnnotation.declaringClass
+        val internalBindingMarker =
+          moduleClass.find(internalBindingMarkerFqName.asString()).single()
+
+        val bindingFunction = moduleClass.getAllFunctions().single {
+          val functionName = it.simpleName.asString()
+          functionName.startsWith("bind") || functionName.startsWith("provide")
+        }
+
+        val originClass =
+          internalBindingMarker.originClass()!!
+
+        if (originClass in excludedModules || originClass in replacedModules) return@mapNotNull null
+        if (moduleClass in excludedModules || moduleClass in replacedModules) return@mapNotNull null
+
+        val boundType = bindingFunction.returnTypeOrNull()!!.resolveKSClassDeclaration()!!
+        val isMultibinding =
+          internalBindingMarker.argumentAt("isMultibinding")?.value == true
+        val qualifierKey =
+          (internalBindingMarker.argumentAt("qualifierKey")?.value as? String?).orEmpty()
+        val rank = (internalBindingMarker.argumentAt("rank")
+          ?.value as? Int?)
+          ?: ContributesBinding.RANK_NORMAL
+        val scope = contributedAnnotation.scope()
+        ContributedBinding(
+                scope = scope.toClassName(),
+                isMultibinding = isMultibinding,
+                bindingModule = moduleClass.toClassName(),
+                originClass = originClass.toClassName(),
+                boundType = boundType,
+                qualifierKey = qualifierKey,
+                rank = rank,
+                replaces = moduleClass.find(contributesToFqName.asString()).single()
+                        .replaces()
+                        .map { it.toClassName() },
+        )
+      }
+      .let { ContributedBindings.from(it) }
+
+    if (predefinedModules.isNotEmpty()) {
+      val intersect = predefinedModules.intersect(excludedModules.toSet())
+      if (intersect.isNotEmpty()) {
+        throw KspAnvilException(
+          message = "${declaration.qualifiedName?.asString()} includes and excludes modules " +
+            "at the same time: ${intersect.joinToString { it.qualifiedName?.asString()!! }}",
+          node = declaration,
+        )
+      }
+    }
+
+    val contributedSubcomponentModules =
+      findContributedSubcomponentModules(
+        declaration,
+        scopes,
+        resolver,
+      )
+
+    val contributedModules = contributesAnnotations
+      .asSequence()
+      .map { it.declaringClass }
+      .plus(
+              bindings.bindings.values.flatMap { it.values }
+                      .flatten()
+                      .map { it.bindingModule }
+                      .map { resolver.getClassDeclarationByName(resolver.getKSNameFromString(it.canonicalName))!! },
+      )
+      .minus(replacedModules)
+      .minus(excludedModules)
+      .plus(predefinedModules)
+      .plus(contributedSubcomponentModules)
+      .distinct()
+      .toList()
+
+    return AnnotationSpec.builder(daggerAnnotationClassName)
+      .addMember(
+        "modules = [%L]",
+        contributedModules.map { CodeBlock.of("%T::class", it.toClassName()) }.joinToCode(),
+      )
+      .apply {
+        fun copyArrayValue(name: String) {
+          val varargArguments = annotations
+            .mapNotNull {
+              @Suppress("UNCHECKED_CAST")
+              (it.argumentAt(name)?.value as? List<KSType>?)
+                ?.map { it.toClassName() }
+            }
+            .ifEmpty { return }
+
+          addMember(
+            "$name = [%L]",
+            varargArguments.map { CodeBlock.of("%T::class", it) }.joinToCode(),
+          )
+        }
+
+        if (annotations[0].annotationType.resolve().toClassName() == mergeComponentClassName) {
+          copyArrayValue("dependencies")
+        }
+
+        if (annotations[0].annotationType.resolve().toClassName() == mergeModulesClassName) {
+          copyArrayValue("subcomponents")
+        }
+      }
+      .build()
   }
 
   private fun contributedInterfaces(
@@ -331,6 +568,36 @@ internal class KspContributionMerger(override val env: SymbolProcessorEnvironmen
     }
   }
 
+  private fun findContributedSubcomponentModules(
+    declaration: KSClassDeclaration,
+    scopes: List<KSType>,
+    resolver: Resolver,
+  ): Sequence<KSClassDeclaration> {
+    return classScanner
+      .findContributedClasses(
+        resolver = resolver,
+        annotation = contributesSubcomponentFqName,
+        scope = null,
+      )
+      .filter { clazz ->
+        clazz.find(contributesSubcomponentFqName.asString())
+          .any { it.parentScope().asType(emptyList()) in scopes }
+      }
+      .mapNotNull { contributedSubcomponent ->
+        contributedSubcomponent.classId
+          .generatedAnvilSubcomponentClassId(declaration.classId)
+          .createNestedClassId(Name.identifier(SUBCOMPONENT_MODULE))
+          .let { classId ->
+            resolver.getClassDeclarationByName(
+              resolver.getKSNameFromString(
+                classId.asSingleFqName()
+                  .toString(),
+              ),
+            )
+          }
+      }
+  }
+
   private fun findContributedSubcomponentParentInterfaces(
     clazz: KSClassDeclaration,
     scopes: Collection<KSType>,
@@ -347,8 +614,8 @@ internal class KspContributionMerger(override val env: SymbolProcessorEnvironmen
           .parentScope().asType(emptyList()) in scopes
       }
       .mapNotNull { contributedSubcomponent ->
-        contributedSubcomponent.toClassName().asClassId()
-          .generatedAnvilSubcomponentClassId(clazz.toClassName().asClassId())
+        contributedSubcomponent.classId
+          .generatedAnvilSubcomponentClassId(clazz.classId)
           .createNestedClassId(Name.identifier(PARENT_COMPONENT))
           .let { classId ->
             resolver.getClassDeclarationByName(
@@ -361,3 +628,60 @@ internal class KspContributionMerger(override val env: SymbolProcessorEnvironmen
       }
   }
 }
+
+private fun checkSameScope(
+  contributedClass: KSClassDeclaration,
+  classToReplace: KSClassDeclaration,
+  scopes: List<KSType>,
+) {
+  val contributesToOurScope = classToReplace
+    .findAll(
+            contributesToFqName.asString(),
+            contributesBindingFqName.asString(),
+            contributesMultibindingFqName.asString(),
+    )
+    .map { it.scope() }
+    .any { scope -> scope in scopes }
+
+  if (!contributesToOurScope) {
+    val origin = contributedClass.originClass()
+    throw KspAnvilException(
+      node = origin,
+      message = "${origin.qualifiedName?.asString()} with scopes " +
+        "${
+          scopes.joinToString(
+                  prefix = "[",
+                  postfix = "]",
+          ) { it.resolveKSClassDeclaration()?.qualifiedName?.asString()!! }
+        } " +
+        "wants to replace ${classToReplace.qualifiedName?.asString()}, but the replaced class isn't " +
+        "contributed to the same scope.",
+    )
+  }
+}
+
+private fun KSClassDeclaration.originClass(): KSClassDeclaration {
+  val originClassValue = find(internalBindingMarkerFqName.asString())
+    .singleOrNull()
+    ?.argumentAt("originClass")
+    ?.value
+
+  val originClass = (originClassValue as? KSType?)?.resolveKSClassDeclaration()
+  return originClass ?: this
+}
+
+private fun KSAnnotation.originClass(): KSClassDeclaration? {
+  val originClassValue = argumentAt("originClass")
+    ?.value
+
+  val originClass = (originClassValue as? KSType?)?.resolveKSClassDeclaration()
+  return originClass
+}
+
+private val KSAnnotation.daggerAnnotationClassName: ClassName
+  get() = when (annotationType.resolve().toClassName()) {
+    mergeComponentClassName -> daggerComponentClassName
+    mergeSubcomponentClassName -> daggerSubcomponentClassName
+    mergeModulesClassName -> daggerModuleClassName
+    else -> throw NotImplementedError("Don't know how to handle $this.")
+  }

--- a/compiler/src/main/java/com/squareup/anvil/compiler/KspContributionMerger.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/KspContributionMerger.kt
@@ -16,6 +16,7 @@ import com.google.devtools.ksp.symbol.Visibility
 import com.google.devtools.ksp.symbol.impl.hasAnnotation
 import com.squareup.anvil.annotations.ContributesBinding
 import com.squareup.anvil.annotations.ContributesTo
+import com.squareup.anvil.compiler.api.ComponentMergingBackend
 import com.squareup.anvil.compiler.codegen.generatedAnvilSubcomponentClassId
 import com.squareup.anvil.compiler.codegen.ksp.AnvilSymbolProcessor
 import com.squareup.anvil.compiler.codegen.ksp.AnvilSymbolProcessorProvider
@@ -72,7 +73,9 @@ internal class KspContributionMerger(override val env: SymbolProcessorEnvironmen
 
   @AutoService(SymbolProcessorProvider::class)
   class Provider : AnvilSymbolProcessorProvider(
-    { context -> !context.disableComponentMerging && !context.generateFactories },
+    { context ->
+      !context.disableComponentMerging && !context.generateFactories && !context.generateFactoriesOnly && context.componentMergingBackend == ComponentMergingBackend.KSP
+    },
     ::KspContributionMerger,
   )
 

--- a/compiler/src/main/java/com/squareup/anvil/compiler/Utils.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/Utils.kt
@@ -11,6 +11,7 @@ import com.squareup.anvil.annotations.compat.MergeModules
 import com.squareup.anvil.annotations.internal.InternalBindingMarker
 import com.squareup.anvil.compiler.api.AnvilCompilationException
 import com.squareup.anvil.compiler.internal.fqName
+import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.asClassName
 import dagger.Binds
 import dagger.Component
@@ -23,15 +24,20 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.internal.DoubleCheck
+import org.jetbrains.kotlin.name.FqName
 import java.io.File
 import javax.inject.Inject
 import javax.inject.Provider
 import javax.inject.Qualifier
 
 internal val mergeComponentFqName = MergeComponent::class.fqName
+internal val mergeComponentClassName = MergeComponent::class.asClassName()
 internal val mergeSubcomponentFqName = MergeSubcomponent::class.fqName
+internal val mergeSubcomponentClassName = MergeSubcomponent::class.asClassName()
 internal val mergeInterfacesFqName = MergeInterfaces::class.fqName
+internal val mergeInterfacesClassName = MergeInterfaces::class.asClassName()
 internal val mergeModulesFqName = MergeModules::class.fqName
+internal val mergeModulesClassName = MergeModules::class.asClassName()
 internal val contributesToFqName = ContributesTo::class.fqName
 internal val contributesBindingFqName = ContributesBinding::class.fqName
 internal val contributesMultibindingFqName = ContributesMultibinding::class.fqName
@@ -39,10 +45,13 @@ internal val contributesSubcomponentFqName = ContributesSubcomponent::class.fqNa
 internal val contributesSubcomponentFactoryFqName = ContributesSubcomponent.Factory::class.fqName
 internal val internalBindingMarkerFqName = InternalBindingMarker::class.fqName
 internal val daggerComponentFqName = Component::class.fqName
+internal val daggerComponentClassName = Component::class.asClassName()
 internal val daggerSubcomponentFqName = Subcomponent::class.fqName
+internal val daggerSubcomponentClassName = Subcomponent::class.asClassName()
 internal val daggerSubcomponentFactoryFqName = Subcomponent.Factory::class.fqName
 internal val daggerSubcomponentBuilderFqName = Subcomponent.Builder::class.fqName
 internal val daggerModuleFqName = Module::class.fqName
+internal val daggerModuleClassName = Module::class.asClassName()
 internal val daggerBindsFqName = Binds::class.fqName
 internal val daggerProvidesFqName = Provides::class.fqName
 internal val daggerLazyFqName = Lazy::class.fqName
@@ -155,4 +164,8 @@ internal inline fun <T, R> Array<T>.mapToSet(
   transform: (T) -> R,
 ): Set<R> {
   return mapTo(destination, transform)
+}
+
+internal val ClassName.fqName: FqName get() {
+  return FqName(canonicalName)
 }

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/RealAnvilContext.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/RealAnvilContext.kt
@@ -3,9 +3,11 @@ package com.squareup.anvil.compiler.codegen
 import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
 import com.squareup.anvil.compiler.CommandLineOptions
 import com.squareup.anvil.compiler.api.AnvilContext
+import com.squareup.anvil.compiler.api.ComponentMergingBackend
 import com.squareup.anvil.compiler.disableComponentMergingName
 import com.squareup.anvil.compiler.generateDaggerFactoriesName
 import com.squareup.anvil.compiler.generateDaggerFactoriesOnlyName
+import com.squareup.anvil.compiler.mergingBackendName
 import com.squareup.anvil.compiler.willHaveDaggerFactoriesName
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 
@@ -15,6 +17,7 @@ internal data class RealAnvilContext(
   override val disableComponentMerging: Boolean,
   override val trackSourceFiles: Boolean,
   override val willHaveDaggerFactories: Boolean,
+  override val componentMergingBackend: ComponentMergingBackend,
   val nullableModule: ModuleDescriptor?,
 ) : AnvilContext {
   override val module: ModuleDescriptor
@@ -29,6 +32,7 @@ internal fun CommandLineOptions.toAnvilContext(
   disableComponentMerging = disableComponentMerging,
   trackSourceFiles = trackSourceFiles,
   willHaveDaggerFactories = willHaveDaggerFactories,
+  componentMergingBackend = componentMergingBackend,
   nullableModule = module,
 )
 
@@ -38,6 +42,7 @@ internal fun SymbolProcessorEnvironment.toAnvilContext(): AnvilContext = RealAnv
   disableComponentMerging = options.booleanOption(disableComponentMergingName),
   trackSourceFiles = false,
   willHaveDaggerFactories = options.booleanOption(willHaveDaggerFactoriesName),
+  componentMergingBackend = options[mergingBackendName]?.let(ComponentMergingBackend::fromString) ?: ComponentMergingBackend.IR,
   nullableModule = null,
 )
 

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ksp/KSAnnotationExtensions.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ksp/KSAnnotationExtensions.kt
@@ -120,6 +120,12 @@ internal fun KSAnnotation.exclude(): List<KSClassDeclaration> =
     it.resolveKSClassDeclaration() ?: throw KspAnvilException("Could not resolve exclude $it", this)
   }
 
+@Suppress("UNCHECKED_CAST")
+internal fun KSAnnotation.modules(): List<KSClassDeclaration> =
+  (argumentAt("modules")?.value as? List<KSType>).orEmpty().map {
+    it.resolveKSClassDeclaration() ?: throw KspAnvilException("Could not resolve modules $it", this)
+  }
+
 internal fun KSAnnotation.parentScope(): KSClassDeclaration {
   return (
     argumentAt("parentScope")

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ksp/KspUtil.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ksp/KspUtil.kt
@@ -6,6 +6,7 @@ import com.google.devtools.ksp.isAnnotationPresent
 import com.google.devtools.ksp.isConstructor
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.processing.impl.KSNameImpl
+import com.google.devtools.ksp.symbol.ClassKind
 import com.google.devtools.ksp.symbol.ClassKind.ANNOTATION_CLASS
 import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.KSAnnotation
@@ -14,11 +15,19 @@ import com.google.devtools.ksp.symbol.KSFunctionDeclaration
 import com.google.devtools.ksp.symbol.KSModifierListOwner
 import com.google.devtools.ksp.symbol.KSType
 import com.google.devtools.ksp.symbol.KSTypeAlias
+import com.google.devtools.ksp.symbol.KSValueParameter
 import com.google.devtools.ksp.symbol.Modifier
+import com.google.devtools.ksp.symbol.impl.synthetic.KSErrorTypeClassDeclaration.simpleName
 import com.squareup.anvil.compiler.internal.reference.asClassId
+import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.ParameterSpec
 import com.squareup.kotlinpoet.TypeName
+import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.jvm.jvmSuppressWildcards
+import com.squareup.kotlinpoet.ksp.toAnnotationSpec
 import com.squareup.kotlinpoet.ksp.toClassName
+import com.squareup.kotlinpoet.ksp.toKModifier
+import com.squareup.kotlinpoet.ksp.toTypeName
 import dagger.assisted.AssistedInject
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.FqName
@@ -226,3 +235,48 @@ internal fun KSClassDeclaration.atLeastOneAnnotation(
 internal fun ClassId.toKSName() = KSNameImpl.getCached(asSingleFqName().toString())
 
 internal val KSClassDeclaration.classId: ClassId get() = toClassName().asClassId()
+
+internal fun KSClassDeclaration.extend(name: String = simpleName.asString()): TypeSpec {
+  val builder = when (classKind) {
+    ClassKind.INTERFACE -> TypeSpec.interfaceBuilder(name)
+      .superclass(toClassName())
+    ClassKind.CLASS -> TypeSpec.classBuilder(name)
+      .addSuperinterface(toClassName())
+    ClassKind.ENUM_CLASS,
+    ClassKind.ENUM_ENTRY,
+    ClassKind.OBJECT,
+    ClassKind.ANNOTATION_CLASS -> throw KspAnvilException(
+      node = this,
+      message = "Unsupported class kind: $classKind"
+    )
+  }
+  return builder
+    .addAnnotations(annotations.map { it.toAnnotationSpec() }.asIterable())
+    .apply {
+      for (function in getDeclaredFunctions()) {
+        addFunction(function.toFunSpec())
+      }
+    }
+    .build()
+}
+
+internal fun KSFunctionDeclaration.toFunSpec(): FunSpec {
+  val builder = FunSpec.builder(simpleName.getShortName())
+    // TODO in interfaces, will they be "ABSTRACT" here still?
+    .addModifiers(modifiers.mapNotNull { it.toKModifier() })
+    .addAnnotations(annotations.map { it.toAnnotationSpec() }.asIterable())
+
+  returnType?.resolve()?.toTypeName()?.let { builder.returns(it) }
+
+  for (parameter in parameters) {
+    builder.addParameter(parameter.toParameterSpec())
+  }
+
+  return builder.build()
+}
+
+internal fun KSValueParameter.toParameterSpec(): ParameterSpec {
+  return ParameterSpec.builder(name!!.asString(), type.resolve().toTypeName())
+    .addAnnotations(annotations.map { it.toAnnotationSpec() }.asIterable())
+    .build()
+}

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ksp/KspUtil.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ksp/KspUtil.kt
@@ -15,8 +15,10 @@ import com.google.devtools.ksp.symbol.KSModifierListOwner
 import com.google.devtools.ksp.symbol.KSType
 import com.google.devtools.ksp.symbol.KSTypeAlias
 import com.google.devtools.ksp.symbol.Modifier
+import com.squareup.anvil.compiler.internal.reference.asClassId
 import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.jvm.jvmSuppressWildcards
+import com.squareup.kotlinpoet.ksp.toClassName
 import dagger.assisted.AssistedInject
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.FqName
@@ -222,3 +224,5 @@ internal fun KSClassDeclaration.atLeastOneAnnotation(
 }
 
 internal fun ClassId.toKSName() = KSNameImpl.getCached(asSingleFqName().toString())
+
+internal val KSClassDeclaration.classId: ClassId get() = toClassName().asClassId()

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ksp/KspUtil.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ksp/KspUtil.kt
@@ -197,7 +197,9 @@ internal fun KSFunctionDeclaration.returnTypeOrNull(): KSType? =
 
 internal fun Resolver.getSymbolsWithAnnotations(
   vararg annotations: FqName,
-): Sequence<KSAnnotated> = annotations.asSequence().flatMap { getSymbolsWithAnnotation(it.asString()) }
+): Sequence<KSAnnotated> = annotations.asSequence().flatMap {
+  getSymbolsWithAnnotation(it.asString())
+}
 
 internal fun KSAnnotated.findAll(vararg annotations: String): List<KSAnnotation> {
   return annotations.flatMap { annotation ->
@@ -214,9 +216,8 @@ internal fun KSAnnotated.find(
   return findAll(annotationName)
     .filter {
       scopeName == null || it.scopeOrNull() == scopeName
-  }
+    }
 }
-
 
 internal fun KSClassDeclaration.atLeastOneAnnotation(
   annotationName: String,
@@ -245,9 +246,10 @@ internal fun KSClassDeclaration.extend(name: String = simpleName.asString()): Ty
     ClassKind.ENUM_CLASS,
     ClassKind.ENUM_ENTRY,
     ClassKind.OBJECT,
-    ClassKind.ANNOTATION_CLASS -> throw KspAnvilException(
+    ClassKind.ANNOTATION_CLASS,
+    -> throw KspAnvilException(
       node = this,
-      message = "Unsupported class kind: $classKind"
+      message = "Unsupported class kind: $classKind",
     )
   }
   return builder

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ksp/KspUtil.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ksp/KspUtil.kt
@@ -17,6 +17,7 @@ import com.google.devtools.ksp.symbol.Modifier
 import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.jvm.jvmSuppressWildcards
 import dagger.assisted.AssistedInject
+import org.jetbrains.kotlin.name.FqName
 import javax.inject.Inject
 import kotlin.reflect.KClass
 
@@ -180,3 +181,13 @@ internal fun KSFunctionDeclaration.returnTypeOrNull(): KSType? =
   returnType?.resolve()?.takeIf {
     it.declaration.qualifiedName?.asString() != "kotlin.Unit"
   }
+
+internal fun Resolver.getSymbolsWithAnnotations(
+  vararg annotations: FqName,
+): Sequence<KSAnnotated> = annotations.asSequence().flatMap { getSymbolsWithAnnotation(it.asString()) }
+
+internal fun KSAnnotated.findAll(vararg annotations: FqName): List<KSAnnotation> {
+  return annotations.flatMap { annotation ->
+    getKSAnnotationsByQualifiedName(annotation.asString()).toList()
+  }
+}

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ksp/KspUtil.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ksp/KspUtil.kt
@@ -5,8 +5,6 @@ import com.google.devtools.ksp.getDeclaredFunctions
 import com.google.devtools.ksp.isAnnotationPresent
 import com.google.devtools.ksp.isConstructor
 import com.google.devtools.ksp.processing.Resolver
-import com.google.devtools.ksp.processing.impl.KSNameImpl
-import com.google.devtools.ksp.symbol.ClassKind
 import com.google.devtools.ksp.symbol.ClassKind.ANNOTATION_CLASS
 import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.KSAnnotation
@@ -17,12 +15,10 @@ import com.google.devtools.ksp.symbol.KSType
 import com.google.devtools.ksp.symbol.KSTypeAlias
 import com.google.devtools.ksp.symbol.KSValueParameter
 import com.google.devtools.ksp.symbol.Modifier
-import com.google.devtools.ksp.symbol.impl.synthetic.KSErrorTypeClassDeclaration.simpleName
 import com.squareup.anvil.compiler.internal.reference.asClassId
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.ParameterSpec
 import com.squareup.kotlinpoet.TypeName
-import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.jvm.jvmSuppressWildcards
 import com.squareup.kotlinpoet.ksp.toAnnotationSpec
 import com.squareup.kotlinpoet.ksp.toClassName
@@ -233,38 +229,10 @@ internal fun KSClassDeclaration.atLeastOneAnnotation(
     }
 }
 
-internal fun ClassId.toKSName() = KSNameImpl.getCached(asSingleFqName().toString())
-
 internal val KSClassDeclaration.classId: ClassId get() = toClassName().asClassId()
-
-internal fun KSClassDeclaration.extend(name: String = simpleName.asString()): TypeSpec {
-  val builder = when (classKind) {
-    ClassKind.INTERFACE -> TypeSpec.interfaceBuilder(name)
-      .superclass(toClassName())
-    ClassKind.CLASS -> TypeSpec.classBuilder(name)
-      .addSuperinterface(toClassName())
-    ClassKind.ENUM_CLASS,
-    ClassKind.ENUM_ENTRY,
-    ClassKind.OBJECT,
-    ClassKind.ANNOTATION_CLASS,
-    -> throw KspAnvilException(
-      node = this,
-      message = "Unsupported class kind: $classKind",
-    )
-  }
-  return builder
-    .addAnnotations(annotations.map { it.toAnnotationSpec() }.asIterable())
-    .apply {
-      for (function in getDeclaredFunctions()) {
-        addFunction(function.toFunSpec())
-      }
-    }
-    .build()
-}
 
 internal fun KSFunctionDeclaration.toFunSpec(): FunSpec {
   val builder = FunSpec.builder(simpleName.getShortName())
-    // TODO in interfaces, will they be "ABSTRACT" here still?
     .addModifiers(modifiers.mapNotNull { it.toKModifier() })
     .addAnnotations(annotations.map { it.toAnnotationSpec() }.asIterable())
 

--- a/gradle-plugin/src/main/java/com/squareup/anvil/plugin/AnvilExtension.kt
+++ b/gradle-plugin/src/main/java/com/squareup/anvil/plugin/AnvilExtension.kt
@@ -223,6 +223,10 @@ public abstract class AnvilExtension @Inject constructor(
           "generate-dagger-factories-only" to generateDaggerFactoriesOnly,
           "disable-component-merging" to disableComponentMerging,
           "will-have-dagger-factories" to willHaveDaggerFactories,
+          "merging-backend" to useKspComponentMergingBackend
+            .map { enabled ->
+              if (enabled) "ksp" else "none"
+            },
         ),
       )
     }
@@ -279,7 +283,7 @@ public abstract class AnvilExtension @Inject constructor(
  * because of its `Project` property.
  */
 private fun commandLineArgumentProvider(
-  vararg args: Pair<String, Provider<Boolean>>,
+  vararg args: Pair<String, Provider<*>>,
 ): CommandLineArgumentProvider {
   return CommandLineArgumentProvider {
     args.map { (arg, provider) -> "$arg=${provider.get()}" }


### PR DESCRIPTION
This is a second, clean restart on implementing contribution merging in KSP. This would make Anvil compatible with dagger KSP (while also being backward compatible with dagger apt, but more on that later).

**How it works**

This approach builds on our recent simplifications to how hints are generated. Now that they are just in a single package, we can use public KSP APIs. It does change a little about how Anvil's historically worked. Instead of modifying in-memory class representations directly, this generates an _intermediate_ component interface with the correct annotations (essentially a source file version of what we did in-memory before). This would then get processed by Dagger's KSP processor in a following round.

```kotlin
// In source, AppComponent.kt
@MergeComponent(AppScope::class)
interface AppComponent {
  @Component.Factory
  interface Factory {
    fun create(): AppComponent
  }
}

// Generated by Anvil KSP
@Component(modules = [AppModule::class])
interface AnvilAppComponent : AppComponent, ContributedInterface {
  @Component.Factory
  interface Factory : AppComponent.Factory {
    fun create(): AnvilAppComponent
  }
}

// Generated by Dagger KSP
class DaggerAnvilAppComponent : AnvilAppComponent {
  // ...
}
```

`@Component.Factory` and `@Component.Builder` are both covered.

Since folks usually have a `DaggerAppComponent` entry point they expect, this also generates a corresponding shim like so, so that theoretically no source changes are needed.

```kotlin
// Source-compatible shim to the new Dagger-generated location
object DaggerAppComponent {
  @JvmStatic
  fun factory() = DaggerAnvilAppComponent.factory()
}
```

Lastly, this is actually backward compatible with dagger apt as well. It would be not ideal to run both, but given that dagger-ksp is quite slow it may be convenient. All that would need to be done would be for Anvil KSP's contribution merging to run before kapt and its sources be inputs into kapt. Kapt wouldn't know any difference.

**Open questions**
- `@MergeModules` no longer works in this case. That one exclusively relies on modifying sources and it's not clear how we can handle that here. One idea is we could generate a module in a "known" location, such as `AppModule -> MergedAppModule` and just say people need to include it directly.
- Similarly, `@MergeInterfaces` no longer works.
- There exists an ordering concern. While with IR we could always assume all contribution generation had happened by the time it runs, here we may have contributions happening during the same around and merge too soon. Couple ideas:
  - Check first for any contribution annotations. Do one of two things
    a. Immediately defer the element until the next round (simplest)
    b. Generate anyway, but "know" where and what it will generate to and expect those sources to be generated.
  - Merge all processors into one composite processor, make it run component merging last. This is what dagger does too (I think).

**TODO**
- [ ] Update tests (will make a separate PR first to set up infra for it)
- [x] Make sure that subclassing with overrides with subclass's type works as expected