### PR TITLE
Surface Kotlin language version param (kotlinLanguageVersion) in compileAnvil() compile-utils function

### DIFF
--- a/compiler-utils/src/testFixtures/java/com/squareup/anvil/compiler/internal/testing/AnvilCompilation.kt
+++ b/compiler-utils/src/testFixtures/java/com/squareup/anvil/compiler/internal/testing/AnvilCompilation.kt
@@ -309,6 +309,7 @@ public fun compileAnvil(
   mode: AnvilCompilationMode = Embedded(emptyList()),
   moduleName: String? = null,
   jvmTarget: JvmTarget? = null,
+  kotlinLanguageVersion: String? = null,
   expectExitCode: KotlinCompilation.ExitCode? = null,
   block: JvmCompilationResult.() -> Unit = { },
 ): JvmCompilationResult {
@@ -317,6 +318,7 @@ public fun compileAnvil(
       kotlinCompilation.apply {
         this.allWarningsAsErrors = allWarningsAsErrors
         this.messageOutputStream = messageOutputStream
+        this.languageVersion = kotlinLanguageVersion
         if (workingDir != null) {
           this.workingDir = workingDir
         }


### PR DESCRIPTION
The internals of `compileAnvil` contain a [KotlinCompilation](https://github.com/ZacSweers/kotlin-compile-testing/blob/fc96a2c58740a4ac6feb688cf661ef7d755b650b/core/src/main/kotlin/com/tschuchort/compiletesting/AbstractKotlinCompilation.kt#L104) instance which provides a parameter for the kotlin language version. This PR is simply surfacing access to set this param from `compileAnvil(...)` so that other versions of Kotlin can be targeted in tests other than the default. Eg: allows specifying Kotlin 1.9 when using Kotlin 2.0

Example:

```kotlin
    // Run with Kotlin 2.0.XX
    @Test
    fun `target kotlin 1.9`() {
        compileAnvil(
            """
                package com.example
                import com.mine.InjectWith
                import com.mine.InitializedScope
                @InjectWith(InitializedScope::class)
                class MyTestActivity : FakeBaseActivity()
            """.trimIndent(),
            kotlinLanguageVersion = KOTLIN_1_9, // <-- Target Kotlin 1.9 when using Kotlin 2.0
            mode = Embedded(codeGenerators = listOf(InjectWithCodeGenerator())),
            workingDir = workingDirectory.root
        ) {
            if (exitCode != ExitCode.OK) {
                fail(messages)
            }
            assertThat(classLoader.loadClass("com.example.MyTestActivityAnvilInjector").createInstance(
                MembersInjector<Any> { }
            )).isNotNull()
        }
    }
```

This also provides a workaround for `languageVersion.set(KOTLIN_1_9)` workarounds for Anvil when using Kotlin 2.0, in which case the above test fail and you need to use `AnvilCompilation` directly.