### PR TITLE
Hide api for enabling KSP for upcoming release because it's currently only a partial implementation in the main Anvil repo

### DIFF
--- a/gradle-plugin/api/gradle-plugin.api
+++ b/gradle-plugin/api/gradle-plugin.api
@@ -8,8 +8,6 @@ public final class com/squareup/anvil/plugin/AndroidVariantFilter : com/squareup
 	public fun getName ()Ljava/lang/String;
 	public fun getSyncGeneratedSources ()Z
 	public fun getTrackSourceFiles ()Z
-	public fun getUseKspBackend ()Z
-	public fun getUseKspComponentMergingBackend ()Z
 	public fun setAddOptionalAnnotations (Z)V
 	public fun setDisableComponentMerging (Z)V
 	public fun setGenerateDaggerFactories (Z)V
@@ -17,8 +15,6 @@ public final class com/squareup/anvil/plugin/AndroidVariantFilter : com/squareup
 	public fun setIgnore (Z)V
 	public fun setSyncGeneratedSources (Z)V
 	public fun setTrackSourceFiles (Z)V
-	public fun setUseKspBackend (Z)V
-	public fun setUseKspComponentMergingBackend (Z)V
 }
 
 public abstract class com/squareup/anvil/plugin/AnvilExtension {
@@ -29,11 +25,6 @@ public abstract class com/squareup/anvil/plugin/AnvilExtension {
 	public final fun getGenerateDaggerFactoriesOnly ()Lorg/gradle/api/provider/Property;
 	public final fun getSyncGeneratedSources ()Lorg/gradle/api/provider/Property;
 	public final fun getTrackSourceFiles ()Lorg/gradle/api/provider/Property;
-	public final fun getUseKspBackend ()Lorg/gradle/api/provider/Property;
-	public final fun getUseKspComponentMergingBackend ()Lorg/gradle/api/provider/Property;
-	public final fun useKsp (Z)V
-	public final fun useKsp (ZZ)V
-	public static synthetic fun useKsp$default (Lcom/squareup/anvil/plugin/AnvilExtension;ZZILjava/lang/Object;)V
 	public final fun variantFilter (Lorg/gradle/api/Action;)V
 }
 
@@ -46,8 +37,6 @@ public final class com/squareup/anvil/plugin/JvmVariantFilter : com/squareup/anv
 	public fun getName ()Ljava/lang/String;
 	public fun getSyncGeneratedSources ()Z
 	public fun getTrackSourceFiles ()Z
-	public fun getUseKspBackend ()Z
-	public fun getUseKspComponentMergingBackend ()Z
 	public fun setAddOptionalAnnotations (Z)V
 	public fun setDisableComponentMerging (Z)V
 	public fun setGenerateDaggerFactories (Z)V
@@ -55,8 +44,6 @@ public final class com/squareup/anvil/plugin/JvmVariantFilter : com/squareup/anv
 	public fun setIgnore (Z)V
 	public fun setSyncGeneratedSources (Z)V
 	public fun setTrackSourceFiles (Z)V
-	public fun setUseKspBackend (Z)V
-	public fun setUseKspComponentMergingBackend (Z)V
 }
 
 public abstract interface class com/squareup/anvil/plugin/VariantFilter : org/gradle/api/Named {
@@ -67,8 +54,6 @@ public abstract interface class com/squareup/anvil/plugin/VariantFilter : org/gr
 	public abstract fun getIgnore ()Z
 	public abstract fun getSyncGeneratedSources ()Z
 	public abstract fun getTrackSourceFiles ()Z
-	public abstract fun getUseKspBackend ()Z
-	public abstract fun getUseKspComponentMergingBackend ()Z
 	public abstract fun setAddOptionalAnnotations (Z)V
 	public abstract fun setDisableComponentMerging (Z)V
 	public abstract fun setGenerateDaggerFactories (Z)V
@@ -76,7 +61,5 @@ public abstract interface class com/squareup/anvil/plugin/VariantFilter : org/gr
 	public abstract fun setIgnore (Z)V
 	public abstract fun setSyncGeneratedSources (Z)V
 	public abstract fun setTrackSourceFiles (Z)V
-	public abstract fun setUseKspBackend (Z)V
-	public abstract fun setUseKspComponentMergingBackend (Z)V
 }
 

