### PR TITLE
avoid dependency-guard dependency locking flakes in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,12 @@ jobs:
           check-latest: true
 
       - name: Dependency Guard Check
-        run: ./gradlew dependencyGuard --no-build-cache --no-daemon --stacktrace
+        # Using --no-parallel to avoid the following error during dependency locking:
+        # > java.lang.IllegalStateException: Something has been appended to this collector already
+        #
+        # https://youtrack.jetbrains.com/issue/KT-74241/Dependency-locking-sometimes-fails-with-gradle-kotlin-plugin
+        # https://youtrack.jetbrains.com/issue/KT-74394/KGP-isolated-projects-Something-has-been-appended-to-this-collector-already
+        run: ./gradlew dependencyGuard --no-parallel
 
   ktlint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Using --no-parallel to avoid:

https://youtrack.jetbrains.com/issue/KT-74241/Dependency-locking-sometimes-fails-with-gradle-kotlin-plugin https://youtrack.jetbrains.com/issue/KT-74394/KGP-isolated-projects-Something-has-been-appended-to-this-collector-already

https://github.com/square/anvil/actions/runs/13141745288/job/36670332186

```

1: Task failed with an exception.
-----------
> Task :compiler-api:dependencyGuard
* What went wrong:
Execution failed for task ':compiler:dependencyGuard'.
> Something has been appended to this collector already

* Try:
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
> Get more help at https://help.gradle.org.

* Exception is:
org.gradle.api.tasks.TaskExecutionException: Execution failed for task ':compiler:dependencyGuard'.
[...]
Caused by: java.lang.IllegalStateException: Something has been appended to this collector already
	at com.google.common.base.Preconditions.checkState(Preconditions.java:512)
	at org.gradle.api.internal.provider.AbstractCollectionProperty$CollectingSupplier.plus(AbstractCollectionProperty.java:574)
[...]
	at org.jetbrains.kotlin.gradle.utils.ReportUtilsKt.addConfigurationMetrics(reportUtils.kt:23)
	at org.jetbrains.kotlin.gradle.plugin.statistics.KotlinStdlibConfigurationMetrics.collectMetrics$kotlin_gradle_plugin_common(FusMetrics.kt:291)
	at org.jetbrains.kotlin.gradle.internal.StdlibDependencyManagementKt$addStdlibDependency$1$1$1.execute(stdlibDependencyManagement.kt:139)
[...]
	at org.gradle.internal.ImmutableActionSet$SetWithFewActions.execute(ImmutableActionSet.java:285)
	at org.gradle.api.internal.artifacts.configurations.DefaultConfiguration.lambda$runDependencyActions$2(DefaultConfiguration.java:509)
[...]
	at org.gradle.api.internal.artifacts.configurations.DefaultConfiguration$1.call(DefaultConfiguration.java:769)
```