### PR TITLE
include inherited functions in Subcomponent Factory checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 ### Changed
 
 ### Deprecated
+- `ClassReference.functions` has been deprecated in favor of `ClassReference.memberFunctions` and `ClassReference.declaredMemberFunctions`
+- `ClassReference.properties` has been deprecated in favor of `ClassReference.memberProperties` and `ClassReference.declaredMemberProperties`
 
 ### Removed
 

--- a/compiler-utils/api/compiler-utils.api
+++ b/compiler-utils/api/compiler-utils.api
@@ -192,9 +192,13 @@ public abstract class com/squareup/anvil/compiler/internal/reference/ClassRefere
 	public abstract fun getClassId ()Lorg/jetbrains/kotlin/name/ClassId;
 	public abstract fun getConstructors ()Ljava/util/List;
 	public abstract fun getContainingFileAsJavaFile ()Ljava/io/File;
+	public abstract fun getDeclaredMemberFunctions ()Ljava/util/List;
+	public abstract fun getDeclaredMemberProperties ()Ljava/util/List;
 	public abstract fun getFqName ()Lorg/jetbrains/kotlin/name/FqName;
 	public abstract fun getFunctions ()Ljava/util/List;
 	protected abstract fun getInnerClassesAndObjects ()Ljava/util/List;
+	public final fun getMemberFunctions ()Ljava/util/List;
+	public final fun getMemberProperties ()Ljava/util/List;
 	public abstract fun getModule ()Lcom/squareup/anvil/compiler/internal/reference/AnvilModuleDescriptor;
 	public final fun getPackageFqName ()Lorg/jetbrains/kotlin/name/FqName;
 	public abstract fun getProperties ()Ljava/util/List;
@@ -223,6 +227,8 @@ public final class com/squareup/anvil/compiler/internal/reference/ClassReference
 	public final fun getClazz ()Lorg/jetbrains/kotlin/descriptors/ClassDescriptor;
 	public fun getConstructors ()Ljava/util/List;
 	public fun getContainingFileAsJavaFile ()Ljava/io/File;
+	public fun getDeclaredMemberFunctions ()Ljava/util/List;
+	public fun getDeclaredMemberProperties ()Ljava/util/List;
 	public fun getFqName ()Lorg/jetbrains/kotlin/name/FqName;
 	public fun getFunctions ()Ljava/util/List;
 	public fun getModule ()Lcom/squareup/anvil/compiler/internal/reference/AnvilModuleDescriptor;
@@ -248,6 +254,8 @@ public final class com/squareup/anvil/compiler/internal/reference/ClassReference
 	public final fun getClazz ()Lorg/jetbrains/kotlin/psi/KtClassOrObject;
 	public fun getConstructors ()Ljava/util/List;
 	public fun getContainingFileAsJavaFile ()Ljava/io/File;
+	public fun getDeclaredMemberFunctions ()Ljava/util/List;
+	public fun getDeclaredMemberProperties ()Ljava/util/List;
 	public fun getFqName ()Lorg/jetbrains/kotlin/name/FqName;
 	public fun getFunctions ()Ljava/util/List;
 	public fun getModule ()Lcom/squareup/anvil/compiler/internal/reference/AnvilModuleDescriptor;