--- a/gradle-plugin/src/gradleTest/java/com/squareup/anvil/plugin/DaggerFactoryGenerationDetectionTest.kt
+++ b/gradle-plugin/src/gradleTest/java/com/squareup/anvil/plugin/DaggerFactoryGenerationDetectionTest.kt
@@ -242,7 +242,7 @@ class DaggerFactoryGenerationDetectionTest : BaseGradleTest() {
   ): Stream<out DynamicNode> = asContainers { versions ->
     cartesianProduct(
       listOf(true, false),
-      listOf(true, false),
+      listOf(false),
       listOf(true, false),
       listOf(true, false),
     )

--- a/gradle-plugin/src/gradleTest/java/com/squareup/anvil/plugin/LifecycleTest.kt
+++ b/gradle-plugin/src/gradleTest/java/com/squareup/anvil/plugin/LifecycleTest.kt
@@ -411,10 +411,10 @@ class LifecycleTest : BaseGradleTest() {
       useKsp: Boolean,
     ) -> Unit,
   ): Stream<out DynamicNode> = asContainers { versions ->
-    listOf(true, false)
+    listOf(false)
       .asTests(
         testEnvironmentFactory = AnvilGradleTestEnvironment.Factory().wrap(versions),
-        testName = { useKsp -> if (useKsp) "KSP" else "Embedded" },
+        testName = { _ -> "Embedded" },
         testAction = { useKsp -> testAction(versions, useKsp) },
       )
   }

--- a/gradle-plugin/src/main/java/com/squareup/anvil/plugin/AnvilExtension.kt
+++ b/gradle-plugin/src/main/java/com/squareup/anvil/plugin/AnvilExtension.kt
@@ -1,17 +1,13 @@
 package com.squareup.anvil.plugin
 
-import com.google.devtools.ksp.gradle.KspExtension
 import org.gradle.api.Action
 import org.gradle.api.Project
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
-import org.gradle.api.provider.Provider
 import org.gradle.api.provider.ProviderFactory
-import org.gradle.process.CommandLineArgumentProvider
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinProjectExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinSingleTargetExtension
-import org.jetbrains.kotlin.gradle.dsl.kotlinExtension
 import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType.androidJvm
 import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType.jvm
 import org.jetbrains.kotlin.gradle.plugin.KotlinTarget
