### PR TITLE
consider `ignoreQualifier` arguments when checking for duplicate bindings

### DIFF
--- a/compiler/src/main/java/com/squareup/anvil/compiler/ContributedBinding.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/ContributedBinding.kt
@@ -14,6 +14,7 @@ import com.squareup.anvil.compiler.internal.reference.ClassReference
 import com.squareup.anvil.compiler.internal.reference.ClassReference.Descriptor
 import com.squareup.anvil.compiler.internal.reference.ClassReference.Psi
 import com.squareup.anvil.compiler.internal.requireFqName
+import com.squareup.kotlinpoet.ksp.toTypeName
 import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
 import org.jetbrains.kotlin.types.KotlinType
 
@@ -223,7 +224,7 @@ internal fun KSClassDeclaration.checkNotGeneric(
 }
 
 internal fun KSAnnotation.qualifierKey(): String {
-  return shortName.asString() +
+  return annotationType.resolve().toTypeName().toString() +
     arguments.joinToString(separator = "") { argument ->
       val valueString = when (val value = argument.value) {
         is KSType -> value.resolveKSClassDeclaration()!!.qualifiedName!!.asString()

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/Contribution.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/Contribution.kt
@@ -41,6 +41,7 @@ internal sealed class Contribution {
       originType = origin,
       boundType = boundType,
       scopeType = scope,
+      qualifierKeyOrNull = qualifier?.key,
       suffix = bindingModuleNameSuffix,
     )
   }
@@ -204,15 +205,23 @@ internal sealed class Contribution {
       originType: ClassName,
       boundType: ClassName,
       scopeType: ClassName,
+      qualifierKeyOrNull: String?,
       suffix: String,
     ): ClassName {
       val types = listOf(originType, boundType, scopeType)
+
       return ClassName(
         packageName = originType.packageName,
         simpleNames = types.map { it.simpleName } + suffix,
       )
         .joinSimpleNamesAndTruncate(
-          hashParams = types + suffix,
+          hashParams = listOfNotNull(
+            originType,
+            boundType,
+            scopeType,
+            qualifierKeyOrNull,
+            suffix,
+          ),
           separator = "_",
         )
     }

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ksp/KSAnnotationExtensions.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ksp/KSAnnotationExtensions.kt
@@ -12,6 +12,7 @@ import com.google.devtools.ksp.symbol.KSValueArgument
 import com.squareup.anvil.annotations.ContributesBinding
 import com.squareup.anvil.compiler.internal.mapKeyFqName
 import com.squareup.anvil.compiler.qualifierFqName
+import com.squareup.anvil.compiler.qualifierKey
 import com.squareup.kotlinpoet.ksp.toClassName
 import org.jetbrains.kotlin.name.FqName
 
@@ -53,7 +54,13 @@ internal fun <T : KSAnnotation> List<T>.checkNoDuplicateScopeAndBoundType(
   if (size < 2) return
   if (size == 2 && this[0].scope() != this[1].scope()) return
 
-  val duplicateScopes = groupBy { it.scope() }
+  val qualifierKey = annotatedType.qualifierAnnotation()?.qualifierKey()
+
+  val duplicateScopes = groupBy { annotation ->
+    // If there's a qualifier and this annotation isn't using `ignoreQualifier`,
+    // we need to include that qualifier in the duplicate check.
+    annotation.scope() to qualifierKey?.takeIf { !annotation.ignoreQualifier() }
+  }
     .filterValues { it.size > 1 }
     .ifEmpty { return }
 

--- a/compiler/src/test/java/com/squareup/anvil/compiler/codegen/BindingModuleQualifierTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/codegen/BindingModuleQualifierTest.kt
@@ -4,6 +4,7 @@ import com.google.common.truth.Truth.assertThat
 import com.squareup.anvil.annotations.MergeComponent
 import com.squareup.anvil.annotations.MergeSubcomponent
 import com.squareup.anvil.annotations.compat.MergeInterfaces
+import com.squareup.anvil.annotations.compat.MergeModules
 import com.squareup.anvil.compiler.anyQualifier
 import com.squareup.anvil.compiler.componentInterface
 import com.squareup.anvil.compiler.contributingInterface
@@ -23,7 +24,7 @@ import javax.inject.Named
 class BindingModuleQualifierTest : AnvilAnnotationsTest(
   MergeComponent::class,
   MergeSubcomponent::class,
-  MergeInterfaces::class,
+  MergeModules::class,
 ) {
 
   @TestFactory fun `the Dagger binding method has a qualifier without parameter`() = testFactory {

--- a/compiler/src/test/java/com/squareup/anvil/compiler/codegen/BindingModuleQualifierTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/codegen/BindingModuleQualifierTest.kt
@@ -3,51 +3,30 @@ package com.squareup.anvil.compiler.codegen
 import com.google.common.truth.Truth.assertThat
 import com.squareup.anvil.annotations.MergeComponent
 import com.squareup.anvil.annotations.MergeSubcomponent
-import com.squareup.anvil.annotations.compat.MergeModules
+import com.squareup.anvil.annotations.compat.MergeInterfaces
 import com.squareup.anvil.compiler.anyQualifier
-import com.squareup.anvil.compiler.compile
 import com.squareup.anvil.compiler.componentInterface
 import com.squareup.anvil.compiler.contributingInterface
 import com.squareup.anvil.compiler.generatedBindingModule
 import com.squareup.anvil.compiler.generatedMultiBindingModule
 import com.squareup.anvil.compiler.internal.testing.isAbstract
-import com.squareup.anvil.compiler.isFullTestRun
 import com.squareup.anvil.compiler.mergedModules
 import com.squareup.anvil.compiler.parentInterface
 import com.squareup.anvil.compiler.subcomponentInterface
+import com.squareup.anvil.compiler.testing.AnvilAnnotationsTest
 import dagger.Binds
 import dagger.Provides
 import dagger.multibindings.IntoSet
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.Parameterized
-import org.junit.runners.Parameterized.Parameters
+import org.junit.jupiter.api.TestFactory
 import javax.inject.Named
-import kotlin.reflect.KClass
 
-@RunWith(Parameterized::class)
-class BindingModuleQualifierTest(
-  private val annotationClass: KClass<out Annotation>,
+class BindingModuleQualifierTest : AnvilAnnotationsTest(
+  MergeComponent::class,
+  MergeSubcomponent::class,
+  MergeInterfaces::class,
 ) {
 
-  private val annotation = "@${annotationClass.simpleName}"
-  private val import = "import ${annotationClass.java.canonicalName}"
-
-  companion object {
-    @Parameters(name = "{0}")
-    @JvmStatic
-    fun annotationClasses(): Collection<Any> {
-      return buildList {
-        add(MergeComponent::class)
-        if (isFullTestRun()) {
-          add(MergeSubcomponent::class)
-          add(MergeModules::class)
-        }
-      }
-    }
-  }
-
-  @Test fun `the Dagger binding method has a qualifier without parameter`() {
+  @TestFactory fun `the Dagger binding method has a qualifier without parameter`() = testFactory {
     compile(
       """
       package com.squareup.test
@@ -82,42 +61,44 @@ class BindingModuleQualifierTest(
     }
   }
 
-  @Test fun `the Dagger multibinding method has a qualifier without parameter`() {
-    compile(
-      """
-      package com.squareup.test
-      
-      import com.squareup.anvil.annotations.ContributesMultibinding
-      import javax.inject.Qualifier
-      $import
-      
-      @Qualifier
-      annotation class AnyQualifier
+  @TestFactory fun `the Dagger multibinding method has a qualifier without parameter`() =
+    testFactory {
+      compile(
+        """
+        package com.squareup.test
+        
+        import com.squareup.anvil.annotations.ContributesMultibinding
+        import javax.inject.Qualifier
+        $import
+        
+        @Qualifier
+        annotation class AnyQualifier
+  
+        interface ParentInterface
+        
+        @ContributesMultibinding(Any::class)
+        @AnyQualifier
+        interface ContributingInterface : ParentInterface
+        
+        $annotation(Any::class)
+        interface ComponentInterface
+        """,
+      ) {
+        val bindingMethod =
+          contributingInterface.generatedMultiBindingModule.declaredMethods.single()
 
-      interface ParentInterface
-      
-      @ContributesMultibinding(Any::class)
-      @AnyQualifier
-      interface ContributingInterface : ParentInterface
-      
-      $annotation(Any::class)
-      interface ComponentInterface
-      """,
-    ) {
-      val bindingMethod = contributingInterface.generatedMultiBindingModule.declaredMethods.single()
+        with(bindingMethod) {
+          assertThat(returnType).isEqualTo(parentInterface)
+          assertThat(parameterTypes.toList()).containsExactly(contributingInterface)
+          assertThat(isAbstract).isTrue()
 
-      with(bindingMethod) {
-        assertThat(returnType).isEqualTo(parentInterface)
-        assertThat(parameterTypes.toList()).containsExactly(contributingInterface)
-        assertThat(isAbstract).isTrue()
-
-        assertThat(annotations.map { it.annotationClass })
-          .containsExactly(Binds::class, IntoSet::class, anyQualifier.kotlin)
+          assertThat(annotations.map { it.annotationClass })
+            .containsExactly(Binds::class, IntoSet::class, anyQualifier.kotlin)
+        }
       }
     }
-  }
 
-  @Test fun `the Dagger provider method for an object has a qualifier`() {
+  @TestFactory fun `the Dagger provider method for an object has a qualifier`() = testFactory {
     compile(
       """
       package com.squareup.test
@@ -152,9 +133,10 @@ class BindingModuleQualifierTest(
     }
   }
 
-  @Test fun `the Dagger multibind provider method for an object has a qualifier`() {
-    compile(
-      """
+  @TestFactory fun `the Dagger multibind provider method for an object has a qualifier`() =
+    testFactory {
+      compile(
+        """
       package com.squareup.test
       
       import com.squareup.anvil.annotations.ContributesMultibinding
@@ -173,21 +155,22 @@ class BindingModuleQualifierTest(
       $annotation(Any::class)
       interface ComponentInterface
       """,
-    ) {
-      val bindingMethod = contributingInterface.generatedMultiBindingModule.declaredMethods.single()
+      ) {
+        val bindingMethod =
+          contributingInterface.generatedMultiBindingModule.declaredMethods.single()
 
-      with(bindingMethod) {
-        assertThat(returnType).isEqualTo(parentInterface)
-        assertThat(parameterTypes.toList()).isEmpty()
-        assertThat(isAbstract).isFalse()
+        with(bindingMethod) {
+          assertThat(returnType).isEqualTo(parentInterface)
+          assertThat(parameterTypes.toList()).isEmpty()
+          assertThat(isAbstract).isFalse()
 
-        assertThat(annotations.map { it.annotationClass })
-          .containsExactly(Provides::class, IntoSet::class, anyQualifier.kotlin)
+          assertThat(annotations.map { it.annotationClass })
+            .containsExactly(Provides::class, IntoSet::class, anyQualifier.kotlin)
+        }
       }
     }
-  }
 
-  @Test fun `the Dagger binding method has a qualifier with string value`() {
+  @TestFactory fun `the Dagger binding method has a qualifier with string value`() = testFactory {
     compile(
       """
       package com.squareup.test
@@ -221,7 +204,7 @@ class BindingModuleQualifierTest(
     }
   }
 
-  @Test fun `the Dagger binding method has a qualifier with a class value`() {
+  @TestFactory fun `the Dagger binding method has a qualifier with a class value`() = testFactory {
     compile(
       """
       package com.squareup.test
@@ -263,7 +246,7 @@ class BindingModuleQualifierTest(
     }
   }
 
-  @Test fun `the Dagger binding method has a qualifier with a value`() {
+  @TestFactory fun `the Dagger binding method has a qualifier with a value`() = testFactory {
     compile(
       """
       package com.squareup.test
@@ -310,9 +293,10 @@ class BindingModuleQualifierTest(
     }
   }
 
-  @Test fun `the Dagger binding method has a qualifier with multiple arguments`() {
-    compile(
-      """
+  @TestFactory fun `the Dagger binding method has a qualifier with multiple arguments`() =
+    testFactory {
+      compile(
+        """
       package com.squareup.test
       
       import com.squareup.anvil.annotations.ContributesBinding
@@ -335,27 +319,28 @@ class BindingModuleQualifierTest(
       $annotation(Any::class)
       interface ComponentInterface
       """,
-    ) {
-      val bindingMethod = contributingInterface.generatedBindingModule.declaredMethods.single()
+      ) {
+        val bindingMethod = contributingInterface.generatedBindingModule.declaredMethods.single()
 
-      with(bindingMethod) {
-        assertThat(returnType).isEqualTo(parentInterface)
-        assertThat(parameterTypes.toList()).containsExactly(contributingInterface)
-        assertThat(isAbstract).isTrue()
+        with(bindingMethod) {
+          assertThat(returnType).isEqualTo(parentInterface)
+          assertThat(parameterTypes.toList()).containsExactly(contributingInterface)
+          assertThat(isAbstract).isTrue()
 
-        assertThat(annotations.map { it.annotationClass })
-          .containsExactly(Binds::class, anyQualifier.kotlin)
+          assertThat(annotations.map { it.annotationClass })
+            .containsExactly(Binds::class, anyQualifier.kotlin)
 
-        val qualifierAnnotation = annotations.single { it.annotationClass == anyQualifier.kotlin }
-        assertThat(qualifierAnnotation.toString())
-          .isEqualTo("@com.squareup.test.AnyQualifier(abc=java.lang.String.class, def=1)")
+          val qualifierAnnotation = annotations.single { it.annotationClass == anyQualifier.kotlin }
+          assertThat(qualifierAnnotation.toString())
+            .isEqualTo("@com.squareup.test.AnyQualifier(abc=java.lang.String.class, def=1)")
+        }
       }
     }
-  }
 
-  @Test fun `the Dagger binding method has no other annotation that is not a qualifier`() {
-    compile(
-      """
+  @TestFactory fun `the Dagger binding method has no other annotation that is not a qualifier`() =
+    testFactory {
+      compile(
+        """
       package com.squareup.test
       
       import com.squareup.anvil.annotations.ContributesBinding
@@ -372,20 +357,20 @@ class BindingModuleQualifierTest(
       $annotation(Any::class)
       interface ComponentInterface
       """,
-    ) {
-      val bindingMethod = contributingInterface.generatedBindingModule.declaredMethods.single()
+      ) {
+        val bindingMethod = contributingInterface.generatedBindingModule.declaredMethods.single()
 
-      with(bindingMethod) {
-        assertThat(returnType).isEqualTo(parentInterface)
-        assertThat(parameterTypes.toList()).containsExactly(contributingInterface)
-        assertThat(isAbstract).isTrue()
+        with(bindingMethod) {
+          assertThat(returnType).isEqualTo(parentInterface)
+          assertThat(parameterTypes.toList()).containsExactly(contributingInterface)
+          assertThat(isAbstract).isTrue()
 
-        assertThat(annotations.map { it.annotationClass }).containsExactly(Binds::class)
+          assertThat(annotations.map { it.annotationClass }).containsExactly(Binds::class)
+        }
       }
     }
-  }
 
-  @Test fun `the Dagger binding method has no qualifier when disabled`() {
+  @TestFactory fun `the Dagger binding method has no qualifier when disabled`() = testFactory {
     compile(
       """
       package com.squareup.test
@@ -415,7 +400,7 @@ class BindingModuleQualifierTest(
     }
   }
 
-  @Test fun `the Dagger multibinding method has no qualifier when disabled`() {
+  @TestFactory fun `the Dagger multibinding method has no qualifier when disabled`() = testFactory {
     compile(
       """
       package com.squareup.test
@@ -445,53 +430,58 @@ class BindingModuleQualifierTest(
     }
   }
 
-  @Test fun `the Dagger binding method has a qualifier for multiple contributions`() {
-    compile(
-      """
-      package com.squareup.test
-      
-      import com.squareup.anvil.annotations.ContributesBinding
-      import javax.inject.Qualifier
-      $import
-      
-      @Qualifier
-      annotation class AnyQualifier
+  @TestFactory fun `the Dagger binding method has a qualifier for multiple contributions`() =
+    params
+      // MergeInterfaces doesn't make a component or subcomponent, so it's not applicable here.
+      .filterNot { it.a1 == MergeInterfaces::class }
+      .asTests {
+        compile(
+          """ 
+          package com.squareup.test
+          import com.squareup.anvil.annotations.ContributesBinding
+          import javax.inject.Qualifier
+          $import
+          
+          @Qualifier
+          annotation class AnyQualifier
+          
+          interface ParentInterface
+          
+          @ContributesBinding(Any::class)
+          @ContributesBinding(Unit::class)
+          @AnyQualifier
+          interface ContributingInterface : ParentInterface
+          
+          $annotation(Any::class)
+          interface ComponentInterface
+          
+          $annotation(Unit::class)
+          interface SubcomponentInterface
+          """,
+        ) {
+          with(
+            componentInterface.mergedModules(annotationClass)
+              .single().java.declaredMethods.single(),
+          ) {
+            assertThat(returnType).isEqualTo(parentInterface)
+            assertThat(parameterTypes.toList()).containsExactly(contributingInterface)
+            assertThat(isAbstract).isTrue()
 
-      interface ParentInterface
-      
-      @ContributesBinding(Any::class)
-      @ContributesBinding(Unit::class)
-      @AnyQualifier
-      interface ContributingInterface : ParentInterface
-      
-      $annotation(Any::class)
-      interface ComponentInterface
-      
-      $annotation(Unit::class)
-      interface SubcomponentInterface
-      """,
-    ) {
-      with(
-        componentInterface.mergedModules(annotationClass).single().java.declaredMethods.single(),
-      ) {
-        assertThat(returnType).isEqualTo(parentInterface)
-        assertThat(parameterTypes.toList()).containsExactly(contributingInterface)
-        assertThat(isAbstract).isTrue()
+            assertThat(annotations.map { it.annotationClass })
+              .containsExactly(Binds::class, anyQualifier.kotlin)
+          }
 
-        assertThat(annotations.map { it.annotationClass })
-          .containsExactly(Binds::class, anyQualifier.kotlin)
+          with(
+            subcomponentInterface.mergedModules(annotationClass)
+              .single().java.declaredMethods.single(),
+          ) {
+            assertThat(returnType).isEqualTo(parentInterface)
+            assertThat(parameterTypes.toList()).containsExactly(contributingInterface)
+            assertThat(isAbstract).isTrue()
+
+            assertThat(annotations.map { it.annotationClass })
+              .containsExactly(Binds::class, anyQualifier.kotlin)
+          }
+        }
       }
-
-      with(
-        subcomponentInterface.mergedModules(annotationClass).single().java.declaredMethods.single(),
-      ) {
-        assertThat(returnType).isEqualTo(parentInterface)
-        assertThat(parameterTypes.toList()).containsExactly(contributingInterface)
-        assertThat(isAbstract).isTrue()
-
-        assertThat(annotations.map { it.annotationClass })
-          .containsExactly(Binds::class, anyQualifier.kotlin)
-      }
-    }
-  }
 }

--- a/compiler/src/test/java/com/squareup/anvil/compiler/testing/AnvilAnnotationsTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/testing/AnvilAnnotationsTest.kt
@@ -1,0 +1,56 @@
+package com.squareup.anvil.compiler.testing
+
+import com.rickbusarow.kase.DefaultTestEnvironment
+import com.rickbusarow.kase.Kase1
+import com.rickbusarow.kase.KaseTestFactory
+import com.rickbusarow.kase.ParamTestEnvironmentFactory
+import com.rickbusarow.kase.files.HasWorkingDir
+import com.rickbusarow.kase.files.TestLocation
+import com.rickbusarow.kase.kases
+import com.squareup.anvil.compiler.isFullTestRun
+import kotlin.reflect.KClass
+
+abstract class AnvilAnnotationsTest(
+  firstAnnotation: KClass<out Annotation>,
+  vararg fullTestRunAnnotations: KClass<out Annotation>,
+) : KaseTestFactory<
+  Kase1<KClass<out Annotation>>,
+  AnnotationTestEnvironment,
+  ParamTestEnvironmentFactory<Kase1<KClass<out Annotation>>, AnnotationTestEnvironment>,
+  > {
+
+  override val params: List<Kase1<KClass<out Annotation>>> = kases(
+    buildList {
+      add(firstAnnotation)
+      if (isFullTestRun()) {
+        addAll(fullTestRunAnnotations)
+      }
+    },
+    displayNameFactory = { "annotationClass: ${a1.simpleName!!}" },
+  )
+
+  override val testEnvironmentFactory:
+    ParamTestEnvironmentFactory<Kase1<KClass<out Annotation>>, AnnotationTestEnvironment> =
+    AnnotationTestEnvironment
+}
+
+class AnnotationTestEnvironment(
+  val annotationClass: KClass<out Annotation>,
+  hasWorkingDir: HasWorkingDir,
+) : DefaultTestEnvironment(hasWorkingDir),
+  CompilationEnvironment {
+
+  val annotation = "@${annotationClass.simpleName}"
+  val import = "import ${annotationClass.java.canonicalName}"
+
+  companion object : ParamTestEnvironmentFactory<Kase1<KClass<out Annotation>>, AnnotationTestEnvironment> {
+    override fun create(
+      params: Kase1<KClass<out Annotation>>,
+      names: List<String>,
+      location: TestLocation,
+    ): AnnotationTestEnvironment = AnnotationTestEnvironment(
+      params.a1,
+      HasWorkingDir(names, location),
+    )
+  }
+}


### PR DESCRIPTION
fixes #986