--- a/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/reference/AnnotationArgumentReference.kt
+++ b/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/reference/AnnotationArgumentReference.kt
@@ -144,7 +144,7 @@ public sealed class AnnotationArgumentReference {
           }
           is KtObjectDeclaration -> {
             toClassReference(module)
-              .properties
+              .declaredMemberProperties
               .mapNotNull { it.property as? KtProperty }
               .findConstPropertyWithName(name)
               ?.initializer

--- a/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/reference/MemberPropertyReference.kt
+++ b/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/reference/MemberPropertyReference.kt
@@ -205,6 +205,8 @@ public fun PropertyDescriptor.toPropertyReference(
 internal fun MemberPropertyReference.toDescriptorOrNull(): Descriptor? {
   return when (this) {
     is Descriptor -> this
-    is Psi -> declaringClass.toDescriptorReferenceOrNull()?.properties?.find { it.name == name }
+    is Psi -> declaringClass.toDescriptorReferenceOrNull()
+      ?.declaredMemberProperties
+      ?.find { it.name == name }
   }
 }

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesSubcomponentCodeGen.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesSubcomponentCodeGen.kt
@@ -324,7 +324,7 @@ internal object ContributesSubcomponentCodeGen : AnvilApplicabilityChecker {
         )
       }
 
-      val functions = componentInterface.functions
+      val functions = componentInterface.memberFunctions
         .filter { it.returnType().asClassReference() == this }
 
       if (functions.size >= 2) {
@@ -377,7 +377,7 @@ internal object ContributesSubcomponentCodeGen : AnvilApplicabilityChecker {
         )
       }
 
-      val functions = factory.functions
+      val functions = factory.memberFunctions
         .let { functions ->
           if (factory.isInterface()) {
             functions

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesSubcomponentHandlerGenerator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/ContributesSubcomponentHandlerGenerator.kt
@@ -298,7 +298,7 @@ internal class ContributesSubcomponentHandlerGenerator(
       )
     }
 
-    val functions = componentInterface.functions
+    val functions = componentInterface.memberFunctions
       .filter { it.isAbstract() && it.visibility() == PUBLIC }
       .filter {
         val returnType = it.returnType().asClassReference()
@@ -337,7 +337,7 @@ internal class ContributesSubcomponentHandlerGenerator(
           )
         }
 
-        val createComponentFunctions = factory.functions
+        val createComponentFunctions = factory.memberFunctions
           .filter { it.isAbstract() }
           .filter { it.returnType().asClassReference().fqName == contributionFqName }
 

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/AssistedFactoryCodeGen.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/AssistedFactoryCodeGen.kt
@@ -432,7 +432,7 @@ internal object AssistedFactoryCodeGen : AnvilApplicabilityChecker {
       val assistedFunctions = allSuperTypeClassReferences(includeSelf = true)
         .distinctBy { it.fqName }
         .flatMap { clazz ->
-          clazz.functions
+          clazz.declaredMemberFunctions
             .filter {
               it.isAbstract() &&
                 (it.visibility() == Visibility.PUBLIC || it.visibility() == Visibility.PROTECTED)

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/BindsMethodValidator.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/BindsMethodValidator.kt
@@ -178,7 +178,7 @@ internal object BindsMethodValidator : AnvilApplicabilityChecker {
         .forEach { clazz ->
           (clazz.companionObjects() + clazz)
             .asSequence()
-            .flatMap { it.functions }
+            .flatMap { it.declaredMemberFunctions }
             .filter { it.isAnnotatedWith(daggerBindsFqName) }
             .also { functions ->
               assertNoDuplicateFunctions(clazz, functions)

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/DaggerGenerationUtils.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/DaggerGenerationUtils.kt
@@ -222,7 +222,7 @@ private fun ClassReference.declaredMemberInjectParameters(
   superParameters: List<Parameter>,
   implementingClass: ClassReference,
 ): List<MemberInjectParameter> {
-  return properties
+  return declaredMemberProperties
     .filter { it.isAnnotatedWith(injectFqName) }
     .filter { it.visibility() != PRIVATE }
     .fold(listOf()) { acc, property ->

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/MapKeyCreatorCodeGen.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/MapKeyCreatorCodeGen.kt
@@ -231,7 +231,7 @@ internal object MapKeyCreatorCodeGen : AnvilApplicabilityChecker {
         if (clazz.isAnnotationClass()) {
           val added = creatorsToGenerate.add(clazz)
           if (added) {
-            for (property in clazz.properties) {
+            for (property in clazz.declaredMemberProperties) {
               val type = property.type().asClassReferenceOrNull()
               if (type?.isAnnotationClass() == true) {
                 visitAnnotations(type)
@@ -254,7 +254,7 @@ internal object MapKeyCreatorCodeGen : AnvilApplicabilityChecker {
         }
         .toSortedMap()
         .map { (className, clazz) ->
-          val properties = clazz.properties
+          val properties = clazz.declaredMemberProperties
             .map { AnnotationProperty(it) }
             .associateBy { it.name }
           generateCreatorFunction(className, properties)
@@ -276,7 +276,7 @@ internal object MapKeyCreatorCodeGen : AnvilApplicabilityChecker {
       className: ClassName,
       annotationClass: ClassReference,
     ): FunSpec {
-      val properties = annotationClass.properties
+      val properties = annotationClass.declaredMemberProperties
         .map { AnnotationProperty(it) }
         .associateBy { it.name }
       return generateCreatorFunction(className, properties)

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/MembersInjectorCodeGen.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/MembersInjectorCodeGen.kt
@@ -133,7 +133,7 @@ internal object MembersInjectorCodeGen : AnvilApplicabilityChecker {
         // Only generate a MembersInjector if the target class declares its own member-injected
         // properties. If it does, then any properties from superclasses must be added as well
         // (clazz.memberInjectParameters() will do this).
-        clazz.properties
+        clazz.declaredMemberProperties
           .filter { it.visibility() != Visibility.PRIVATE }
           .any { it.isAnnotatedWith(injectFqName) }
       }

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/ProvidesMethodFactoryCodeGen.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/ProvidesMethodFactoryCodeGen.kt
@@ -243,7 +243,7 @@ internal object ProvidesMethodFactoryCodeGen : AnvilApplicabilityChecker {
           .asSequence()
 
         val functions = types
-          .flatMap { it.functions }
+          .flatMap { it.declaredMemberFunctions }
           .filter { it.isAnnotatedWith(daggerProvidesFqName) }
           .onEach { function ->
             checkFunctionIsNotAbstract(clazz, function)
@@ -261,7 +261,7 @@ internal object ProvidesMethodFactoryCodeGen : AnvilApplicabilityChecker {
           }
 
         val properties = types
-          .flatMap { it.properties }
+          .flatMap { it.declaredMemberProperties }
           .filter { property ->
             // Must be `@get:Provides`.
             property.getterAnnotations.any { it.fqName == daggerProvidesFqName }

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/reference/RealAnvilModuleDescriptor.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/reference/RealAnvilModuleDescriptor.kt
@@ -137,7 +137,7 @@ public class RealAnvilModuleDescriptor private constructor(
     }
 
     return classAndCompanions.firstNotNullOfOrNull { clazz ->
-      clazz.properties.firstOrNull { it.name == shortName }
+      clazz.declaredMemberProperties.firstOrNull { it.name == shortName }
     }
   }
 

--- a/compiler/src/test/java/com/squareup/anvil/compiler/internal/reference/MemberFunctionReferenceTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/internal/reference/MemberFunctionReferenceTest.kt
@@ -99,20 +99,21 @@ class MemberFunctionReferenceTest {
             "SomeClass1" -> {
               // Notice that the size differs between the descriptor and Psi implementation. Both
               // implementations see different values and that's expected.
-              assertThat(psiRef.functions).hasSize(0)
-              assertThat(descriptorRef.functions).hasSize(3)
-              assertThat(descriptorRef.functions.map { it.name }).containsExactly(
+              assertThat(psiRef.declaredMemberFunctions).hasSize(0)
+              assertThat(descriptorRef.declaredMemberFunctions).hasSize(3)
+              assertThat(descriptorRef.declaredMemberFunctions.map { it.name }).containsExactly(
                 "equals",
                 "toString",
                 "hashCode",
               )
             }
             "SomeClass2" -> {
-              assertThat(psiRef.functions).hasSize(1)
-              assertThat(descriptorRef.functions).hasSize(4)
+              assertThat(psiRef.declaredMemberFunctions).hasSize(1)
+              assertThat(descriptorRef.declaredMemberFunctions).hasSize(4)
 
-              val psiFunction = psiRef.functions.single()
-              val descriptorFunction = descriptorRef.functions.single { it.name == "test" }
+              val psiFunction = psiRef.declaredMemberFunctions.single()
+              val descriptorFunction = descriptorRef.declaredMemberFunctions
+                .single { it.name == "test" }
 
               assertThat(psiFunction.name).isEqualTo("test")
               assertThat(descriptorFunction.name).isEqualTo("test")
@@ -126,11 +127,12 @@ class MemberFunctionReferenceTest {
                 .isEqualTo(Unit::class.fqName)
             }
             "SomeInterface" -> {
-              assertThat(psiRef.functions).hasSize(1)
-              assertThat(descriptorRef.functions).hasSize(4)
+              assertThat(psiRef.declaredMemberFunctions).hasSize(1)
+              assertThat(descriptorRef.declaredMemberFunctions).hasSize(4)
 
-              val psiFunction = psiRef.functions.single()
-              val descriptorFunction = descriptorRef.functions.single { it.name == "test" }
+              val psiFunction = psiRef.declaredMemberFunctions.single()
+              val descriptorFunction = descriptorRef.declaredMemberFunctions
+                .single { it.name == "test" }
 
               assertThat(psiFunction.name).isEqualTo("test")
               assertThat(descriptorFunction.name).isEqualTo("test")
@@ -148,8 +150,8 @@ class MemberFunctionReferenceTest {
               assertThat(psiRef.enclosingClass()?.shortName).isEqualTo("SomeInterface")
               assertThat(descriptorRef.enclosingClass()?.shortName).isEqualTo("SomeInterface")
 
-              assertThat(psiRef.functions).hasSize(1)
-              assertThat(descriptorRef.functions).hasSize(4)
+              assertThat(psiRef.declaredMemberFunctions).hasSize(1)
+              assertThat(descriptorRef.declaredMemberFunctions).hasSize(4)
             }
             else -> throw NotImplementedError()
           }
@@ -192,8 +194,9 @@ class MemberFunctionReferenceTest {
 
           when (psiRef.shortName) {
             "SomeClass1" -> {
-              val psiFunction = psiRef.functions.single()
-              val descriptorFunction = descriptorRef.functions.single { it.name == "test" }
+              val psiFunction = psiRef.declaredMemberFunctions.single()
+              val descriptorFunction = descriptorRef.declaredMemberFunctions
+                .single { it.name == "test" }
 
               assertThat(psiFunction.returnTypeOrNull()).isNull()
               assertThat(descriptorFunction.returnType().asClassReference().fqName)
@@ -205,8 +208,9 @@ class MemberFunctionReferenceTest {
               assertThat(psiFunction.resolveGenericReturnTypeOrNull(psiRef)).isNull()
             }
             "SomeClass2", "SomeClass3" -> {
-              val psiFunction = psiRef.functions.single()
-              val descriptorFunction = descriptorRef.functions.single { it.name == "hello" }
+              val psiFunction = psiRef.declaredMemberFunctions.single()
+              val descriptorFunction = descriptorRef.declaredMemberFunctions
+                .single { it.name == "hello" }
 
               assertThat(psiFunction.returnType().asClassReference().fqName)
                 .isEqualTo(FqName("kotlin.String"))
@@ -214,8 +218,9 @@ class MemberFunctionReferenceTest {
                 .isEqualTo(FqName("kotlin.String"))
             }
             "GenericInterface1" -> {
-              val psiFunction = psiRef.functions.single()
-              val descriptorFunction = descriptorRef.functions.single { it.name == "hello" }
+              val psiFunction = psiRef.declaredMemberFunctions.single()
+              val descriptorFunction = descriptorRef.declaredMemberFunctions
+                .single { it.name == "hello" }
 
               assertThat(psiFunction.returnType().asClassReferenceOrNull()).isNull()
               assertThat(descriptorFunction.returnType().asClassReferenceOrNull()).isNull()
@@ -267,10 +272,11 @@ class MemberFunctionReferenceTest {
               ).isEqualTo(FqName("kotlin.String"))
             }
             "GenericInterface2" -> {
-              assertThat(psiRef.functions).hasSize(0)
-              assertThat(descriptorRef.functions).hasSize(4)
+              assertThat(psiRef.declaredMemberFunctions).hasSize(0)
+              assertThat(descriptorRef.declaredMemberFunctions).hasSize(4)
 
-              val descriptorFunction = descriptorRef.functions.single { it.name == "hello" }
+              val descriptorFunction = descriptorRef.declaredMemberFunctions
+                .single { it.name == "hello" }
               assertThat(descriptorFunction.returnType().asClassReferenceOrNull()).isNull()
 
               val implementingClass = FqName("com.squareup.test.SomeClass3")
@@ -324,8 +330,9 @@ class MemberFunctionReferenceTest {
 
           when (psiRef.shortName) {
             "SomeClass1", "SomeClass2" -> {
-              val psiFunction = psiRef.functions.single()
-              val descriptorFunction = descriptorRef.functions.single { it.name == "hello" }
+              val psiFunction = psiRef.declaredMemberFunctions.single()
+              val descriptorFunction =
+                descriptorRef.declaredMemberFunctions.single { it.name == "hello" }
 
               assertThat(
                 psiFunction.parameters.single().typeOrNull()
@@ -346,8 +353,9 @@ class MemberFunctionReferenceTest {
               ).isNotNull()
             }
             "GenericInterface1" -> {
-              val psiFunction = psiRef.functions.single()
-              val descriptorFunction = descriptorRef.functions.single { it.name == "hello" }
+              val psiFunction = psiRef.declaredMemberFunctions.single()
+              val descriptorFunction = descriptorRef.declaredMemberFunctions
+                .single { it.name == "hello" }
 
               assertThat(psiFunction.parameters.single().type().asClassReferenceOrNull())
                 .isNull()
@@ -397,10 +405,11 @@ class MemberFunctionReferenceTest {
               ).isNotNull()
             }
             "GenericInterface2" -> {
-              assertThat(psiRef.functions).hasSize(0)
-              assertThat(descriptorRef.functions).hasSize(4)
+              assertThat(psiRef.declaredMemberFunctions).hasSize(0)
+              assertThat(descriptorRef.declaredMemberFunctions).hasSize(4)
 
-              val descriptorFunction = descriptorRef.functions.single { it.name == "hello" }
+              val descriptorFunction = descriptorRef.declaredMemberFunctions
+                .single { it.name == "hello" }
               assertThat(
                 descriptorFunction.parameters.single().type().asClassReferenceOrNull(),
               ).isNull()

--- a/compiler/src/test/java/com/squareup/anvil/compiler/internal/reference/MemberPropertyReferenceTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/internal/reference/MemberPropertyReferenceTest.kt
@@ -6,6 +6,7 @@ import com.squareup.anvil.compiler.internal.testing.simpleCodeGenerator
 import com.tschuchort.compiletesting.KotlinCompilation.ExitCode.OK
 import org.junit.Test
 
+@Suppress("RemoveRedundantQualifierName")
 class MemberPropertyReferenceTest {
 
   @Test fun `primary constructor val properties are properties`() {
@@ -191,7 +192,7 @@ class MemberPropertyReferenceTest {
 
           listOf(psiRef, descriptorRef).forEach { ref ->
 
-            assertThat(ref.properties.single().type().asTypeName().toString())
+            assertThat(ref.declaredMemberProperties.single().type().asTypeName().toString())
               .isEqualTo("kotlin.String")
           }
 
@@ -223,7 +224,7 @@ class MemberPropertyReferenceTest {
 
           listOf(psiRef, descriptorRef).forEach { ref ->
 
-            val propertyType = ref.properties.single().type()
+            val propertyType = ref.declaredMemberProperties.single().type()
 
             assertThat(propertyType.asTypeName().toString())
               .isEqualTo("com.squareup.test.Subject.`Nested\$Fancy`")
@@ -260,7 +261,7 @@ class MemberPropertyReferenceTest {
 
           listOf(psiRef, descriptorRef).forEach { ref ->
 
-            val propertyType = ref.properties.single().type()
+            val propertyType = ref.declaredMemberProperties.single().type()
 
             assertThat(propertyType.asTypeName().toString())
               .isEqualTo("com.squareup.test.Subject.`Nested\$Fancy`")
@@ -297,7 +298,7 @@ class MemberPropertyReferenceTest {
 
           listOf(psiRef, descriptorRef).forEach { ref ->
 
-            val propertyType = ref.properties.single().type()
+            val propertyType = ref.declaredMemberProperties.single().type()
 
             assertThat(propertyType.asTypeName().toString())
               .isEqualTo("com.squareup.test.Subject.`Nested\$Fancy`")
@@ -435,13 +436,13 @@ class MemberPropertyReferenceTest {
 
           listOf(psiRef, descriptorRef).forEach { ref ->
 
-            val nameAnnotations = ref.properties.named("name")
+            val nameAnnotations = ref.declaredMemberProperties.named("name")
               .annotations
               .map { it.fqName.asString() }
 
             assertThat(nameAnnotations).containsExactly("javax.inject.Inject")
 
-            val ageAnnotations = ref.properties.named("age")
+            val ageAnnotations = ref.declaredMemberProperties.named("age")
               .annotations
               .map { it.fqName.asString() }
 
@@ -475,7 +476,7 @@ class MemberPropertyReferenceTest {
 
           listOf(psiRef, descriptorRef).forEach { ref ->
 
-            val nameGetterAnnotations = ref.properties.named("name")
+            val nameGetterAnnotations = ref.declaredMemberProperties.named("name")
               .getterAnnotations
               .map { it.fqName.asString() }
 
@@ -509,13 +510,13 @@ class MemberPropertyReferenceTest {
 
           listOf(psiRef, descriptorRef).forEach { ref ->
 
-            val nameGetterAnnotations = ref.properties.named("name")
+            val nameGetterAnnotations = ref.declaredMemberProperties.named("name")
               .getterAnnotations
               .map { it.fqName.asString() }
 
             assertThat(nameGetterAnnotations).containsExactly("javax.inject.Inject")
 
-            val nameAnnotations = ref.properties.named("name")
+            val nameAnnotations = ref.declaredMemberProperties.named("name")
               .annotations
               .map { it.fqName.asString() }
 
@@ -549,7 +550,7 @@ class MemberPropertyReferenceTest {
 
           listOf(psiRef, descriptorRef).forEach { ref ->
 
-            val nameSetterAnnotations = ref.properties.named("name")
+            val nameSetterAnnotations = ref.declaredMemberProperties.named("name")
               .setterAnnotations
               .map { it.fqName.asString() }
 
@@ -583,13 +584,13 @@ class MemberPropertyReferenceTest {
 
           listOf(psiRef, descriptorRef).forEach { ref ->
 
-            val nameSetterAnnotations = ref.properties.named("name")
+            val nameSetterAnnotations = ref.declaredMemberProperties.named("name")
               .setterAnnotations
               .map { it.fqName.asString() }
 
             assertThat(nameSetterAnnotations).containsExactly("javax.inject.Inject")
 
-            val nameAnnotations = ref.properties.named("name")
+            val nameAnnotations = ref.declaredMemberProperties.named("name")
               .annotations
               .map { it.fqName.asString() }
 
@@ -623,7 +624,7 @@ class MemberPropertyReferenceTest {
 
           listOf(psiRef, descriptorRef).forEach { ref ->
 
-            val nameProperty = ref.properties.named("name")
+            val nameProperty = ref.declaredMemberProperties.named("name")
 
             assertThat(nameProperty.getterAnnotations).isEmpty()
             assertThat(nameProperty.setterAnnotations).isEmpty()
@@ -657,13 +658,13 @@ class MemberPropertyReferenceTest {
 
           listOf(psiRef, descriptorRef).forEach { ref ->
 
-            val nameAnnotations = ref.properties.named("name")
+            val nameAnnotations = ref.declaredMemberProperties.named("name")
               .annotations
               .map { it.fqName.asString() }
 
             assertThat(nameAnnotations).containsExactly("javax.inject.Inject")
 
-            val ageAnnotations = ref.properties.named("age")
+            val ageAnnotations = ref.declaredMemberProperties.named("age")
               .annotations
               .map { it.fqName.asString() }
 
@@ -751,7 +752,7 @@ class MemberPropertyReferenceTest {
     }
   }
 
-  private fun ClassReference.propertyTypeNames() = properties
+  private fun ClassReference.propertyTypeNames() = declaredMemberProperties
     .map { "${it.name}: ${it.type().asTypeName()}" }
 
   private fun List<MemberPropertyReference>.named(name: String) = single { it.name == name }

--- a/compiler/src/test/java/com/squareup/anvil/compiler/internal/reference/ReferencesTestEnvironment.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/internal/reference/ReferencesTestEnvironment.kt
@@ -40,11 +40,6 @@ class ReferencesTestEnvironment(
 ) : DefaultTestEnvironment(hasWorkingDir = hasWorkingDir),
   LanguageInjection<File> by LanguageInjection(JavaFileFileInjection()) {
 
-  operator fun <E : FunctionReference> List<E>.getValue(
-    thisRef: Any?,
-    property: KProperty<*>,
-  ): E = single { it.name == property.name }
-
   operator fun <E> Map<String, E>.getValue(
     thisRef: Any?,
     property: KProperty<*>,
@@ -79,13 +74,13 @@ class ReferencesTestEnvironment(
           ?.let { refsContainer ->
 
             val refsFun = when (referenceType) {
-              ReferenceType.Psi -> refsContainer.functions
-              ReferenceType.Descriptor -> refsContainer.toDescriptorReference().functions
+              ReferenceType.Psi -> refsContainer.declaredMemberFunctions
+              ReferenceType.Descriptor -> refsContainer.toDescriptorReference().declaredMemberFunctions
             }
               .singleOrNull { it.name == "refs" }
               ?: error {
                 "RefsContainer.refs not found.  " +
-                  "Existing functions: ${refsContainer.functions.map { it.name }}"
+                  "Existing functions: ${refsContainer.declaredMemberFunctions.map { it.name }}"
               }
 
             when (referenceType) {

--- a/compiler/src/test/java/com/squareup/anvil/compiler/internal/reference/TypeReferenceTest.kt
+++ b/compiler/src/test/java/com/squareup/anvil/compiler/internal/reference/TypeReferenceTest.kt
@@ -227,19 +227,19 @@ class TypeReferenceTest {
             "SomeClass" -> {
               listOf(psiRef, psiRef.toDescriptorReference()).forEach { ref ->
                 assertThat(
-                  ref.properties.single { it.name == "map1" }.type().unwrappedTypes
+                  ref.declaredMemberProperties.single { it.name == "map1" }.type().unwrappedTypes
                     .map { it.asClassReference().shortName },
                 ).containsExactly("Any", "Any").inOrder()
                 assertThat(
-                  ref.properties.single { it.name == "map2" }.type().unwrappedTypes
+                  ref.declaredMemberProperties.single { it.name == "map2" }.type().unwrappedTypes
                     .map { it.asClassReference().shortName },
                 ).containsExactly("Int", "Any").inOrder()
                 assertThat(
-                  ref.properties.single { it.name == "map3" }.type().unwrappedTypes
+                  ref.declaredMemberProperties.single { it.name == "map3" }.type().unwrappedTypes
                     .map { it.asClassReference().shortName },
                 ).containsExactly("Any", "String").inOrder()
                 assertThat(
-                  ref.properties.single { it.name == "map4" }.type().unwrappedTypes
+                  ref.declaredMemberProperties.single { it.name == "map4" }.type().unwrappedTypes
                     .map { it.asClassReference().shortName },
                 ).containsExactly("Int", "String").inOrder()
               }
@@ -279,15 +279,15 @@ class TypeReferenceTest {
             "SomeClass" -> {
               listOf(psiRef, psiRef.toDescriptorReference()).forEach { ref ->
                 assertThat(
-                  ref.properties.single { it.name == "map" }.type().unwrappedTypes
+                  ref.declaredMemberProperties.single { it.name == "map" }.type().unwrappedTypes
                     .map { it.asClassReference().shortName },
                 ).containsExactly("String", "Int").inOrder()
                 assertThat(
-                  ref.properties.single { it.name == "single1" }.type().unwrappedTypes
+                  ref.declaredMemberProperties.single { it.name == "single1" }.type().unwrappedTypes
                     .map { it.asClassReference().shortName },
                 ).containsExactly("Int", "String", "Long").inOrder()
                 assertThat(
-                  ref.properties.single { it.name == "single2" }.type().unwrappedTypes
+                  ref.declaredMemberProperties.single { it.name == "single2" }.type().unwrappedTypes
                     .map { it.asClassReference().shortName },
                 ).containsExactly("Int", "Int", "Int").inOrder()
               }


### PR DESCRIPTION
fixes #1003

Our checks for a single abstract method in a `@ContributesSubcomponent.Factory`-annotated interface do not consider functions that are defined in a supertype.  The existing `ClassReference.functions` property was somewhat ambiguously named, which probably contributed to the error.