@@ -22,21 +18,6 @@ public abstract class AnvilExtension @Inject constructor(
   objects: ObjectFactory,
   private val providers: ProviderFactory,
 ) {
-
-  init {
-    val useKspBackend = providers.gradleProperty("com.squareup.anvil.useKspBackend")
-      .map { it.toBoolean() }
-      .getOrElse(false)
-    val useKspComponentMergingBackend = providers.gradleProperty(
-      "com.squareup.anvil.useKspComponentMergingBackend",
-    )
-      .map { it.toBoolean() }
-      .getOrElse(false)
-    if (useKspBackend || useKspComponentMergingBackend) {
-      useKsp(useKspBackend, useKspComponentMergingBackend)
-    }
-  }
-
   /**
    * Allows you to use Anvil to generate Factory classes that usually the Dagger annotation
    * processor would generate for `@Provides` methods, `@Inject` constructors and `@Inject` fields.
@@ -140,101 +121,6 @@ public abstract class AnvilExtension @Inject constructor(
   public val trackSourceFiles: Property<Boolean> = objects.property(Boolean::class.java)
     .conventionFromProperty("com.squareup.anvil.trackSourceFiles", false)
 
-  /**
-   * @see useKsp
-   */
-  public val useKspBackend: Property<Boolean> = objects.property(Boolean::class.java)
-    .convention(false)
-
-  /**
-   * @see useKsp
-   */
-  public val useKspComponentMergingBackend: Property<Boolean> = objects.property(
-    Boolean::class.java,
-  ).convention(false)
-
-  /**
-   * Enables the new [KSP](https://github.com/google/ksp) backends for Anvil. Note that this
-   * requires the KSP plugin to already be on the buildscript classpath.
-   *
-   * These modes can optionally be enabled via these gradle properties:
-   * ```properties
-   * com.squareup.anvil.useKspBackend=true
-   * com.squareup.anvil.useKspComponentMergingBackend=true
-   * ```
-   *
-   * @param contributesAndFactoryGeneration This is an experimental feature that
-   *   replaces the previous `AnalysisHandlerExtension`-based backend, which is removed in Kotlin
-   *   2.0 and struggled with incremental compilation.
-   * @param componentMerging This is an experimental feature that currently does nothing. It's a
-   *   placeholder for future work. Requires [disableComponentMerging] to be `false`.
-   */
-  @JvmOverloads
-  public fun useKsp(
-    contributesAndFactoryGeneration: Boolean,
-    componentMerging: Boolean = false,
-  ) {
-    useKspBackend.setDisallowChanges(contributesAndFactoryGeneration)
-    useKspComponentMergingBackend.setDisallowChanges(componentMerging)
-    // Wire KSP
-    try {
-      project.pluginManager.apply("com.google.devtools.ksp")
-    } catch (e: Exception) {
-      // KSP not on the classpath, ask them to add it
-      error(
-        "Anvil's KSP backends require the KSP plugin to be applied to the project. " +
-          "Please apply the KSP Gradle plugin ('com.google.devtools.ksp') to your buildscript " +
-          "and try again.",
-      )
-    }
-    // Add the KSP dependency to the appropriate configurations
-    // In KMP, we only add to androidJvm/jvm targets
-    val kExtension = project.kotlinExtension
-    if (kExtension is KotlinMultiplatformExtension) {
-      kExtension.targets
-        .matching { it.isSupportedType() }
-        .configureEach {
-          addKspDep(it.kspConfigName())
-        }
-    } else {
-      addKspDep("ksp")
-    }
-
-    val willHaveDaggerFactories = generateDaggerFactories.map { anvilGenerated ->
-      // If Anvil is creating factories due to `generateDaggerFactories`, then we're done.
-      // Otherwise, we have to check if the Dagger compiler dependency is in KSP's classpath.
-      anvilGenerated || kExtension.targets
-        .filter { it.isSupportedType() }
-        .any { target ->
-          target.compilations.any { c ->
-            // If using Anvil with KSP, Dagger factory generation can come from either KSP or KAPT.
-            c.kspConfigOrNull(project)?.hasDaggerCompilerDependency() == true ||
-              c.kaptConfigOrNull(project)?.hasDaggerCompilerDependency() == true
-          }
-        }
-    }
-
-    project.extensions.configure(KspExtension::class.java) { ksp ->
-      // Do not convert this to a lambda.
-      // It will leak the AnvilExtension instance and break configuration caching.
-      ksp.arg(
-        commandLineArgumentProvider(
-          "generate-dagger-factories" to generateDaggerFactories,
-          "generate-dagger-factories-only" to generateDaggerFactoriesOnly,
-          "disable-component-merging" to disableComponentMerging,
-          "will-have-dagger-factories" to willHaveDaggerFactories,
-        ),
-      )
-    }
-  }
-
-  private fun addKspDep(configurationName: String) {
-    project.dependencies.add(
-      configurationName,
-      "com.squareup.anvil:compiler:$VERSION",
-    )
-  }
-
   @Suppress("PropertyName")
   internal var _variantFilter: Action<VariantFilter>? = null
 
@@ -264,25 +150,6 @@ public abstract class AnvilExtension @Inject constructor(
     val SUPPORTED_PLATFORMS = setOf(androidJvm, jvm)
 
     private fun KotlinTarget.isSupportedType(): Boolean = platformType in SUPPORTED_PLATFORMS
-  }
-}
-
-/**
- * This function is propping up configuration caching in two ways:
- *
- * 1. It creates local references to the providers,
- *    so that we can pass them to the KSP task without a reference to `AnvilExtension`.
- * 2. It creates the `CommandLineArgumentProvider` lambda outside the `AnvilExtension` class,
- *    so that we can't accidentally capture `AnvilExtension` in the lambda.
- *
- * [AnvilExtension] currently isn't serializable for configuration caching
- * because of its `Project` property.
- */
-private fun commandLineArgumentProvider(
-  vararg args: Pair<String, Provider<Boolean>>,
-): CommandLineArgumentProvider {
-  return CommandLineArgumentProvider {
-    args.map { (arg, provider) -> "$arg=${provider.get()}" }
   }
 }
 

