### PR TITLE
fix incremental behavior when the compilation target has IR merging but no KAPT stub generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Fixed
 
+- incremental compilation is automatically disabled for source sets that perform interface or module merging ([#1024](https://github.com/square/anvil/pull/1024))
+
 ### Security
 
 ### Custom Code Generator

--- a/compiler-utils/src/testFixtures/java/com/squareup/anvil/compiler/internal/testing/AnvilCompilation.kt
+++ b/compiler-utils/src/testFixtures/java/com/squareup/anvil/compiler/internal/testing/AnvilCompilation.kt
@@ -68,6 +68,9 @@ public class AnvilCompilation internal constructor(
       val anvilCommandLineProcessor = AnvilCommandLineProcessor()
       commandLineProcessors = listOf(anvilCommandLineProcessor)
 
+      val buildDir = workingDir.resolve("build")
+      val anvilCacheDir = buildDir.resolve("anvil-cache")
+
       pluginOptions = mutableListOf(
         PluginOption(
           pluginId = anvilCommandLineProcessor.pluginId,
@@ -79,12 +82,21 @@ public class AnvilCompilation internal constructor(
           optionName = "analysis-backend",
           optionValue = mode.analysisBackend.name.lowercase(Locale.US),
         ),
+        PluginOption(
+          pluginId = anvilCommandLineProcessor.pluginId,
+          optionName = "ir-merges-file",
+          optionValue = anvilCacheDir.resolve("merges/ir-merges.txt").absolutePath,
+        ),
+        PluginOption(
+          pluginId = anvilCommandLineProcessor.pluginId,
+          optionName = "track-source-files",
+          optionValue = (trackSourceFiles && mode is Embedded).toString(),
+        ),
       )
 
       when (mode) {
         is Embedded -> {
           anvilComponentRegistrar.addCodeGenerators(mode.codeGenerators)
-          val buildDir = workingDir.resolve("build")
           pluginOptions +=
             listOf(
               PluginOption(
@@ -105,7 +117,7 @@ public class AnvilCompilation internal constructor(
               PluginOption(
                 pluginId = anvilCommandLineProcessor.pluginId,
                 optionName = "anvil-cache-dir",
-                optionValue = buildDir.resolve("anvil-cache").absolutePath,
+                optionValue = anvilCacheDir.absolutePath,
               ),
               PluginOption(
                 pluginId = anvilCommandLineProcessor.pluginId,
@@ -121,11 +133,6 @@ public class AnvilCompilation internal constructor(
                 pluginId = anvilCommandLineProcessor.pluginId,
                 optionName = "will-have-dagger-factories",
                 optionValue = (generateDaggerFactories || enableDaggerAnnotationProcessor).toString(),
-              ),
-              PluginOption(
-                pluginId = anvilCommandLineProcessor.pluginId,
-                optionName = "track-source-files",
-                optionValue = trackSourceFiles.toString(),
               ),
             )
         }

--- a/compiler/src/main/java/com/squareup/anvil/compiler/AnvilCommandLineProcessor.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/AnvilCommandLineProcessor.kt
@@ -25,6 +25,10 @@ internal const val gradleBuildDirName = "gradle-build-dir"
 internal val gradleBuildDirKey =
   CompilerConfigurationKey.create<File>("anvil $gradleBuildDirName")
 
+internal const val irMergesFileName = "ir-merges-file"
+internal val irMergesFileKey =
+  CompilerConfigurationKey.create<File>("anvil $irMergesFileName")
+
 internal const val generateDaggerFactoriesName = "generate-dagger-factories"
 internal val generateDaggerFactoriesKey =
   CompilerConfigurationKey.create<Boolean>("anvil $generateDaggerFactoriesName")
@@ -86,6 +90,13 @@ public class AnvilCommandLineProcessor : CommandLineProcessor {
       optionName = anvilCacheDirName,
       valueDescription = "<file-path>",
       description = "Path to directory where Anvil stores its incremental compilation state",
+      required = false,
+      allowMultipleOccurrences = false,
+    ),
+    CliOption(
+      optionName = irMergesFileName,
+      valueDescription = "<file-path>",
+      description = "Path of the file where Anvil records its merged module annotations and component/module interfaces",
       required = false,
       allowMultipleOccurrences = false,
     ),
@@ -157,6 +168,7 @@ public class AnvilCommandLineProcessor : CommandLineProcessor {
       gradleBuildDirName -> configuration.put(gradleBuildDirKey, File(value))
       srcGenDirName -> configuration.put(srcGenDirKey, File(value))
       anvilCacheDirName -> configuration.put(anvilCacheDirKey, File(value))
+      irMergesFileName -> configuration.put(irMergesFileKey, File(value))
       generateDaggerFactoriesName ->
         configuration.put(generateDaggerFactoriesKey, value.toBoolean())
 

--- a/compiler/src/main/java/com/squareup/anvil/compiler/AnvilComponentRegistrar.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/AnvilComponentRegistrar.kt
@@ -44,6 +44,8 @@ public class AnvilComponentRegistrar : ComponentRegistrar {
     val moduleDescriptorFactory by lazy(NONE) {
       RealAnvilModuleDescriptor.Factory()
     }
+    val irMergesFile by lazy(NONE) { configuration.getNotNull(irMergesFileKey) }
+    val trackSourceFiles = configuration.getNotNull(trackSourceFilesKey)
 
     val mergingEnabled =
       !commandLineOptions.generateFactoriesOnly && !commandLineOptions.disableComponentMerging
@@ -51,7 +53,12 @@ public class AnvilComponentRegistrar : ComponentRegistrar {
       if (commandLineOptions.componentMergingBackend == ComponentMergingBackend.IR) {
         IrGenerationExtension.registerExtension(
           project,
-          IrContributionMerger(scanner, moduleDescriptorFactory),
+          IrContributionMerger(
+            classScanner = scanner,
+            moduleDescriptorFactory = moduleDescriptorFactory,
+            trackSourceFiles = trackSourceFiles,
+            irMergesFile = irMergesFile,
+          ),
         )
       } else {
         // TODO in dagger-ksp support
@@ -68,7 +75,6 @@ public class AnvilComponentRegistrar : ComponentRegistrar {
     val cacheDir = configuration.getNotNull(anvilCacheDirKey)
     val projectDir = BaseDir.ProjectDir(configuration.getNotNull(gradleProjectDirKey))
     val buildDir = BaseDir.BuildDir(configuration.getNotNull(gradleBuildDirKey))
-    val trackSourceFiles = configuration.getNotNull(trackSourceFilesKey)
 
     val codeGenerators = loadCodeGenerators() +
       manuallyAddedCodeGenerators +

--- a/gradle-plugin/src/gradleTest/java/com/squareup/anvil/plugin/IncrementalTest.kt
+++ b/gradle-plugin/src/gradleTest/java/com/squareup/anvil/plugin/IncrementalTest.kt
@@ -13,6 +13,7 @@ import com.rickbusarow.kase.wrap
 import com.squareup.anvil.plugin.testing.AnvilGradleTestEnvironment
 import com.squareup.anvil.plugin.testing.BaseGradleTest
 import com.squareup.anvil.plugin.testing.allBoundTypes
+import com.squareup.anvil.plugin.testing.allDirectInterfaces
 import com.squareup.anvil.plugin.testing.allMergedModulesForComponent
 import com.squareup.anvil.plugin.testing.anvil
 import com.squareup.anvil.plugin.testing.classGraphResult
@@ -57,8 +58,7 @@ class IncrementalTest : BaseGradleTest() {
     val injectClassFactory = rootAnvilMainGenerated.injectClassFactory
 
     injectClassFactory.shouldExist()
-    injectClassFactory.delete()
-    injectClassFactory.shouldNotExist()
+    injectClassFactory.deleteOrFail()
 
     shouldSucceed("compileJava") {
       task(":compileKotlin")?.outcome shouldBe TaskOutcome.SUCCESS
@@ -206,6 +206,492 @@ class IncrementalTest : BaseGradleTest() {
 
       rootAnvilMainGenerated.injectClassFactory.shouldNotExist()
     }
+
+  @TestFactory
+  fun `a generated binding contribution is deleted if the annotation is removed`() = testFactory {
+
+    rootProject {
+      gradlePropertiesFile(
+        """
+          com.squareup.anvil.trackSourceFiles=true
+        """.trimIndent(),
+      )
+    }
+
+    rootProject.project("lib1") {
+
+      buildFile {
+        plugins {
+          kotlin("jvm")
+          id("com.squareup.anvil")
+        }
+        anvil {
+          generateDaggerFactories.set(true)
+        }
+        dependencies {
+          implementation(libs.dagger2.annotations)
+        }
+      }
+
+      dir("src/main/java") {
+
+        simpleInterface(
+          packageName = "com.squareup.test.lib1",
+          simpleName = "ServiceInterface",
+        )
+
+        multiboundClass(
+          packageName = "com.squareup.test.lib1",
+          simpleName = "Service1",
+          boundTypeFqName = "com.squareup.test.lib1.ServiceInterface",
+          scopeFqName = "kotlin.Any",
+        )
+
+        multiboundClass(
+          packageName = "com.squareup.test.lib1",
+          simpleName = "Service2",
+          boundTypeFqName = "com.squareup.test.lib1.ServiceInterface",
+          scopeFqName = "kotlin.Any",
+        )
+      }
+    }
+
+    rootProject.project("lib2") {
+      buildFile {
+        plugins {
+          kotlin("jvm")
+          id("com.squareup.anvil")
+        }
+        dependencies {
+          implementation(libs.dagger2.annotations)
+          api(project(":lib1"))
+        }
+      }
+      dir("src/main/java") {
+
+        kotlinFile(
+          path = "com/squareup/test/lib2/Merging.kt",
+          content = """
+            package com.squareup.test.lib2
+    
+            import com.squareup.anvil.annotations.MergeComponent
+            import com.squareup.anvil.annotations.compat.MergeModules
+      
+            @MergeComponent(Any::class)
+            interface AnyComponent
+      
+            @MergeModules(Any::class)
+            abstract class AnyModule
+          """.trimIndent(),
+        )
+      }
+    }
+
+    rootProject.settingsFileAsFile.appendText(
+      """
+
+        include(":lib1")
+        include(":lib2")
+      """.trimIndent(),
+    )
+
+    val lib1 by rootProject.subprojects
+    val lib2 by rootProject.subprojects
+
+    shouldSucceed(":lib2:jar") {
+      task(":lib1:compileKotlin")?.outcome shouldBe TaskOutcome.SUCCESS
+      task(":lib2:compileKotlin")?.outcome shouldBe TaskOutcome.SUCCESS
+    }
+
+    lib1.dir("src/main/java") {
+      // Replace the @ContributesMultibinding class declaration with one that isn't bound.
+      injectClass(packageName = "com.squareup.test.lib1", simpleName = "Service1")
+    }
+
+    shouldSucceed(":lib2:jar") {
+
+      task(":lib1:compileKotlin")?.outcome shouldBe TaskOutcome.SUCCESS
+      task(":lib2:compileKotlin")?.outcome shouldBe TaskOutcome.SUCCESS
+    }
+
+    val includes = lib2.classGraphResult(lib1)
+      .allMergedModulesForComponent("com.squareup.test.lib2.AnyComponent")
+      .names()
+
+    includes shouldBe listOf(
+      "com.squareup.test.lib1.Service2_ServiceInterface_Any_MultiBindingModule_4e7cdd78",
+    )
+  }
+
+  @TestFactory
+  fun `a generated multibinding is updated if contributions are removed and added in the same compilation`() =
+    testFactory {
+
+      rootProject {
+        gradlePropertiesFile(
+          """
+          com.squareup.anvil.trackSourceFiles=true
+          """.trimIndent(),
+        )
+      }
+
+      rootProject.project("lib1") {
+
+        buildFile {
+          plugins {
+            kotlin("jvm")
+            id("com.squareup.anvil")
+          }
+          anvil {
+            generateDaggerFactories.set(true)
+          }
+          dependencies {
+            implementation(libs.dagger2.annotations)
+          }
+        }
+
+        dir("src/main/java") {
+
+          simpleInterface(
+            packageName = "com.squareup.test.lib1",
+            simpleName = "ServiceInterface",
+          )
+
+          multiboundClass(
+            packageName = "com.squareup.test.lib1",
+            simpleName = "Service1",
+            boundTypeFqName = "com.squareup.test.lib1.ServiceInterface",
+            scopeFqName = "kotlin.Any",
+          )
+
+          multiboundClass(
+            packageName = "com.squareup.test.lib1",
+            simpleName = "Service2",
+            boundTypeFqName = "com.squareup.test.lib1.ServiceInterface",
+            scopeFqName = "kotlin.Any",
+          )
+        }
+      }
+
+      rootProject.project("lib2") {
+        buildFile {
+          plugins {
+            kotlin("jvm")
+            id("com.squareup.anvil")
+          }
+          dependencies {
+            implementation(libs.dagger2.annotations)
+            api(project(":lib1"))
+          }
+        }
+        dir("src/main/java") {
+
+          kotlinFile(
+            path = "com/squareup/test/lib2/Merging.kt",
+            content = """
+            package com.squareup.test.lib2
+    
+            import com.squareup.anvil.annotations.MergeComponent
+            import com.squareup.anvil.annotations.compat.MergeModules
+      
+            @MergeComponent(Any::class)
+            interface AnyComponent
+      
+            @MergeModules(Any::class)
+            abstract class AnyModule
+            """.trimIndent(),
+          )
+        }
+      }
+
+      rootProject.settingsFileAsFile.appendText(
+        """
+
+        include(":lib1")
+        include(":lib2")
+        """.trimIndent(),
+      )
+
+      val lib1 by rootProject.subprojects
+      val lib2 by rootProject.subprojects
+
+      shouldSucceed(":lib2:jar") {
+        task(":lib1:compileKotlin")?.outcome shouldBe TaskOutcome.SUCCESS
+        task(":lib2:compileKotlin")?.outcome shouldBe TaskOutcome.SUCCESS
+      }
+
+      lib1.dir("src/main/java") {
+        // Replace the @ContributesMultibinding class declaration with one that isn't bound.
+        injectClass(packageName = "com.squareup.test.lib1", simpleName = "Service1")
+
+        multiboundClass(
+          packageName = "com.squareup.test.lib1",
+          simpleName = "Service3",
+          boundTypeFqName = "com.squareup.test.lib1.ServiceInterface",
+          scopeFqName = "kotlin.Any",
+        )
+      }
+
+      shouldSucceed(":lib2:jar") {
+
+        task(":lib1:compileKotlin")?.outcome shouldBe TaskOutcome.SUCCESS
+        task(":lib2:compileKotlin")?.outcome shouldBe TaskOutcome.SUCCESS
+      }
+
+      val includes = lib2.classGraphResult(lib1)
+        .allMergedModulesForComponent("com.squareup.test.lib2.AnyComponent")
+        .names()
+
+      includes shouldBe listOf(
+        "com.squareup.test.lib1.Service2_ServiceInterface_Any_MultiBindingModule_4e7cdd78",
+        "com.squareup.test.lib1.Service3_ServiceInterface_Any_MultiBindingModule_a6a5fcfa",
+      )
+    }
+
+  @TestFactory
+  fun `a generated binding contribution is added if an annotation and merge target are added in the same compilation`() =
+    testFactory {
+
+      rootProject {
+        gradlePropertiesFile(
+          """
+          com.squareup.anvil.trackSourceFiles=true
+          """.trimIndent(),
+        )
+      }
+
+      rootProject.project("lib1") {
+
+        buildFile {
+          plugins {
+            kotlin("jvm")
+            id("com.squareup.anvil")
+          }
+          anvil {
+            generateDaggerFactories.set(true)
+          }
+          dependencies {
+            implementation(libs.dagger2.annotations)
+          }
+        }
+
+        dir("src/main/java") {
+
+          simpleInterface(
+            packageName = "com.squareup.test.lib1",
+            simpleName = "ServiceInterface",
+          )
+
+          multiboundClass(
+            packageName = "com.squareup.test.lib1",
+            simpleName = "Service1",
+            boundTypeFqName = "com.squareup.test.lib1.ServiceInterface",
+            scopeFqName = "kotlin.Any",
+          )
+        }
+      }
+
+      rootProject.project("lib2") {
+        buildFile {
+          plugins {
+            kotlin("jvm")
+            id("com.squareup.anvil")
+          }
+          dependencies {
+            implementation(libs.dagger2.annotations)
+            api(project(":lib1"))
+          }
+        }
+        dir("src/main/java") {
+          kotlinFile(
+            path = "com/squareup/test/lib2/Merging.kt",
+            content = """
+              package com.squareup.test.lib2
+      
+              interface AnyComponent
+            """.trimIndent(),
+          )
+        }
+      }
+
+      rootProject.settingsFileAsFile.appendText(
+        """
+
+          include(":lib1")
+          include(":lib2")
+        """.trimIndent(),
+      )
+
+      val lib1 by rootProject.subprojects
+      val lib2 by rootProject.subprojects
+
+      shouldSucceed(":lib2:jar") {
+        task(":lib1:compileKotlin")?.outcome shouldBe TaskOutcome.SUCCESS
+        task(":lib2:compileKotlin")?.outcome shouldBe TaskOutcome.SUCCESS
+      }
+
+      lib1.dir("src/main/java") {
+
+        multiboundClass(
+          packageName = "com.squareup.test.lib1",
+          simpleName = "Service2",
+          boundTypeFqName = "com.squareup.test.lib1.ServiceInterface",
+          scopeFqName = "kotlin.Any",
+        )
+      }
+
+      lib2.dir("src/main/java") {
+        kotlinFile(
+          path = "com/squareup/test/lib2/Merging.kt",
+          content = """
+            package com.squareup.test.lib2
+    
+            import com.squareup.anvil.annotations.MergeComponent
+            import com.squareup.anvil.annotations.compat.MergeModules
+      
+            @MergeComponent(Any::class)
+            interface AnyComponent
+      
+            @MergeModules(Any::class)
+            abstract class AnyModule
+          """.trimIndent(),
+        )
+      }
+
+      shouldSucceed(":lib2:jar") {
+
+        task(":lib1:compileKotlin")?.outcome shouldBe TaskOutcome.SUCCESS
+        task(":lib2:compileKotlin")?.outcome shouldBe TaskOutcome.SUCCESS
+      }
+
+      val includes = lib2.classGraphResult(lib1)
+        .allMergedModulesForComponent("com.squareup.test.lib2.AnyComponent")
+        .names()
+
+      includes shouldBe listOf(
+        "com.squareup.test.lib1.Service1_ServiceInterface_Any_MultiBindingModule_a39836ad",
+        "com.squareup.test.lib1.Service2_ServiceInterface_Any_MultiBindingModule_4e7cdd78",
+      )
+    }
+
+  @TestFactory
+  fun `a contributed supertype can be added as part of an incremental compilation`() = testFactory {
+
+    rootProject {
+      gradlePropertiesFile(
+        """
+          com.squareup.anvil.trackSourceFiles=true
+        """.trimIndent(),
+      )
+    }
+
+    rootProject.project("lib1") {
+
+      buildFile {
+        plugins {
+          kotlin("jvm")
+          id("com.squareup.anvil")
+        }
+        anvil {
+          generateDaggerFactories.set(true)
+        }
+        dependencies {
+          implementation(libs.dagger2.annotations)
+        }
+      }
+
+      dir("src/main/java") {
+
+        kotlinFile(
+          path = "com/squareup/test/lib1/Contributed1.kt",
+          content = """
+            package com.squareup.test.lib1
+
+            import com.squareup.anvil.annotations.ContributesTo
+            
+            @ContributesTo(Any::class)
+            interface Contributed1
+          """.trimIndent(),
+        )
+      }
+    }
+
+    rootProject.project("lib2") {
+      buildFile {
+        plugins {
+          kotlin("jvm")
+          id("com.squareup.anvil")
+        }
+        dependencies {
+          implementation(libs.dagger2.annotations)
+          api(project(":lib1"))
+        }
+      }
+      dir("src/main/java") {
+        kotlinFile(
+          path = "com/squareup/test/lib2/AnyComponent.kt",
+          content = """
+            package com.squareup.test.lib2
+
+            import com.squareup.anvil.annotations.compat.MergeInterfaces
+      
+            @MergeInterfaces(Any::class)
+            interface AnyComponent
+          """.trimIndent(),
+        )
+      }
+    }
+
+    rootProject.settingsFileAsFile.appendText(
+      """
+
+        include(":lib1")
+        include(":lib2")
+      """.trimIndent(),
+    )
+
+    val lib1 by rootProject.subprojects
+    val lib2 by rootProject.subprojects
+
+    shouldSucceed(":lib2:jar") {
+      task(":lib1:compileKotlin")?.outcome shouldBe TaskOutcome.SUCCESS
+      task(":lib2:compileKotlin")?.outcome shouldBe TaskOutcome.SUCCESS
+    }
+
+    lib1.dir("src/main/java") {
+
+      simpleInterface(
+        packageName = "com.squareup.test.lib1",
+        simpleName = "Contributed1",
+      )
+
+      kotlinFile(
+        path = "com/squareup/test/lib1/Contributed2.kt",
+        content = """
+          package com.squareup.test.lib1
+   
+          import com.squareup.anvil.annotations.ContributesTo
+   
+          @ContributesTo(Any::class)
+          interface Contributed2
+        """.trimIndent(),
+      )
+    }
+
+    workingDir.resolve("build/reports").deleteRecursivelyOrFail()
+
+    shouldSucceed(":lib2:jar") {
+
+      task(":lib1:compileKotlin")?.outcome shouldBe TaskOutcome.SUCCESS
+      task(":lib2:compileKotlin")?.outcome shouldBe TaskOutcome.SUCCESS
+    }
+
+    val superTypes = lib2.classGraphResult(lib1)
+      .allDirectInterfaces("com.squareup.test.lib2.AnyComponent")
+      .names()
+
+    superTypes shouldBe listOf("com.squareup.test.lib1.Contributed2")
+  }
 
   @TestFactory
   fun `a generated factory is updated if the source class constructor is changed`() =

--- a/gradle-plugin/src/gradleTest/java/com/squareup/anvil/plugin/IncrementalTest.kt
+++ b/gradle-plugin/src/gradleTest/java/com/squareup/anvil/plugin/IncrementalTest.kt
@@ -303,6 +303,17 @@ class IncrementalTest : BaseGradleTest() {
       task(":lib2:compileKotlin")?.outcome shouldBe TaskOutcome.SUCCESS
     }
 
+    fun includedModules(): List<String> {
+      return lib2.classGraphResult(lib1)
+        .allMergedModulesForComponent("com.squareup.test.lib2.AnyComponent")
+        .names()
+    }
+
+    includedModules() shouldBe listOf(
+      "com.squareup.test.lib1.Service1_ServiceInterface_Any_MultiBindingModule_a39836ad",
+      "com.squareup.test.lib1.Service2_ServiceInterface_Any_MultiBindingModule_4e7cdd78",
+    )
+
     lib1.dir("src/main/java") {
       // Replace the @ContributesMultibinding class declaration with one that isn't bound.
       injectClass(packageName = "com.squareup.test.lib1", simpleName = "Service1")
@@ -314,11 +325,7 @@ class IncrementalTest : BaseGradleTest() {
       task(":lib2:compileKotlin")?.outcome shouldBe TaskOutcome.SUCCESS
     }
 
-    val includes = lib2.classGraphResult(lib1)
-      .allMergedModulesForComponent("com.squareup.test.lib2.AnyComponent")
-      .names()
-
-    includes shouldBe listOf(
+    includedModules() shouldBe listOf(
       "com.squareup.test.lib1.Service2_ServiceInterface_Any_MultiBindingModule_4e7cdd78",
     )
   }
@@ -420,6 +427,17 @@ class IncrementalTest : BaseGradleTest() {
         task(":lib2:compileKotlin")?.outcome shouldBe TaskOutcome.SUCCESS
       }
 
+      fun includedModules(): List<String> {
+        return lib2.classGraphResult(lib1)
+          .allMergedModulesForComponent("com.squareup.test.lib2.AnyComponent")
+          .names()
+      }
+
+      includedModules() shouldBe listOf(
+        "com.squareup.test.lib1.Service1_ServiceInterface_Any_MultiBindingModule_a39836ad",
+        "com.squareup.test.lib1.Service2_ServiceInterface_Any_MultiBindingModule_4e7cdd78",
+      )
+
       lib1.dir("src/main/java") {
         // Replace the @ContributesMultibinding class declaration with one that isn't bound.
         injectClass(packageName = "com.squareup.test.lib1", simpleName = "Service1")
@@ -438,11 +456,7 @@ class IncrementalTest : BaseGradleTest() {
         task(":lib2:compileKotlin")?.outcome shouldBe TaskOutcome.SUCCESS
       }
 
-      val includes = lib2.classGraphResult(lib1)
-        .allMergedModulesForComponent("com.squareup.test.lib2.AnyComponent")
-        .names()
-
-      includes shouldBe listOf(
+      includedModules() shouldBe listOf(
         "com.squareup.test.lib1.Service2_ServiceInterface_Any_MultiBindingModule_4e7cdd78",
         "com.squareup.test.lib1.Service3_ServiceInterface_Any_MultiBindingModule_a6a5fcfa",
       )

--- a/gradle-plugin/src/gradleTest/java/com/squareup/anvil/plugin/testing/FileStubs.kt
+++ b/gradle-plugin/src/gradleTest/java/com/squareup/anvil/plugin/testing/FileStubs.kt
@@ -6,15 +6,18 @@ import java.io.File
 
 interface FileStubs {
 
-  fun DirectoryBuilder.injectClass(packageName: String = "com.squareup.test"): File {
+  fun DirectoryBuilder.injectClass(
+    packageName: String = "com.squareup.test",
+    simpleName: String = "InjectClass",
+  ): File {
     return kotlinFile(
-      packageName.replace(".", "/") / "InjectClass.kt",
+      packageName.replace(".", "/") / "$simpleName.kt",
       """
         package $packageName
         
         import javax.inject.Inject
         
-        class InjectClass @Inject constructor()
+        class $simpleName @Inject constructor()
       """.trimIndent(),
     )
   }
@@ -23,9 +26,10 @@ interface FileStubs {
     boundTypeFqName: String,
     scopeFqName: String = "kotlin.Any",
     packageName: String = "com.squareup.test",
+    simpleName: String = "BoundClass",
   ): File {
     return kotlinFile(
-      path = packageName.replace(".", "/") / "BoundClass.kt",
+      path = packageName.replace(".", "/") / "$simpleName.kt",
       content = """
         package $packageName
 
@@ -33,7 +37,44 @@ interface FileStubs {
         import javax.inject.Inject
   
         @ContributesBinding($scopeFqName::class)
-        class BoundClass @Inject constructor() : $boundTypeFqName
+        class $simpleName @Inject constructor() : $boundTypeFqName
+      """.trimIndent(),
+    )
+  }
+
+  fun DirectoryBuilder.multiboundClass(
+    fqName: String,
+    boundTypeFqName: String,
+    scopeFqName: String = "kotlin.Any",
+  ): File {
+    val (packageName, simpleName) = """(.+)\.(.+)""".toRegex().find(fqName)
+      ?.destructured
+      ?: error("Invalid fqName: $fqName")
+
+    return multiboundClass(
+      packageName = packageName,
+      simpleName = simpleName,
+      boundTypeFqName = boundTypeFqName,
+      scopeFqName = scopeFqName,
+    )
+  }
+
+  fun DirectoryBuilder.multiboundClass(
+    packageName: String,
+    simpleName: String,
+    boundTypeFqName: String,
+    scopeFqName: String = "kotlin.Any",
+  ): File {
+    return kotlinFile(
+      path = packageName.replace(".", "/") / "$simpleName.kt",
+      content = """
+        package $packageName
+
+        import com.squareup.anvil.annotations.ContributesMultibinding
+        import javax.inject.Inject
+  
+        @ContributesMultibinding($scopeFqName::class)
+        class $simpleName @Inject constructor() : $boundTypeFqName
       """.trimIndent(),
     )
   }

--- a/gradle-plugin/src/gradleTest/java/com/squareup/anvil/plugin/testing/classGraph.kt
+++ b/gradle-plugin/src/gradleTest/java/com/squareup/anvil/plugin/testing/classGraph.kt
@@ -98,6 +98,50 @@ fun ScanResult.allMergedModulesForComponent(componentInterfaceName: String): Lis
 }
 
 /**
+ * Returns all interfaces that are direct supertypes to [className].
+ *
+ * ```
+ * @TestFactory
+ * fun `my test`() = testFactory {
+ *   rootProject {
+ *     dir("src/main/java") {
+ *       kotlinFile(
+ *         path = "com/squareup/test/AppComponent.kt",
+ *         content = """
+ *           package com.squareup.test
+ *
+ *           interface Base
+ *
+ *           @ContributesTo(Any::class)
+ *           interface A : Base
+ *           @ContributesTo(Any::class)
+ *           interface B : Base
+ *
+ *           @MergeComponent(Any::class)
+ *           interface AppComponent
+ *         """.trimIndent()
+ *       )
+ *     }
+ *   }
+ *
+ *   shouldSucceed("jar") // note the "jar" task
+ *
+ *   rootProject.classGraphResult()
+ *     .allMergedModulesForComponent("com.squareup.test.AppComponent")
+ *     .names() shouldBe listOf(
+ *       "com.squareup.test.A",
+ *       "com.squareup.test.B",
+ *     )
+ * }
+ * ```
+ */
+fun ScanResult.allDirectInterfaces(className: String): List<ClassInfo> {
+  return loadClass(className, false)
+    .interfaces
+    .map { getClassInfo(it.name) as ClassInfo }
+}
+
+/**
  * Returns all methods inside `@Module` types that are annotated with `@Binds` in this scan result.
  * The methods are sorted by their name.
  *


### PR DESCRIPTION
KGP's "classpath snapshot" incremental logic uses a previous build's `.class` files to track references and invalidate files.  Assume there are two projects: `:lib1` and `:lib2`.  `:lib2` depends on `:lib1`.  If a change is made to an existing type in `:lib1` since the last successful build, KGP will inspect the snapshot of `:lib2`'s class files to see if it references anything in `:lib1`.  If `:lib2` didn't already reference `:lib1`, then the `:lib2:compileKotlin` task will be treated as `UP_TO_DATE` and will not execute again.

Anvil's module and interface merging logic only changes the IR symbols.  This means that all merged references are added to the resultant binary, but not to class files.  Those changes are invisible to the classpath snapshots.  This is why we disable incremental compilation in KAPT stub generation tasks, but it's also a problem in non-KAPT modules that are using other merging annotations.

### The fix

If a compilation merges any interfaces or modules, a file is created with their names.  The `AnvilPlugin` checks for the existence of this file during task configuration, and disables incremental compilation for that task if it's present.  The file won't exist on a fresh build, regardless of whether there will be merging, but that's okay because the build wouldn't be incremental anyway.