### PR TITLE
generic type resolution fixes

### DIFF
--- a/compiler-utils/api/compiler-utils.api
+++ b/compiler-utils/api/compiler-utils.api
@@ -376,6 +376,8 @@ public final class com/squareup/anvil/compiler/internal/reference/MemberFunction
 }
 
 public final class com/squareup/anvil/compiler/internal/reference/MemberFunctionReferenceKt {
+	public static final fun returnTypeWithGenericSubstitution (Lcom/squareup/anvil/compiler/internal/reference/FunctionReference;Lcom/squareup/anvil/compiler/internal/reference/ClassReference;)Lcom/squareup/anvil/compiler/internal/reference/TypeReference;
+	public static final fun returnTypeWithGenericSubstitutionOrNull (Lcom/squareup/anvil/compiler/internal/reference/FunctionReference;Lcom/squareup/anvil/compiler/internal/reference/ClassReference;)Lcom/squareup/anvil/compiler/internal/reference/TypeReference;
 	public static final fun toFunctionReference (Lorg/jetbrains/kotlin/descriptors/FunctionDescriptor;Lcom/squareup/anvil/compiler/internal/reference/ClassReference$Descriptor;)Lcom/squareup/anvil/compiler/internal/reference/MemberFunctionReference$Descriptor;
 	public static final fun toFunctionReference (Lorg/jetbrains/kotlin/psi/KtFunction;Lcom/squareup/anvil/compiler/internal/reference/ClassReference$Psi;)Lcom/squareup/anvil/compiler/internal/reference/MemberFunctionReference$Psi;
 }
@@ -630,6 +632,7 @@ public abstract class com/squareup/anvil/compiler/internal/reference/TypeReferen
 	public abstract fun isNullable ()Z
 	public final fun resolveGenericTypeNameOrNull (Lcom/squareup/anvil/compiler/internal/reference/ClassReference;)Lcom/squareup/kotlinpoet/TypeName;
 	public abstract fun resolveGenericTypeOrNull (Lcom/squareup/anvil/compiler/internal/reference/ClassReference;)Lcom/squareup/anvil/compiler/internal/reference/TypeReference;
+	public final fun resolveGenericTypeOrSelf (Lcom/squareup/anvil/compiler/internal/reference/ClassReference;)Lcom/squareup/anvil/compiler/internal/reference/TypeReference;
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -667,6 +670,7 @@ public final class com/squareup/anvil/compiler/internal/reference/Visibility : j
 	public static final field PROTECTED Lcom/squareup/anvil/compiler/internal/reference/Visibility;
 	public static final field PUBLIC Lcom/squareup/anvil/compiler/internal/reference/Visibility;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun isProtectedOrPublic ()Z
 	public static fun valueOf (Ljava/lang/String;)Lcom/squareup/anvil/compiler/internal/reference/Visibility;
 	public static fun values ()[Lcom/squareup/anvil/compiler/internal/reference/Visibility;
 }

--- a/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/reference/MemberFunctionReference.kt
+++ b/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/reference/MemberFunctionReference.kt
@@ -152,6 +152,24 @@ public sealed class MemberFunctionReference : AnnotatedReference, FunctionRefere
 }
 
 @ExperimentalAnvilApi
+public fun FunctionReference.returnTypeWithGenericSubstitution(
+  implementingClass: ClassReference,
+): TypeReference {
+  return returnTypeWithGenericSubstitutionOrNull(implementingClass)
+    ?: throw AnvilCompilationExceptionFunctionReference(
+      functionReference = this,
+      message = "Unable to get the return type for function $fqName.",
+    )
+}
+
+@ExperimentalAnvilApi
+public fun FunctionReference.returnTypeWithGenericSubstitutionOrNull(
+  implementingClass: ClassReference,
+): TypeReference? {
+  return returnTypeOrNull()?.resolveGenericTypeOrSelf(implementingClass)
+}
+
+@ExperimentalAnvilApi
 public fun KtFunction.toFunctionReference(
   declaringClass: ClassReference.Psi,
 ): Psi {

--- a/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/reference/TypeReference.kt
+++ b/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/reference/TypeReference.kt
@@ -92,9 +92,16 @@ public sealed class TypeReference {
       return asTypeName()
     }
 
-    return resolveGenericTypeOrNull(implementingClass)
-      ?.asTypeNameOrNull()
-      ?: asTypeNameOrNull()
+    return resolveGenericTypeOrSelf(implementingClass).asTypeNameOrNull()
+  }
+
+  /**
+   * If this type is generic, returns the resolved type in [implementingClass]. If the type is not
+   * generic or the generic type can't be resolved, the current type is returned.
+   */
+  public fun resolveGenericTypeOrSelf(implementingClass: ClassReference): TypeReference {
+    if (!isGenericType()) return this
+    return resolveGenericTypeOrNull(implementingClass) ?: this
   }
 
   public fun isGenericType(): Boolean = asClassReferenceOrNull()?.isGenericClass() ?: true

--- a/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/reference/Visibility.kt
+++ b/compiler-utils/src/main/java/com/squareup/anvil/compiler/internal/reference/Visibility.kt
@@ -8,4 +8,7 @@ public enum class Visibility {
   INTERNAL,
   PROTECTED,
   PRIVATE,
+  ;
+
+  public fun isProtectedOrPublic(): Boolean = this == PROTECTED || this == PUBLIC
 }

--- a/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/DaggerGenerationUtils.kt
+++ b/compiler/src/main/java/com/squareup/anvil/compiler/codegen/dagger/DaggerGenerationUtils.kt
@@ -359,7 +359,7 @@ private fun MemberPropertyReference.toMemberInjectParameter(
   }
 
   val originalName = name
-  val type = type()
+  val type = type().resolveGenericTypeOrSelf(implementingClass)
 
   val isWrappedInProvider = type.asClassReferenceOrNull()?.fqName == providerFqName
   val isWrappedInLazy = type.asClassReferenceOrNull()?.fqName == daggerLazyFqName


### PR DESCRIPTION
Fixes two bugs where we were using a type variable name (e.g., `T`) instead of resolving the actual type.

fixes #1040
fixes #1041