--- a/gradle-plugin/src/main/java/com/squareup/anvil/plugin/AnvilPlugin.kt
+++ b/gradle-plugin/src/main/java/com/squareup/anvil/plugin/AnvilPlugin.kt
@@ -258,11 +258,11 @@ internal open class AnvilPlugin : KotlinCompilerPluginSupportPlugin {
         ),
         SubpluginOption(
           key = "analysis-backend",
-          lazy { if (variant.variantFilter.useKspBackend) "KSP" else "EMBEDDED" },
+          lazy { "EMBEDDED" },
         ),
         SubpluginOption(
           key = "merging-backend",
-          lazy { if (variant.variantFilter.useKspComponentMergingBackend) "KSP" else "IR" },
+          lazy { "IR" },
         ),
       )
     }

--- a/gradle-plugin/src/main/java/com/squareup/anvil/plugin/VariantFilter.kt
+++ b/gradle-plugin/src/main/java/com/squareup/anvil/plugin/VariantFilter.kt
@@ -56,22 +56,6 @@ public interface VariantFilter : Named {
    * @see AnvilExtension.trackSourceFiles for more details.
    */
   public var trackSourceFiles: Boolean
-
-  /**
-   * Enables KSP code gen support for this variant.
-   * The default value comes from the [AnvilExtension].
-   *
-   * @see AnvilExtension.useKspBackend for more details.
-   */
-  public var useKspBackend: Boolean
-
-  /**
-   * Enables KSP module merging support for this variant.
-   * The default value comes from the [AnvilExtension].
-   *
-   * @see AnvilExtension.useKspComponentMergingBackend for more details.
-   */
-  public var useKspComponentMergingBackend: Boolean
 }
 
 internal class CommonFilter(
@@ -121,20 +105,6 @@ internal class CommonFilter(
     get() = trackSourceFilesOverride ?: extension.trackSourceFiles.get()
     set(value) {
       trackSourceFilesOverride = value
-    }
-
-  private var useKspBackendOverride: Boolean? = null
-  override var useKspBackend: Boolean
-    get() = useKspBackendOverride ?: extension.useKspBackend.get()
-    set(value) {
-      useKspBackendOverride = value
-    }
-
-  private var useKspComponentMergingBackendOverride: Boolean? = null
-  override var useKspComponentMergingBackend: Boolean
-    get() = useKspComponentMergingBackendOverride ?: extension.useKspComponentMergingBackend.get()
-    set(value) {
-      useKspComponentMergingBackendOverride = value
     }
 }
 


### PR DESCRIPTION
This is grabbed from the [Kotlin 2.0.21](https://github.com/square/anvil/tree/joel.kotlin-2.0.21) branch, since we want to disable the KSP apis in 2.5.0 as well.