### PR TITLE
Include generated Dagger modules from @ContributesBinding when merging modules

### DIFF
--- a/compiler-k2/src/test/kotlin/com/squareup/anvil/compiler/k2/fir/FirCanaryTest.kt
+++ b/compiler-k2/src/test/kotlin/com/squareup/anvil/compiler/k2/fir/FirCanaryTest.kt
@@ -4,7 +4,7 @@ import com.squareup.anvil.compiler.k2.utils.names.ClassIds
 import com.squareup.anvil.compiler.testing.CompilationMode
 import com.squareup.anvil.compiler.testing.CompilationModeTest
 import com.squareup.anvil.compiler.testing.classgraph.getAnnotationInfo
-import io.github.classgraph.AnnotationClassRef
+import com.squareup.anvil.compiler.testing.classgraph.moduleNames
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import org.junit.jupiter.api.TestFactory
@@ -68,13 +68,7 @@ class FirCanaryTest : CompilationModeTest(
       val testComponent = scanResult.getClassInfo("com.squareup.test.TestComponent") shouldNotBe null
       val generatedComponentAnnotation = testComponent.getAnnotationInfo(ClassIds.daggerComponent) shouldNotBe null
 
-      val moduleClasses = generatedComponentAnnotation.parameterValues
-        .getValue("modules")
-        .let { it as Array<*> }
-        .map { (it as AnnotationClassRef).name }
-        .sorted()
-
-      moduleClasses shouldBe listOf(
+      generatedComponentAnnotation.moduleNames shouldBe listOf(
         "com.squareup.test.ABindingModule",
         "com.squareup.test.BBindingModule",
       )

--- a/compiler-testing/api/compiler-testing.api
+++ b/compiler-testing/api/compiler-testing.api
@@ -222,6 +222,7 @@ public final class com/squareup/anvil/compiler/testing/classgraph/ClassInfoKt {
 	public static final fun fqNames (Ljava/util/Collection;)Ljava/util/List;
 	public static final fun getAnnotationInfo (Lio/github/classgraph/ClassInfo;Lorg/jetbrains/kotlin/name/ClassId;)Lio/github/classgraph/AnnotationInfo;
 	public static final fun getClassId (Lio/github/classgraph/ClassInfo;)Lorg/jetbrains/kotlin/name/ClassId;
+	public static final fun getModuleNames (Lio/github/classgraph/AnnotationInfo;)Ljava/util/List;
 }
 
 public final class com/squareup/anvil/compiler/testing/classgraph/MethodInfoKt {

--- a/compiler-testing/src/main/kotlin/com/squareup/anvil/compiler/testing/classgraph/classInfo.kt
+++ b/compiler-testing/src/main/kotlin/com/squareup/anvil/compiler/testing/classgraph/classInfo.kt
@@ -1,6 +1,8 @@
 package com.squareup.anvil.compiler.testing.classgraph
 
+import com.squareup.anvil.compiler.k2.utils.names.Names
 import com.squareup.anvil.compiler.testing.asJavaNameString
+import io.github.classgraph.AnnotationClassRef
 import io.github.classgraph.AnnotationInfo
 import io.github.classgraph.ClassInfo
 import org.jetbrains.kotlin.name.ClassId
@@ -26,6 +28,18 @@ public fun Collection<ClassInfo>.classIds(): List<ClassId> = map { it.classId }
 public fun ClassInfo.getAnnotationInfo(annotationClassId: ClassId): AnnotationInfo {
   return getAnnotationInfo(annotationClassId.asJavaNameString())
 }
+
+/**
+ * Returns all Dagger modules specified by the Component as fully qualified names
+ */
+public val AnnotationInfo.moduleNames: List<String>
+  get() {
+    return parameterValues
+      .getValue(Names.modules.identifier)
+      .let { it as Array<*> }
+      .map { (it as AnnotationClassRef).name }
+      .sorted()
+  }
 
 /**
  * Returns all binding methods declared in a particular `@Module` type.


### PR DESCRIPTION
This is effectively a POC integration between the two for now to work around needing multiple compilation rounds for the way we pick up the modules in K1.